### PR TITLE
Use with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_LOG_DIR /var/log/apache2
 ENV APACHE_LOCK_DIR /var/lock/apache2
 ENV APACHE_PID_FILE /var/run/apache2.pid
+ENV MAX_FILESIZE 5120000
 
 # Add extra script
 COPY docker-init docker-init

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:jessie
 # Inspiration from MAINTAINER Marc Richter <mail@marc-richter.info>
 MAINTAINER Kyle Gordon <kyle@lodge.glasgownet.com>
 
-RUN apt update && apt -y install git apache2 php5 php5-mysql php5-apcu php5-mcrypt php5-intl
+RUN apt-get update && apt-get -y install git apache2 php5 php5-mysql php5-apcu php5-mcrypt php5-intl
 
 # Enable mysql extension, disable PDO and mysqli
 #RUN sed -i'' 's#^;\(extension=mysql.so.*$\)#\1#g' /etc/php/php.ini
@@ -12,18 +12,13 @@ RUN apt update && apt -y install git apache2 php5 php5-mysql php5-apcu php5-mcry
 
 # Use php5enmod to link /etc/php5/mods-available items to /etc/php5/apache2/conf.d/
 # FIXME See above about disabling or enabling mysql php extensions
-RUN php5enmod apcu mysql mysqli pdo_mysql mcrypt intl
-
-# Add extra script
-#ADD assets/init /extra/init
-
-#VOLUME ["/app"]
-EXPOSE 80
-
-#CMD ["/init"]
-#COPY src/ /var/www/html/
+RUN php5enmod apcu mcrypt intl pdo_mysql
+RUN php5dismod mysqli mysql
 
 RUN rm /var/www/html/index.html && git clone https://github.com/ignacionelson/ProjectSend /var/www/html/
+# Forbid access to .git
+RUN echo -e '\nRedirectMatch 404 /\.git' >> /var/www/html/.htaccess
+RUN chown www-data:www-data -R /var/www/html
 
 ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
@@ -31,5 +26,18 @@ ENV APACHE_LOG_DIR /var/log/apache2
 ENV APACHE_LOCK_DIR /var/lock/apache2
 ENV APACHE_PID_FILE /var/run/apache2.pid
 
+# Add extra script
+COPY docker-init docker-init
+RUN chmod +x /docker-init
+
+# Temporary diagnostics page
+COPY phpinfo.php /var/www/html/info.php
+
 EXPOSE 80
-CMD ["/usr/sbin/apache2", "-D", "FOREGROUND"]
+#CMD ["/usr/sbin/apache2", "-D", "FOREGROUND"]
+CMD ["/docker-init"]
+
+#VOLUME ["/app"]
+
+#CMD ["/init"]
+#COPY src/ /var/www/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:jessie
 # Inspiration from MAINTAINER Marc Richter <mail@marc-richter.info>
 MAINTAINER Kyle Gordon <kyle@lodge.glasgownet.com>
 
-RUN apt-get update && apt-get -y install git apache2 php5 php5-mysql php5-apcu php5-mcrypt php5-intl
+RUN apt-get update && apt-get -y install wget git apache2 php5 php5-mysql php5-apcu php5-mcrypt php5-intl
 
 # Enable mysql extension, disable PDO and mysqli
 #RUN sed -i'' 's#^;\(extension=mysql.so.*$\)#\1#g' /etc/php/php.ini
@@ -15,7 +15,9 @@ RUN apt-get update && apt-get -y install git apache2 php5 php5-mysql php5-apcu p
 RUN php5enmod apcu mcrypt intl pdo_mysql
 RUN php5dismod mysqli mysql
 
-RUN rm /var/www/html/index.html && git clone https://github.com/ignacionelson/ProjectSend /var/www/html/
+#RUN rm /var/www/html/index.html && git clone https://github.com/ignacionelson/ProjectSend /var/www/html/
+RUN rm /var/www/html/index.html && wget https://codeload.github.com/ignacionelson/ProjectSend/tar.gz/r756 -O /tmp/ProjectSend.tar.gz && tar -zxvf /tmp/ProjectSend.tar.gz --strip-components=1 -C /var/www/html/
+
 # Forbid access to .git
 RUN echo -e '\nRedirectMatch 404 /\.git' >> /var/www/html/.htaccess
 RUN chown www-data:www-data -R /var/www/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN rm /var/www/html/index.html && wget https://codeload.github.com/ignacionelso
 # Forbid access to .git
 RUN echo -e '\nRedirectMatch 404 /\.git' >> /var/www/html/.htaccess
 RUN chown www-data:www-data -R /var/www/html
+RUN mkdir /var/www/html/upload/files/ && chown www-data. /var/www/html/upload/files/ && chmod 755 /var/www/html/upload/files/
 
 ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:jessie
 # Inspiration from MAINTAINER Marc Richter <mail@marc-richter.info>
 MAINTAINER Kyle Gordon <kyle@lodge.glasgownet.com>
 
-RUN apt-get update && apt-get -y install wget git apache2 php5 php5-mysql php5-apcu php5-mcrypt php5-intl
+RUN apt-get update && apt-get -y install wget git apache2 php5 php5-mysql php5-apcu php5-mcrypt php5-intl && apt-get clean && rm -d /var/lib/apt/lists/*
 
 # Use php5enmod to link /etc/php5/mods-available items to /etc/php5/apache2/conf.d/
 RUN php5enmod apcu mcrypt intl pdo_mysql

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,7 @@ MAINTAINER Kyle Gordon <kyle@lodge.glasgownet.com>
 
 RUN apt-get update && apt-get -y install wget git apache2 php5 php5-mysql php5-apcu php5-mcrypt php5-intl
 
-# Enable mysql extension, disable PDO and mysqli
-#RUN sed -i'' 's#^;\(extension=mysql.so.*$\)#\1#g' /etc/php/php.ini
-#RUN sed -i'' 's#^\(extension=mysqli.so.*$\)#;\1#g' /etc/php/php.ini
-#RUN sed -i'' 's#^\(extension=pdo_mysql.so.*$\)#;\1#g' /etc/php/php.ini
-
 # Use php5enmod to link /etc/php5/mods-available items to /etc/php5/apache2/conf.d/
-# FIXME See above about disabling or enabling mysql php extensions
 RUN php5enmod apcu mcrypt intl pdo_mysql
 RUN php5dismod mysqli mysql
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,6 @@ ENV APACHE_PID_FILE /var/run/apache2.pid
 COPY docker-init docker-init
 RUN chmod +x /docker-init
 
-# Temporary diagnostics page
-COPY phpinfo.php /var/www/html/info.php
-
 EXPOSE 80
 #CMD ["/usr/sbin/apache2", "-D", "FOREGROUND"]
 CMD ["/docker-init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,7 @@ COPY docker-init docker-init
 RUN chmod +x /docker-init
 
 EXPOSE 80
-#CMD ["/usr/sbin/apache2", "-D", "FOREGROUND"]
 CMD ["/docker-init"]
 
-#VOLUME ["/app"]
+VOLUME ["/var/www/html/upload/files/"]
 
-#CMD ["/init"]
-#COPY src/ /var/www/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM debian:jessie
+
+# Inspiration from MAINTAINER Marc Richter <mail@marc-richter.info>
+MAINTAINER Kyle Gordon <kyle@lodge.glasgownet.com>
+
+RUN apt update && apt -y install git apache2 php5 php5-mysql php5-apcu php5-mcrypt php5-intl
+
+# Enable mysql extension, disable PDO and mysqli
+#RUN sed -i'' 's#^;\(extension=mysql.so.*$\)#\1#g' /etc/php/php.ini
+#RUN sed -i'' 's#^\(extension=mysqli.so.*$\)#;\1#g' /etc/php/php.ini
+#RUN sed -i'' 's#^\(extension=pdo_mysql.so.*$\)#;\1#g' /etc/php/php.ini
+
+# Use php5enmod to link /etc/php5/mods-available items to /etc/php5/apache2/conf.d/
+# FIXME See above about disabling or enabling mysql php extensions
+RUN php5enmod apcu mysql mysqli pdo_mysql mcrypt intl
+
+# Add extra script
+#ADD assets/init /extra/init
+
+#VOLUME ["/app"]
+EXPOSE 80
+
+#CMD ["/init"]
+#COPY src/ /var/www/html/
+
+RUN rm /var/www/html/index.html && git clone https://github.com/ignacionelson/ProjectSend /var/www/html/
+
+ENV APACHE_RUN_USER www-data
+ENV APACHE_RUN_GROUP www-data
+ENV APACHE_LOG_DIR /var/log/apache2
+ENV APACHE_LOCK_DIR /var/lock/apache2
+ENV APACHE_PID_FILE /var/run/apache2.pid
+
+EXPOSE 80
+CMD ["/usr/sbin/apache2", "-D", "FOREGROUND"]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ MySQL or MariaDB instance. The below example assumes you have a database host on
 192.168.1.100, with a 'projectsend' table, with the username and password also
 set to 'projectsend'
 
-1. docker run -d -ti -p 80:80 -e DB_NAME=projectsend -e DB_HOST=192.168.1.100 -e DB_USER=projectsend -e DB_PASS=projectsend -e MAX_FILESIZE=51200 kylegordon/projectsend:r756
+1. docker run -d -ti -p 80:80 -e DB_NAME=projectsend -e DB_HOST=192.168.1.100 -e DB_USER=projectsend -e DB_PASS=projectsend -e MAX_FILESIZE=5120000 kylegordon/projectsend:r756
 
 ## Questions, ideas? Want to join the project?
 Send your message to contact@projectsend.org or join us on Facebook, on https://www.facebook.com/projectsend/

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ MySQL or MariaDB instance.
 The below example assumes you have a database host on 192.168.1.100, with a 'projectsend' table, with the username and password also set to 'projectsend'
 The example also provides a volume in which your uploaded files can be stored.
 
-1. docker run -d -ti -p 80:80 /path/to/your/data/:/var/www/html/upload/files/ -e DB_NAME=projectsend -e DB_HOST=192.168.1.100 -e DB_USER=projectsend -e DB_PASS=projectsend -e MAX_FILESIZE=5120000 kylegordon/projectsend:r756
+1. docker run -d -ti -p 80:80 -v /path/to/your/data/:/var/www/html/upload/files/ -e DB_NAME=projectsend -e DB_HOST=192.168.1.100 -e DB_USER=projectsend -e DB_PASS=projectsend -e MAX_FILESIZE=5120000 kylegordon/projectsend:r756
 
 ## Questions, ideas? Want to join the project?
 Send your message to contact@projectsend.org or join us on Facebook, on https://www.facebook.com/projectsend/

--- a/README.md
+++ b/README.md
@@ -55,11 +55,12 @@ Whenever a new version is available, you will be notified in the admin panel via
 ## Using with Docker:
 
 Before running the Docker image, you will need to have a seperate, persistent
-MySQL or MariaDB instance. The below example assumes you have a database host on
-192.168.1.100, with a 'projectsend' table, with the username and password also
-set to 'projectsend'
+MySQL or MariaDB instance. 
 
-1. docker run -d -ti -p 80:80 -e DB_NAME=projectsend -e DB_HOST=192.168.1.100 -e DB_USER=projectsend -e DB_PASS=projectsend -e MAX_FILESIZE=5120000 kylegordon/projectsend:r756
+The below example assumes you have a database host on 192.168.1.100, with a 'projectsend' table, with the username and password also set to 'projectsend'
+The example also provides a volume in which your uploaded files can be stored.
+
+1. docker run -d -ti -p 80:80 /path/to/your/data/:/var/www/html/upload/files/ -e DB_NAME=projectsend -e DB_HOST=192.168.1.100 -e DB_USER=projectsend -e DB_PASS=projectsend -e MAX_FILESIZE=5120000 kylegordon/projectsend:r756
 
 ## Questions, ideas? Want to join the project?
 Send your message to contact@projectsend.org or join us on Facebook, on https://www.facebook.com/projectsend/

--- a/README.md
+++ b/README.md
@@ -53,9 +53,13 @@ When a system user logs in to the system version, a check for database missing d
 Whenever a new version is available, you will be notified in the admin panel via a message shown under the main menu.
 
 ## Using with Docker:
-## FIXME
 
-1. docker run -ti -p 80:80 -e DB_NAME=projectsend -e DB_HOST=10.2.10.213 -e DB_USER=projectsend -e DB_PASS=projectsend -e MAX_FILESIZE=51200 test:latest
+Before running the Docker image, you will need to have a seperate, persistent
+MySQL or MariaDB instance. The below example assumes you have a database host on
+192.168.1.100, with a 'projectsend' table, with the username and password also
+set to 'projectsend'
+
+1. docker run -d -ti -p 80:80 -e DB_NAME=projectsend -e DB_HOST=192.168.1.100 -e DB_USER=projectsend -e DB_PASS=projectsend -e MAX_FILESIZE=51200 kylegordon/projectsend:r756
 
 ## Questions, ideas? Want to join the project?
 Send your message to contact@projectsend.org or join us on Facebook, on https://www.facebook.com/projectsend/

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Your personal configuration file (sys.config.php) is never included on the downl
 When a system user logs in to the system version, a check for database missing data will be made, and if anything is found, it will be updated automatically and a message will appear under the menu one time only.
 Whenever a new version is available, you will be notified in the admin panel via a message shown under the main menu.
 
+## Using with Docker:
+## FIXME
+
+1. docker run -ti -p 80:80 -e DB_NAME=projectsend -e DB_HOST=10.2.10.213 -e DB_USER=projectsend -e DB_PASS=projectsend -e MAX_FILESIZE=51200 test:latest
+
 ## Questions, ideas? Want to join the project?
 Send your message to contact@projectsend.org or join us on Facebook, on https://www.facebook.com/projectsend/
 

--- a/docker-init
+++ b/docker-init
@@ -31,11 +31,11 @@ sed -i'' 's#^define(.*MAX_FILESIZE.*$#MAX_FILESIZE_MARKER#g' "${CONFIGFILE}"
 sed -i'' "s#MAX_FILESIZE_MARKER#define('MAX_FILESIZE',${MAX_FILESIZE});#g" "${CONFIGFILE}"
 # PHP
 # upload_max_filesize
-sed -i'' "s#upload_max_filesize =.*\$#upload_max_filesize = ${MAX_FILESIZE};#g" /etc/php/php.ini
-sed -i'' "s#^;upload_max_filesize#upload_max_filesize#g" /etc/php/php.ini
+sed -i'' "s#upload_max_filesize =.*\$#upload_max_filesize = ${MAX_FILESIZE};#g" /etc/php5/apache2/php.ini
+sed -i'' "s#^;upload_max_filesize#upload_max_filesize#g" /etc/php5/apache2/php.ini
 # post_max_size
-sed -i'' "s#post_max_size =.*\$#post_max_size = ${MAX_FILESIZE};#g" /etc/php/php.ini
-sed -i'' "s#^;post_max_size#post_max_size#g" /etc/php/php.ini
+sed -i'' "s#post_max_size =.*\$#post_max_size = ${MAX_FILESIZE};#g" /etc/php5/apache2/php.ini
+sed -i'' "s#^;post_max_size#post_max_size#g" /etc/php5/apache2/php.ini
 
 # SITE_LANG
 if [ -z "${SITE_LANG}" ]; then

--- a/docker-init
+++ b/docker-init
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Create config if not exist
 CONFIGFILE="/var/www/html/includes/sys.config.php"

--- a/docker-init
+++ b/docker-init
@@ -1,0 +1,59 @@
+#!/bin/bash -x
+
+# Create config if not exist
+CONFIGFILE="/var/www/html/includes/sys.config.php"
+if [ ! -f "${CONFIGFILE}" ]; then
+    cp -f /var/www/html/includes/sys.config.sample.php "${CONFIGFILE}"
+fi
+
+# Make DB settings
+# DB_NAME
+sed -i'' 's#^define(.*DB_NAME.*$#DB_NAME_MARKER#g' "${CONFIGFILE}"
+sed -i'' "s#DB_NAME_MARKER#define('DB_NAME', '${DB_NAME}');#g" "${CONFIGFILE}"
+# DB_HOST
+sed -i'' 's#^define(.*DB_HOST.*$#DB_HOST_MARKER#g' "${CONFIGFILE}"
+sed -i'' "s#DB_HOST_MARKER#define('DB_HOST', '${DB_HOST}');#g" "${CONFIGFILE}"
+# DB_USER
+sed -i'' 's#^define(.*DB_USER.*$#DB_USER_MARKER#g' "${CONFIGFILE}"
+sed -i'' "s#DB_USER_MARKER#define('DB_USER', '${DB_USER}');#g" "${CONFIGFILE}"
+# DB_PASS
+sed -i'' 's#^define(.*DB_PASSWORD.*$#DB_PASS_MARKER#g' "${CONFIGFILE}"
+sed -i'' "s#DB_PASS_MARKER#define('DB_PASSWORD', '${DB_PASS}');#g" "${CONFIGFILE}"
+
+# Make optional changes
+# MAX_FILESIZE
+if [ -z "${MAX_FILESIZE}" ]; then
+    # 2 GB
+    MAX_FILESIZE=2048
+fi
+# ProjectSend
+sed -i'' 's#^define(.*MAX_FILESIZE.*$#MAX_FILESIZE_MARKER#g' "${CONFIGFILE}"
+sed -i'' "s#MAX_FILESIZE_MARKER#define('MAX_FILESIZE',${MAX_FILESIZE});#g" "${CONFIGFILE}"
+# PHP
+# upload_max_filesize
+sed -i'' "s#upload_max_filesize =.*\$#upload_max_filesize = ${MAX_FILESIZE};#g" /etc/php/php.ini
+sed -i'' "s#^;upload_max_filesize#upload_max_filesize#g" /etc/php/php.ini
+# post_max_size
+sed -i'' "s#post_max_size =.*\$#post_max_size = ${MAX_FILESIZE};#g" /etc/php/php.ini
+sed -i'' "s#^;post_max_size#post_max_size#g" /etc/php/php.ini
+
+# SITE_LANG
+if [ -z "${SITE_LANG}" ]; then
+    SITE_LANG=en
+fi
+sed -i'' 's#^define(.*SITE_LANG.*$#SITE_LANG_MARKER#g' "${CONFIGFILE}"
+sed -i'' "s#SITE_LANG_MARKER#define('SITE_LANG', '${SITE_LANG}');#g" "${CONFIGFILE}"
+
+# Execute user_extra - script if present
+USER_EXTRA_SCRIPT=/user_extra/init
+if [ -e ${USER_EXTRA_SCRIPT} ]; then
+    if [ ! -x ${USER_EXTRA_SCRIPT} ]; then
+        chmod +x ${USER_EXTRA_SCRIPT}
+    fi
+    sync
+    ${USER_EXTRA_SCRIPT}
+fi
+
+unset CONFIGFILE SITE_LANG MAX_FILESIZE DB_NAME DB_HOST DB_USER DB_PASS
+
+/usr/sbin/apache2 -D FOREGROUND

--- a/phpinfo.php
+++ b/phpinfo.php
@@ -1,0 +1,7 @@
+<?php
+
+// Show all information, defaults to INFO_ALL
+phpinfo();
+
+?>
+

--- a/phpinfo.php
+++ b/phpinfo.php
@@ -1,7 +1,0 @@
-<?php
-
-// Show all information, defaults to INFO_ALL
-phpinfo();
-
-?>
-


### PR DESCRIPTION
I've taken some inspiration from https://hub.docker.com/r/derjudge/projectsend/ but I disagree with running git clone as part of the docker run stage. After the docker build process, no data should change within an image layer. Anything that changes should be temporary, or as part of a volume.

This Dockerfile will make a static docker image that does not require any git cloning or changing of data during startup. 

It will call upon an external database of the users choosing, and it also makes provision for persistent storage for uploaded files, in the event the docker images is upgraded or started from fresh but with an existing database. 

If you have a hub.docker.com account, please change the example and the Dockerfile to suit. 

A fresh docker image can be built with a command similar to following
git clone https://github.com/kylegordon/ProjectSend/
cd ProjectSend
docker build . -t kylegordon/projectsend:r756
docker push kylegordon/projectsend:r756

Have I missed anything? :-)