### PR TITLE
Fix double encoding issue in file description Fixes #564

### DIFF
--- a/header.php
+++ b/header.php
@@ -54,11 +54,11 @@ if (in_session_or_cookies($core_update_allowed)) {
 <!doctype html>
 <html lang="<?php echo SITE_LANG; ?>">
 <head>
-	<meta charset="utf-8">
+	<meta charset="<?php echo(CHARSET); ?>">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
-	<title><?php echo html_output( $page_title . ' &raquo; ' . htmlspecialchars(THIS_INSTALL_SET_TITLE, ENT_QUOTES, 'UTF-8') ); ?></title>
+	<title><?php echo html_output( $page_title . ' &raquo; ' . htmlspecialchars(THIS_INSTALL_SET_TITLE, ENT_QUOTES, CHARSET) ); ?></title>
 	<?php meta_favicon(); ?>
 	<script type="text/javascript" src="<?php echo BASE_URI; ?>includes/js/jquery.1.12.4.min.js"></script>
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -755,9 +755,9 @@ function html_output($str, $flags = ENT_QUOTES, $encoding = 'UTF-8', $double_enc
  * Allow some html tags for file descriptions on htmlentities
  *
  */
-function htmlentities_allowed($str)
+function htmlentities_allowed($str, $quoteStyle = ENT_COMPAT, $charset = CHARSET, $doubleEncode = false)
 {
-	$description = htmlentities($str);
+	$description = htmlentities($str, $quoteStyle, $charset, $doubleEncode);
 	$allowed_tags = array('i','b','strong','em','p','br','ul','ol','li','u','sup','sub','s');
 
 	$find = array();

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -746,7 +746,7 @@ function get_current_user_username()
  * Wrapper for htmlentities with default options
  *
  */
-function html_output($str, $flags = ENT_QUOTES, $encoding = 'UTF-8', $double_encode = false)
+function html_output($str, $flags = ENT_QUOTES, $encoding = CHARSET, $double_encode = false)
 {
 	return htmlentities($str, $flags, $encoding, $double_encode);
 }
@@ -782,7 +782,7 @@ function htmlentities_allowed($str, $quoteStyle = ENT_COMPAT, $charset = CHARSET
  * characters when saving to the database.
  */
 function encode_html($str) {
-	$str = htmlentities($str, ENT_QUOTES, $encoding='utf-8');
+	$str = htmlentities($str, ENT_QUOTES, $encoding=CHARSET);
 	$str = nl2br($str);
 	//$str = addslashes($str);
 	return $str;

--- a/sys.vars.php
+++ b/sys.vars.php
@@ -43,6 +43,11 @@ define('DEBUG', false);
 define('IS_DEV', false);
 
 /**
+ * This constant holds the current default charset
+ */
+define('CHARSET', 'ISO-8859-1');
+
+/**
  * Turn off reporting of PHP errors, warnings and notices.
  * On a development environment, it should be set to E_ALL for
  * complete debugging.

--- a/sys.vars.php
+++ b/sys.vars.php
@@ -45,7 +45,7 @@ define('IS_DEV', false);
 /**
  * This constant holds the current default charset
  */
-define('CHARSET', 'ISO-8859-1');
+define('CHARSET', 'UTF-8');
 
 /**
  * Turn off reporting of PHP errors, warnings and notices.


### PR DESCRIPTION
@ignacionelson you mentioned, that currently ps is running under iso encoding? Am I right, that the encoding constant should be ISO-8859-1?