### PR TITLE
Graceful handling of image filetypes not supported by SimpleImage

### DIFF
--- a/includes/Classes/Files.php
+++ b/includes/Classes/Files.php
@@ -257,7 +257,7 @@ class Files
         }
 
         // Image
-        $embeddable = ["gif", "jpeg", "jfif", "png", "webp", "bmp", "svg"];
+        $embeddable = ["gif", "jpg", "jpeg", "jfif", "png", "webp", "bmp", "svg"];
         if (isImage($this->full_path) && in_array($this->extension, $embeddable)) {
             $this->embeddable = true;
             $this->embeddable_type = 'image';

--- a/includes/Classes/Files.php
+++ b/includes/Classes/Files.php
@@ -98,7 +98,7 @@ class Files
     }
 
     /**
-     * Set the properties when saving to the database (data comnes from the form)
+     * Set the properties when saving to the database (data comes from the form)
      */
     public function set($arguments = [])
     {
@@ -256,7 +256,9 @@ class Files
             return null;
         }
 
-        if ($this->isImage()) {
+        // Image
+        $embeddable = ["gif", "jpeg", "jfif", "png", "webp", "bmp", "svg"];
+        if (isImage($this->full_path) && in_array($this->extension, $embeddable)) {
             $this->embeddable = true;
             $this->embeddable_type = 'image';
         }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1542,7 +1542,7 @@ function option_file_upload( $file, $validate_ext = '', $option = '', $action = 
 	if ( !empty( $validate_ext ) ) {
 		switch ( $validate_ext ) {
 			case 'image':
-				$validate_types = "/^\.(jpg|jpeg|gif|png){1}$/i";
+				$validate_types = "/^\.(jpg|jfif|jpeg|gif|png){1}$/i";
 				break;
 			default:
 				break;

--- a/manage-files.php
+++ b/manage-files.php
@@ -637,7 +637,11 @@ include_once ADMIN_VIEWS_DIR . DS . 'header.php';
                                 $preview_cell = '<button class="btn btn-warning btn-sm btn-wide get-preview" data-url="'.BASE_URI.'process.php?do=get_preview&file_id='.$file->id.'">'.__('Preview', 'cftp_admin').'</button>';
                             }
                             if ( file_is_image( $file->full_path ) ) {
-                                $thumbnail = make_thumbnail( $file->full_path, null, 50, 50 );
+                                if ($file->embeddable) {
+                                    $thumbnail = make_thumbnail( $file->full_path, null, 50, 50 );
+                                } else {
+                                    $thumbnail = make_thumbnail( "", null, 50, 50 );
+                                }
                                 if ( !empty( $thumbnail['thumbnail']['url'] ) ) {
                                     $preview_cell = '<a href="#" class="get-preview" data-url="'.BASE_URI.'process.php?do=get_preview&file_id='.$file->id.'">
                                         <img src="' . $thumbnail['thumbnail']['url'] . '" class="thumbnail" />

--- a/templates/default/template.php
+++ b/templates/default/template.php
@@ -218,7 +218,12 @@ define('TEMPLATE_THUMBNAILS_HEIGHT', '50');
                                 $preview_cell = '';
                                 if ( $file->expired == false) {
                                     if ( $file->isImage() ) {
-                                        $thumbnail = make_thumbnail( $file->full_path, null, TEMPLATE_THUMBNAILS_WIDTH, TEMPLATE_THUMBNAILS_HEIGHT );
+                                        if ($file->embeddable) {
+                                            $thumbnail = make_thumbnail( $file->full_path, null, TEMPLATE_THUMBNAILS_WIDTH, TEMPLATE_THUMBNAILS_HEIGHT );
+                                        } else {
+                                            $thumbnail = make_thumbnail( "", null, TEMPLATE_THUMBNAILS_WIDTH, TEMPLATE_THUMBNAILS_HEIGHT );
+                                        }
+                                        
                                         if ( !empty( $thumbnail['thumbnail']['url'] ) ) {
                                             $preview_cell = '
                                                 <a href="#" class="get-preview" data-url="'.BASE_URI.'process.php?do=get_preview&file_id='.$file->id.'">


### PR DESCRIPTION
Closes #1048 

Currently, if a file returns TRUE for isImage() (which checks vs mimetype), but isn't supported by SimpleImage, we get a broken link
![CUPjBteTCt](https://user-images.githubusercontent.com/81652082/146601104-4113b78b-614f-4e12-b327-bf42abe49e49.png).

SimpleImage supports "gif", "jpg", "jpeg", "png", "webp", and "bmp" formats (also "jfif" which is just another jpg variant). We also have a way to handle svg file previews.

As such, I am validating whether an image is embeddable vs these extensions, and I've changed the structure of the preview generation in `manage-files.php` and `template.php` to generate the graceful `/thumbnail-unavailable.png`
![lm09Kcbnie](https://user-images.githubusercontent.com/81652082/146603655-3369b567-eb09-4862-b68b-c9879c38933b.png) 
![image](https://user-images.githubusercontent.com/81652082/146604419-56fb5307-7767-4073-acb3-aeb40c2011e3.png)

Alternatively, we could keep isImage filtering by mimetype and then have an exception from SimpleImage's failure to generate a thumbnail trigger `thumbnail-unavailable`. This is probably the cleaner way but I don't have time :)
