### PR TITLE
Account lockout

### DIFF
--- a/clients-edit.php
+++ b/clients-edit.php
@@ -153,8 +153,8 @@ if ($_POST) {
 
 		// get the existing value of active
 		if ($global_level != 0) {
-			$editing = $dbh->prepare("SELECT active FROM " . TABLE_USERS . " WHERE id = :user_id");
-			$editing->bindParam(':user_id', $client_id, PDO::PARAM_INT);
+			$editing = $dbh->prepare("SELECT active FROM " . TABLE_USERS . " WHERE id = :client_id");
+			$editing->bindParam(':client_id', $client_id, PDO::PARAM_INT);
 			$editing->execute();
 			$old_active = $editing->fetchColumn();
 		}
@@ -174,10 +174,10 @@ if ($_POST) {
 		// if account has changed from inactive to active then reset invalid_auth_attempts and start_observation_window
 		if ($global_level != 0) {
 			if ($old_active == ACCOUNT_INACTIVE && $add_client_data_active == ACCOUNT_ACTIVE) {
-				$editing = $dbh->prepare("UPDATE " . TABLE_USERS . " SET invalid_auth_attempts = :invalid_auth_attempts, start_observation_window = :start_observation_window WHERE id = :user_id");
+				$editing = $dbh->prepare("UPDATE " . TABLE_USERS . " SET invalid_auth_attempts = :invalid_auth_attempts, start_observation_window = :start_observation_window WHERE id = :client_id");
 				$editing->bindValue(':invalid_auth_attempts', 0, PDO::PARAM_INT);
 				$editing->bindValue(':start_observation_window', 0, PDO::PARAM_INT);
-				$editing->bindParam(':user_id', $client_id, PDO::PARAM_INT);
+				$editing->bindParam(':client_id', $client_id, PDO::PARAM_INT);
 				$editing->execute();
 			}
 		}

--- a/includes/classes/actions-log.php
+++ b/includes/classes/actions-log.php
@@ -50,6 +50,10 @@ $activities_references = array(
 							37	=> __('An anonymous user downloaded a public file.','cftp_admin'),
 							38	=> __('A client account request was processed.','cftp_admin'),
 							39	=> __("A client's groups membership requests were processed.",'cftp_admin'),
+							40	=> __("A client account failed login",'cftp_admin'),
+							41	=> __("A user account failed login",'cftp_admin'),
+							42	=> __("A client account deactivated due to maximum failed logins reached",'cftp_admin'),
+							43	=> __("A user account deactivated due to maximum failed logins reached",'cftp_admin'),
 						);
  /**
  * More to be added soon.

--- a/includes/classes/actions-log.php
+++ b/includes/classes/actions-log.php
@@ -54,6 +54,7 @@ $activities_references = array(
 							41	=> __("A user account failed login",'cftp_admin'),
 							42	=> __("A client account deactivated due to maximum failed logins reached",'cftp_admin'),
 							43	=> __("A user account deactivated due to maximum failed logins reached",'cftp_admin'),
+							44	=> __("An unknown account failed login",'cftp_admin'),
 						);
  /**
  * More to be added soon.

--- a/includes/core.update.php
+++ b/includes/core.update.php
@@ -1363,6 +1363,29 @@ if (in_session_or_cookies($allowed_update)) {
 				$updates_made++;
 			}
 		}
+		
+		/**
+		* r1023 updates
+		* 1- New solumns invalid_auth_attempts and start_observation_window for account lockout functionality
+		*/
+		if ($last_update < 1023) {
+			$new_database_values = array(
+							'user_max_invalid_auth_attempts'	=> '5',
+							'user_observation_window'		=> '20',
+							'client_max_invalid_auth_attempts'	=> '5',
+							'client_observation_window'		=> '20',
+						);
+			
+			foreach($new_database_values as $row => $value) {
+				if ( add_option_if_not_exists($row, $value) ) {
+					$updates_made++;
+				}
+			}
+
+			$statement = $dbh->query("ALTER TABLE " . TABLE_USERS . " ADD invalid_auth_attempts INT(3) NOT NULL default '0'");
+			$statement = $dbh->query("ALTER TABLE " . TABLE_USERS . " ADD start_observation_window INT(10) NOT NULL default '0'");
+			$updates_made++;
+		}
 
 	}
 }

--- a/includes/core.update.php
+++ b/includes/core.update.php
@@ -1366,7 +1366,8 @@ if (in_session_or_cookies($allowed_update)) {
 		
 		/**
 		* r1023 updates
-		* 1- New solumns invalid_auth_attempts and start_observation_window for account lockout functionality
+		* 1- New columns invalid_auth_attempts and start_observation_window for account lockout functionality
+ 		* 2- New option for logging failed authentication attempts 
 		*/
 		if ($last_update < 1023) {
 			$new_database_values = array(
@@ -1374,6 +1375,7 @@ if (in_session_or_cookies($allowed_update)) {
 							'user_observation_window'		=> '20',
 							'client_max_invalid_auth_attempts'	=> '5',
 							'client_observation_window'		=> '20',
+							'log_failed_auth'			=> '0',
 						);
 			
 			foreach($new_database_values as $row => $value) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1419,6 +1419,11 @@ function render_log_action($params)
 			$action_text = __('deactivated the user due to maximum failed logins reached','cftp_admin');
 			$part2 = $affected_account_name;
 			break;
+		case 44:
+			$action_ico = 'login';
+			$part1 = $owner_user;
+			$action_text = __('unknown account failed login to the system.','cftp_admin');
+			break;
 	}
 	
 	$date = date(TIMEFORMAT_USE,strtotime($timestamp));

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1397,6 +1397,28 @@ function render_log_action($params)
 			$action_text = __('processed group memberships requests for','cftp_admin');
 			$part2 = $affected_account_name;
 			break;
+		case 40:
+			$action_ico = 'login';
+			$part1 = $owner_user;
+			$action_text = __('client failed login to the system.','cftp_admin');
+			break;
+		case 41:
+			$action_ico = 'login';
+			$part1 = $owner_user;
+			$action_text = __('user failed login to the system.','cftp_admin');
+			break;
+		case 42:
+			$action_ico = 'client-deactivate';
+			$part1 = $owner_user;
+			$action_text = __('deactivated the client due to maximum failed logins reached','cftp_admin');
+			$part2 = $affected_account_name;
+			break;
+		case 43:
+			$action_ico = 'user-deactivate';
+			$part1 = $owner_user;
+			$action_text = __('deactivated the user due to maximum failed logins reached','cftp_admin');
+			$part2 = $affected_account_name;
+			break;
 	}
 	
 	$date = date(TIMEFORMAT_USE,strtotime($timestamp));

--- a/includes/site.options.php
+++ b/includes/site.options.php
@@ -328,6 +328,10 @@ if(!empty($options_values)) {
 		define('CLIENT_OBSERVATION_WINDOW',$options_values['client_observation_window']);
 	}
 
+	if (isset($options_values['log_failed_auth'])) {
+		define('LOG_FAILED_AUTH',$options_values['log_failed_auth']);
+	}
+
 	/**
 	 * Set the default timezone based on the value of the Timezone select box
 	 * of the options page.

--- a/includes/site.options.php
+++ b/includes/site.options.php
@@ -319,6 +319,16 @@ if(!empty($options_values)) {
 	}
 
 	/**
+         * For versions 1023 and up
+	 */
+	if (isset($options_values['user_max_invalid_auth_attempts'])) {
+		define('USER_MAX_INVALID_AUTH_ATTEMPTS',$options_values['user_max_invalid_auth_attempts']);
+		define('USER_OBSERVATION_WINDOW',$options_values['user_observation_window']);
+		define('CLIENT_MAX_INVALID_AUTH_ATTEMPTS',$options_values['client_max_invalid_auth_attempts']);
+		define('CLIENT_OBSERVATION_WINDOW',$options_values['client_observation_window']);
+	}
+
+	/**
 	 * Set the default timezone based on the value of the Timezone select box
 	 * of the options page.
 	 */

--- a/includes/vars.php
+++ b/includes/vars.php
@@ -20,6 +20,12 @@ if ( !defined( 'USER_ROLE_LVL_7' ) ) { define('USER_ROLE_LVL_7', $user_role_7_na
 if ( !defined( 'USER_ROLE_LVL_0' ) ) { define('USER_ROLE_LVL_0', $user_role_0_name); }
 
 /**
+ * Account status
+ */
+if ( !defined( 'ACCOUNT_ACTIVE' ) ) { define('ACCOUNT_ACTIVE', 1); }
+if ( !defined( 'ACCOUNT_INACTIVE' ) ) { define('ACCOUNT_INACTIVE', 0); }
+
+/**
  * Validation class strings
  */
 $validation_recaptcha		= __('reCAPTCHA verification failed','cftp_admin');

--- a/install/database.php
+++ b/install/database.php
@@ -63,7 +63,9 @@ if (defined('TRY_INSTALL')) {
 								  `active` tinyint(1) NOT NULL DEFAULT \'1\',
 								  `account_requested` tinyint(1) NOT NULL DEFAULT \'0\',
 								  `account_denied` tinyint(1) NOT NULL DEFAULT \'0\',
-								  `max_file_size` int(20)  NOT NULL DEFAULT \'0\',
+								  `max_file_size` int(20) NOT NULL DEFAULT \'0\',
+								  `start_observation_window` int(10) NOT NULL DEFAULT \'0\',
+								  `invalid_auth_attempts` int(3) NOT NULL DEFAULT \'0\',
 								  PRIMARY KEY (`id`)
 								) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 								',

--- a/install/database.php
+++ b/install/database.php
@@ -337,7 +337,12 @@ if (defined('TRY_INSTALL')) {
 								('public_listing_page_enable', '0'),
 								('public_listing_logged_only', '0'),
 								('public_listing_show_all_files', '0'),
-								('public_listing_use_download_link', '0')
+								('public_listing_use_download_link', '0'),
+								('user_max_invalid_auth_attempts', '5'),
+								('user_observation_window', '20'),
+								('client_max_invalid_auth_attempts', '5'),
+								('client_observation_window', '20'),
+								('log_failed_auth', '0')
 								",
 					'params' => array(
 										':base_uri'	=> $base_uri,

--- a/options.php
+++ b/options.php
@@ -141,6 +141,44 @@ if ($_POST) {
 			}
 		}
 	}
+
+	/** Some server side data validation is always nice */
+	if ($query_state == '0') {
+
+		/** Account lockout options */
+
+		/** user */
+		if (!empty($_POST['user_max_invalid_auth_attempts'])) {
+			if($_POST['user_max_invalid_auth_attempts'] < MIN_INVALID_AUTH_ATTEMPTS || 
+			  $_POST['user_max_invalid_auth_attempts'] > MAX_INVALID_AUTH_ATTEMPTS) {
+				$query_state = 4;
+			}
+		}
+
+		if (!empty($_POST['user_observation_window'])) {
+			if($_POST['user_observation_window'] < MIN_OBSERVED_WINDOW || 
+			  $_POST['user_observation_window'] > MAX_OBSERVED_WINDOW) {
+				$query_state = 4;
+			}
+
+		}
+
+		/** client */
+		if (!empty($_POST['client_max_invalid_auth_attempts'])) {
+			if($_POST['client_max_invalid_auth_attempts'] < MIN_INVALID_AUTH_ATTEMPTS || 
+			  $_POST['client_max_invalid_auth_attempts'] > MAX_INVALID_AUTH_ATTEMPTS) {
+				$query_state = 4;
+			}
+
+		}
+
+		if (!empty($_POST['client_observation_window'])) {
+			if($_POST['client_observation_window'] < MIN_OBSERVED_WINDOW || 
+			  $_POST['client_observation_window'] > MAX_OBSERVED_WINDOW) {
+				$query_state = 4;
+			}
+		}
+	}
 	
 	/** If every option is completed, continue */
 	if ($query_state == '0') {
@@ -266,6 +304,10 @@ $allowed_file_types = implode(',',$allowed_file_types);
 					echo system_message('error',$msg);
 					$show_options_form = 1;
 					break;
+				case '4':
+					$msg = __('Invalid option vale specified. Please try again.','cftp_admin');
+					echo system_message('error',$msg);
+					break;
 			}
 		}
 
@@ -316,32 +358,32 @@ $allowed_file_types = implode(',',$allowed_file_types);
 					});
 			
 					$('#user_observation_window').spinedit({
-						minimum: 2,
-						maximum: 999,
+						minimum: <?php echo MIN_OBSERVED_WINDOW; ?>,
+						maximum: <?php echo MAX_OBSERVED_WINDOW; ?>,
 						step: 1,
 						value: <?php echo USER_OBSERVATION_WINDOW; ?>,
 						numberOfDecimals: 0
 					});
 
 					$('#user_max_invalid_auth_attempts').spinedit({
-						minimum: 0,
-						maximum: 999,
+						minimum: <?php echo MIN_INVALID_AUTH_ATTEMPTS; ?>,
+						maximum: <?php echo MAX_INVALID_AUTH_ATTEMPTS; ?>,
 						step: 1,
 						value: <?php echo USER_MAX_INVALID_AUTH_ATTEMPTS; ?>,
 						numberOfDecimals: 0
 					});
 
 					$('#client_observation_window').spinedit({
-						minimum: 2,
-						maximum: 999,
+						minimum: <?php echo MIN_OBSERVED_WINDOW; ?>,
+						maximum: <?php echo MAX_OBSERVED_WINDOW; ?>,
 						step: 1,
 						value: <?php echo CLIENT_OBSERVATION_WINDOW; ?>,
 						numberOfDecimals: 0
 					});
 
 					$('#client_max_invalid_auth_attempts').spinedit({
-						minimum: 0,
-						maximum: 999,
+						minimum: <?php echo MIN_INVALID_AUTH_ATTEMPTS; ?>,
+						maximum: <?php echo MAX_INVALID_AUTH_ATTEMPTS; ?>,
 						step: 1,
 						value: <?php echo CLIENT_MAX_INVALID_AUTH_ATTEMPTS; ?>,
 						numberOfDecimals: 0

--- a/options.php
+++ b/options.php
@@ -61,6 +61,7 @@ switch ( $section ) {
 								'pass_require_number',
 								'pass_require_special',
 								'recaptcha_enabled',
+								'log_failed_auth',
 							);
 		break;
 	case 'thumbnails':
@@ -923,7 +924,10 @@ $allowed_file_types = implode(',',$allowed_file_types);
 									</div>
 								</div>
 
+								<div class="options_divide"></div>
+
 								<h3><?php _e('Account Lockout','cftp_admin'); ?></h3>
+								<p><?php _e('Configure account lockout of user and client accounts','cftp_admin'); ?></p>
 								<div class="form-group">
 									<label for="user_observation_window" class="col-sm-4 control-label"><?php _e('User observation window (minutes)','cftp_admin'); ?></label>
 									<div class="col-sm-8">
@@ -953,6 +957,19 @@ $allowed_file_types = implode(',',$allowed_file_types);
 									<div class="col-sm-8">
 										<input type="text" name="client_max_invalid_auth_attempts" id="client_max_invalid_auth_attempts" class="form-control" value="<?php echo CLIENT_MAX_INVALID_AUTH_ATTEMPTS; ?>" />
 										<p class="field_note"><?php _e('Once an account reached this number it will be disabled. Set to 0 to disable client account lockout.','cftp_admin'); ?></p>
+									</div>
+								</div>
+
+								<div class="options_divide"></div>
+
+								<h3><?php _e('Logging','cftp_admin'); ?></h3>
+								<p><?php _e('Options for logging of security events','cftp_admin'); ?></p>
+	
+								<div class="form-group">
+									<div class="col-sm-8 col-sm-offset-4">
+										<label for="log_failed_auth">
+											<input type="checkbox" value="1" name="log_failed_auth" id="log_failed_auth" class="checkbox_options" <?php echo (LOG_FAILED_AUTH == 1) ? 'checked="checked"' : ''; ?> /> <?php _e('Log failed authentication attempts','cftp_admin'); ?>
+										</label>
 									</div>
 								</div>
 	

--- a/options.php
+++ b/options.php
@@ -314,6 +314,38 @@ $allowed_file_types = implode(',',$allowed_file_types);
 						value: <?php echo NOTIFICATIONS_MAX_DAYS; ?>,
 						numberOfDecimals: 0
 					});
+			
+					$('#user_observation_window').spinedit({
+						minimum: 2,
+						maximum: 999,
+						step: 1,
+						value: <?php echo USER_OBSERVATION_WINDOW; ?>,
+						numberOfDecimals: 0
+					});
+
+					$('#user_max_invalid_auth_attempts').spinedit({
+						minimum: 0,
+						maximum: 999,
+						step: 1,
+						value: <?php echo USER_MAX_INVALID_AUTH_ATTEMPTS; ?>,
+						numberOfDecimals: 0
+					});
+
+					$('#client_observation_window').spinedit({
+						minimum: 2,
+						maximum: 999,
+						step: 1,
+						value: <?php echo CLIENT_OBSERVATION_WINDOW; ?>,
+						numberOfDecimals: 0
+					});
+
+					$('#client_max_invalid_auth_attempts').spinedit({
+						minimum: 0,
+						maximum: 999,
+						step: 1,
+						value: <?php echo CLIENT_MAX_INVALID_AUTH_ATTEMPTS; ?>,
+						numberOfDecimals: 0
+					});
 	
 					$('#allowed_file_types').tagsInput({
 						'width'			: '95%',
@@ -848,6 +880,40 @@ $allowed_file_types = implode(',',$allowed_file_types);
 										<a href="<?php echo LINK_DOC_RECAPTCHA; ?>" class="external_link" target="_blank"><?php _e('How do I obtain this credentials?','cftp_admin'); ?></a>
 									</div>
 								</div>
+
+								<h3><?php _e('Account Lockout','cftp_admin'); ?></h3>
+								<div class="form-group">
+									<label for="user_observation_window" class="col-sm-4 control-label"><?php _e('User observation window (minutes)','cftp_admin'); ?></label>
+									<div class="col-sm-8">
+										<input type="text" name="user_observation_window" id="user_observation_window" class="form-control" value="<?php echo USER_OBSERVATION_WINDOW; ?>" />
+										<p class="field_note"><?php _e('Define the period of time invalid logins will be observed over in minutes','cftp_admin'); ?></p>
+									</div>
+								</div>
+
+								<div class="form-group">
+									<label for="user_max_invalid_auth_attempts" class="col-sm-4 control-label"><?php _e('User maximum invalid login count','cftp_admin'); ?></label>
+									<div class="col-sm-8">
+										<input type="text" name="user_max_invalid_auth_attempts" id="user_max_invalid_auth_attempts" class="form-control" value="<?php echo USER_MAX_INVALID_AUTH_ATTEMPTS; ?>" />
+										<p class="field_note"><?php _e('Once an account reached this number it will be disabled. Set to 0 to disable user account lockout.','cftp_admin'); ?></p>
+									</div>
+								</div>
+
+								<div class="form-group">
+									<label for="client_observation_window" class="col-sm-4 control-label"><?php _e('Client observation window (minutes)','cftp_admin'); ?></label>
+									<div class="col-sm-8">
+										<input type="text" name="client_observation_window" id="client_observation_window" class="form-control" value="<?php echo CLIENT_OBSERVATION_WINDOW; ?>" />
+										<p class="field_note"><?php _e('Define the period of time invalid logins will be observed over in minutes','cftp_admin'); ?></p>
+									</div>
+								</div>
+
+								<div class="form-group">
+									<label for="client_max_invalid_auth_attempts" class="col-sm-4 control-label"><?php _e('Client maximum invalid login count','cftp_admin'); ?></label>
+									<div class="col-sm-8">
+										<input type="text" name="client_max_invalid_auth_attempts" id="client_max_invalid_auth_attempts" class="form-control" value="<?php echo CLIENT_MAX_INVALID_AUTH_ATTEMPTS; ?>" />
+										<p class="field_note"><?php _e('Once an account reached this number it will be disabled. Set to 0 to disable client account lockout.','cftp_admin'); ?></p>
+									</div>
+								</div>
+	
 					<?php
 							break;
 							case 'thumbnails':

--- a/options.php
+++ b/options.php
@@ -305,7 +305,7 @@ $allowed_file_types = implode(',',$allowed_file_types);
 					$show_options_form = 1;
 					break;
 				case '4':
-					$msg = __('Invalid option vale specified. Please try again.','cftp_admin');
+					$msg = __('Invalid option value specified. Please try again.','cftp_admin');
 					echo system_message('error',$msg);
 					break;
 			}

--- a/process.php
+++ b/process.php
@@ -150,9 +150,28 @@ class process {
 				}
 			}
 			else {
-				//
-				// account lockout logic
-				//
+				/**
+				* failed authentication logging
+				*/
+				
+				if (LOG_FAILED_AUTH) {
+
+					$action = ($this->user_level != '0' ? 41 : 40);
+
+					$this->new_log_action = new LogActions();
+					$this->log_action_args = array(
+							'action' => $action,
+							'owner_id' => $this->logged_id,
+							'owner_user' => $this->global_name,
+							'affected_account_name' => $this->global_name
+										);
+					$this->new_record_action = $this->new_log_action->log_action_save($this->log_action_args);
+				}
+
+
+				/**
+				* account lockout logic
+				*/	
 
 				// set the correct limits based on the user_level of the account
 				if ($this->user_level != '0') {
@@ -248,6 +267,17 @@ class process {
 		else {
 			// count_user = 'wrong_username';
 			$this->errorstate = 'invalid_credentials';
+
+			if (LOG_FAILED_AUTH) {
+
+				$this->new_log_action = new LogActions();
+				$this->log_action_args = array(
+						'action' => 44,
+						'owner_id' => -1,
+						'owner_user' => $_GET['username']
+					);
+				$this->new_record_action = $this->new_log_action->log_action_save($this->log_action_args);
+			}
 		}
 
 		if (isset($this->errorstate)) {

--- a/process.php
+++ b/process.php
@@ -171,12 +171,14 @@ class process {
 						if (time() <= $this->start_observation_window + $this->observation_window * 60) {
 							// this invalid login is in an existing observation_window
 
-							// update user table incrementing invalid_auth_attempts by one
-                                			$this->sql = "UPDATE " . TABLE_USERS . " SET invalid_auth_attempts = :invalid_auth_attempts WHERE id = :logged_id";
-                                			$this->statement = $this->dbh->prepare($this->sql);
-                                			$this->statement->bindValue(':invalid_auth_attempts', $this->invalid_auth_attempts + 1, PDO::PARAM_INT);
-      							$this->statement->bindParam(':logged_id', $this->logged_id, PDO::PARAM_INT);
-                                			$this->statement->execute();
+							// update user table incrementing invalid_auth_attempts by one if current value < MAX_INVALID_AUTH_ATTEMPTS
+							if ($this->invalid_auth_attempts < MAX_INVALID_AUTH_ATTEMPTS) {
+                                				$this->sql = "UPDATE " . TABLE_USERS . " SET invalid_auth_attempts = :invalid_auth_attempts WHERE id = :logged_id";
+                                				$this->statement = $this->dbh->prepare($this->sql);
+                                				$this->statement->bindValue(':invalid_auth_attempts', $this->invalid_auth_attempts + 1, PDO::PARAM_INT);
+      								$this->statement->bindParam(':logged_id', $this->logged_id, PDO::PARAM_INT);
+                                				$this->statement->execute();
+							}
 
 							// requery to refresh $this
 							$this->refresh_account_status($this->logged_id);

--- a/process.php
+++ b/process.php
@@ -188,6 +188,18 @@ class process {
 								// maximum attempts in window exceded so disable user account and refresh status
 								$this->disable_account($this->logged_id);
 								$this->refresh_account_status($this->logged_id);
+					
+								/** Record the lockout action */
+								$action = ($this->user_level != '0' ? 43 : 42);
+
+								$this->new_log_action = new LogActions();
+								$this->log_action_args = array(
+											'action' => $action,
+											'owner_id' => $this->logged_id,
+											'owner_user' => $this->global_name,
+											'affected_account_name' => $this->global_name
+										);
+								$this->new_record_action = $this->new_log_action->log_action_save($this->log_action_args);
 							}
 						}
 						else {
@@ -210,6 +222,18 @@ class process {
 						// maximum attempts exceded so disable user account and refresh status
 						$this->disable_account($this->logged_id);
 						$this->refresh_account_status($this->logged_id);
+
+						/** Record the lockout action */
+						$action = ($this->user_level != '0' ? 43 : 42);
+
+						$this->new_log_action = new LogActions();
+						$this->log_action_args = array(
+									'action' => $action,
+									'owner_id' => $this->logged_id,
+									'owner_user' => $this->global_name,
+									'affected_account_name' => $this->global_name
+								);
+						$this->new_record_action = $this->new_log_action->log_action_save($this->log_action_args);
 					}
 					
 					// user hasn't authenticated correctly so don't bleed any state information about the account

--- a/process.php
+++ b/process.php
@@ -153,22 +153,15 @@ class process {
 				//
 				// account lockout logic
 				//
-				error_log("DBG: *** Start lokout logic", 0);
 
 				// set the correct limits based on the user_level of the account
 				if ($this->user_level != '0') {
-					error_log("DBG: User account", 0);
 					$this->max_invalid_auth_attempts = USER_MAX_INVALID_AUTH_ATTEMPTS;
 					$this->observation_window = USER_OBSERVATION_WINDOW;
 				} else {
-					error_log("DBG: Client account", 0);
 					$this->max_invalid_auth_attempts = CLIENT_MAX_INVALID_AUTH_ATTEMPTS;
 					$this->observation_window = CLIENT_OBSERVATION_WINDOW;
 				}
-
-				error_log("DBG: max_invalid_auth_attempts: " . $this->max_invalid_auth_attempts, 0);
-				error_log("DBG: observation_window: " . $this->observation_window, 0);
-				error_log("DBG: active_status: " . $this->active_status, 0);
 
 				// only bother where the account is active and lockout functionality is enabled (i.e. _MAX_INVALID_AUTH_ATTEMPTS > 0)
 				if ($this->active_status != '0' && $this->max_invalid_auth_attempts != '0') {
@@ -179,10 +172,10 @@ class process {
 							// this invalid login is in an existing observation_window
 
 							// update user table incrementing invalid_auth_attempts by one
-                                			$this->sql = "UPDATE " . TABLE_USERS . " SET invalid_auth_attempts = :invalid_auth_attempts WHERE id = :user_id";
+                                			$this->sql = "UPDATE " . TABLE_USERS . " SET invalid_auth_attempts = :invalid_auth_attempts WHERE id = :logged_id";
                                 			$this->statement = $this->dbh->prepare($this->sql);
                                 			$this->statement->bindValue(':invalid_auth_attempts', $this->invalid_auth_attempts + 1, PDO::PARAM_INT);
-      							$this->statement->bindParam(':user_id', $this->logged_id, PDO::PARAM_INT);
+      							$this->statement->bindParam(':logged_id', $this->logged_id, PDO::PARAM_INT);
                                 			$this->statement->execute();
 
 							// requery to refresh $this
@@ -198,11 +191,11 @@ class process {
 						else {
 							// this invalid login is in a new observation_window
 							
-                                			$this->sql = "UPDATE " . TABLE_USERS . " SET invalid_auth_attempts = :invalid_auth_attempts, start_observation_window = :start_observation_window WHERE id = :user_id";
+                                			$this->sql = "UPDATE " . TABLE_USERS . " SET invalid_auth_attempts = :invalid_auth_attempts, start_observation_window = :start_observation_window WHERE id = :logged_id";
                                 			$this->statement = $this->dbh->prepare($this->sql);
                                 			$this->statement->bindValue(':invalid_auth_attempts', 1, PDO::PARAM_INT);
                                 			$this->statement->bindValue(':start_observation_window', time(), PDO::PARAM_INT);
-      							$this->statement->bindParam(':user_id', $this->logged_id, PDO::PARAM_INT);
+      							$this->statement->bindParam(':logged_id', $this->logged_id, PDO::PARAM_INT);
                                 			$this->statement->execute();
 
 							// requery to refresh $this
@@ -280,8 +273,8 @@ class process {
 
 	private function refresh_account_status($id) {
 		
-		$this->statement = $this->dbh->prepare("SELECT * FROM " . TABLE_USERS . " WHERE id = :user_id");
-		$this->statement->bindParam(':user_id', $id, PDO::PARAM_INT);
+		$this->statement = $this->dbh->prepare("SELECT * FROM " . TABLE_USERS . " WHERE id = :logged_id");
+		$this->statement->bindParam(':logged_id', $id, PDO::PARAM_INT);
 		$this->statement->execute();
 		$this->statement->setFetchMode(PDO::FETCH_ASSOC);
 	
@@ -293,10 +286,10 @@ class process {
 	}
 
 	private function disable_account($id) {
-		$this->sql = "UPDATE " . TABLE_USERS . " SET active = :active_status WHERE id = :user_id";
+		$this->sql = "UPDATE " . TABLE_USERS . " SET active = :active_status WHERE id = :logged_id";
 		$this->statement = $this->dbh->prepare($this->sql);
 		$this->statement->bindValue(':active_status', ACCOUNT_INACTIVE, PDO::PARAM_INT);
-		$this->statement->bindParam(':user_id', $id, PDO::PARAM_INT);
+		$this->statement->bindParam(':logged_id', $id, PDO::PARAM_INT);
 		$this->statement->execute();
 	}	
 

--- a/sys.vars.php
+++ b/sys.vars.php
@@ -14,7 +14,7 @@ session_start();
  * Current version.
  * Updated only when releasing a new downloadable complete version.
  */
-define('CURRENT_VERSION', 'r1022');
+define('CURRENT_VERSION', 'r1023');
 
 /**
  * Fix for including external files when on HTTPS.

--- a/sys.vars.php
+++ b/sys.vars.php
@@ -170,6 +170,13 @@ define('MAX_PASS_CHARS', 60);
 
 define('MIN_GENERATE_PASS_CHARS', 10);
 define('MAX_GENERATE_PASS_CHARS', 20);
+
+// account lockout options validation
+define('MIN_INVALID_AUTH_ATTEMPTS', 0);
+define('MAX_INVALID_AUTH_ATTEMPTS', 999);
+define('MIN_OBSERVED_WINDOW', 2);
+define('MAX_OBSERVED_WINDOW', 999);
+
 /*
  * Cookie expiration time (in seconds).
  * Set by default to 30 days (60*60*24*30).


### PR DESCRIPTION
Introduce account lockout functionality for user and client account types.  This has four new settings exposed under Options->Security in the UI which determine how it works:

User observation window (minutes)
User maximum invalid login count
Client observation window (minutes)
Client maximum invalid login count

* If "User maximum invalid login count" is set to 0 then lockout is disabled for all user accounts
* If "Client maximum invalid login count" is set to 0 then lockout is disabled for all client accounts

The logic is fairly simple in that:
* The counter will increment for every invalid login in the observation window.  If the counter reaches the maximum invalid login count in an observation window then the account is marked inactive.  
* I didn't introduce an additional locked/unlocked flag for the account and just reused the existing active/inactive flag.
* If the observation window expires then the next invalid login will just start a new counter at 1 in a new observation window that starts at the time of the first invalid login.

To fix the account just login to the UI and mark the account as active and this will reset the observation window and counter for the account at the same time.

At the same time enhance logging so that the following are captured:
* When a user account is locked out
* When a client account is locked out
* When a failed authentication attempt happens (Can enable/disable in Security Options)