### PR TITLE
Validate image files vs simpleimage (and svg)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,8 @@ Thumbs.db
 # Test results
 test-results
 
+# VSCode config files
+.vscode
+
 # Misc
 .idea/

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "paragonie/random_compat": "^2.0",
         "phpmailer/phpmailer": "~6.1",
 		"tamtamchik/simple-flash": "^1.2",
-		"hybridauth/hybridauth": "^3.0"
+		"hybridauth/hybridauth": "^3.0",
+        "dmhendricks/file-icon-vectors": "^1.0"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "paragonie/random_compat": "^2.0",
         "phpmailer/phpmailer": "~6.1",
 		"tamtamchik/simple-flash": "^1.2",
-		"hybridauth/hybridauth": "^3.0",
-        "dmhendricks/file-icon-vectors": "^1.0"
+		"hybridauth/hybridauth": "^3.0"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6eba239b6b138c2c64db029d58a1bc8b",
+    "content-hash": "b0d5fd8f5176c50af221961092f4211c",
     "packages": [
         {
             "name": "claviska/simpleimage",
-            "version": "3.5.1",
+            "version": "3.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/claviska/SimpleImage.git",
-                "reference": "ab2ab8a4672738ab77b39b00922ee4e79aeadb11"
+                "reference": "00f90662686696b9b7157dbb176183aabe89700f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/claviska/SimpleImage/zipball/ab2ab8a4672738ab77b39b00922ee4e79aeadb11",
-                "reference": "ab2ab8a4672738ab77b39b00922ee4e79aeadb11",
+                "url": "https://api.github.com/repos/claviska/SimpleImage/zipball/00f90662686696b9b7157dbb176183aabe89700f",
+                "reference": "00f90662686696b9b7157dbb176183aabe89700f",
                 "shasum": ""
             },
             "require": {
@@ -43,13 +43,65 @@
                 }
             ],
             "description": "A PHP class that makes working with images as simple as possible.",
+            "support": {
+                "issues": "https://github.com/claviska/SimpleImage/issues",
+                "source": "https://github.com/claviska/SimpleImage/tree/3.6.5"
+            },
             "funding": [
                 {
                     "url": "https://github.com/claviska",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-30T20:47:26+00:00"
+            "time": "2021-12-01T12:42:55+00:00"
+        },
+        {
+            "name": "dmhendricks/file-icon-vectors",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dmhendricks/file-icon-vectors.git",
+                "reference": "3db48be71c19332dec85c0cae863f8f44ccdf855"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dmhendricks/file-icon-vectors/zipball/3db48be71c19332dec85c0cae863f8f44ccdf855",
+                "reference": "3db48be71c19332dec85c0cae863f8f44ccdf855",
+                "shasum": ""
+            },
+            "type": "component",
+            "extra": {
+                "component": {
+                    "name": "file-icon-vectors",
+                    "files": [
+                        "css/**",
+                        "icons/**"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel M. Hendricks",
+                    "homepage": "https://danhendricks.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A collection of file type icons in SVG format.",
+            "keywords": [
+                "css",
+                "file",
+                "icon",
+                "svg"
+            ],
+            "support": {
+                "issues": "https://github.com/dmhendricks/dmhendricks/file-icon-vectors",
+                "source": "https://github.com/dmhendricks/file-icon-vectors/tree/master"
+            },
+            "time": "2018-08-05T20:19:58+00:00"
         },
         {
             "name": "enshrined/svg-sanitize",
@@ -90,80 +142,36 @@
                 }
             ],
             "description": "An SVG sanitizer for PHP",
+            "support": {
+                "issues": "https://github.com/darylldoyle/svg-sanitizer/issues",
+                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/develop"
+            },
             "time": "2020-01-20T01:34:17+00:00"
         },
         {
-            "name": "firebase/php-jwt",
-            "version": "v5.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "feb0e820b8436873675fd3aca04f3728eb2185cb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/feb0e820b8436873675fd3aca04f3728eb2185cb",
-                "reference": "feb0e820b8436873675fd3aca04f3728eb2185cb",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": ">=4.8 <=9"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Firebase\\JWT\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Neuman Vong",
-                    "email": "neuman+pear@twilio.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Anant Narayanan",
-                    "email": "anant@php.net",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
-            "homepage": "https://github.com/firebase/php-jwt",
-            "keywords": [
-                "jwt",
-                "php"
-            ],
-            "time": "2020-03-25T18:49:23+00:00"
-        },
-        {
             "name": "hybridauth/hybridauth",
-            "version": "3.6.0",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hybridauth/hybridauth.git",
-                "reference": "222ab4e6ee6ffd81caa77283142f3aa97afa5863"
+                "reference": "0ec1b8cb8b230aae739422c5e42bc5733b3a7316"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hybridauth/hybridauth/zipball/222ab4e6ee6ffd81caa77283142f3aa97afa5863",
-                "reference": "222ab4e6ee6ffd81caa77283142f3aa97afa5863",
+                "url": "https://api.github.com/repos/hybridauth/hybridauth/zipball/0ec1b8cb8b230aae739422c5e42bc5733b3a7316",
+                "reference": "0ec1b8cb8b230aae739422c5e42bc5733b3a7316",
                 "shasum": ""
             },
             "require": {
-                "firebase/php-jwt": "*",
-                "php": ">=5.4.0",
-                "phpseclib/phpseclib": "~2.0"
+                "php": "^5.4 || ^7.0 || ^8.0"
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.8.35 || ^6.5 || ^8"
+                "phpunit/phpunit": "^4.8.35 || ^6.5 || ^8.0"
+            },
+            "suggest": {
+                "firebase/php-jwt": "Needed to support Apple provider",
+                "phpseclib/phpseclib": "Needed to support Apple provider"
             },
             "type": "library",
             "autoload": {
@@ -195,7 +203,12 @@
                 "social",
                 "twitter"
             ],
-            "time": "2020-10-21T16:32:08+00:00"
+            "support": {
+                "gitter": "https://gitter.im/hybridauth/hybridauth",
+                "issues": "https://github.com/hybridauth/hybridauth/issues",
+                "source": "https://github.com/hybridauth/hybridauth/tree/3.7.1"
+            },
+            "time": "2021-03-13T17:35:33+00:00"
         },
         {
             "name": "league/color-extractor",
@@ -249,6 +262,10 @@
                 "image",
                 "palette"
             ],
+            "support": {
+                "issues": "https://github.com/thephpleague/color-extractor/issues",
+                "source": "https://github.com/thephpleague/color-extractor/tree/master"
+            },
             "time": "2016-12-15T09:30:02+00:00"
         },
         {
@@ -285,20 +302,24 @@
                 "multi-runtime",
                 "plupload"
             ],
+            "support": {
+                "issues": "https://github.com/moxiecode/plupload/issues",
+                "source": "https://github.com/moxiecode/plupload/tree/v3.1.2"
+            },
             "time": "2018-02-20T06:20:41+00:00"
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.19",
+            "version": "v2.0.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "446fc9faa5c2a9ddf65eb7121c0af7e857295241"
+                "reference": "0f1f60250fccffeaf5dda91eea1c018aed1adc2a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/446fc9faa5c2a9ddf65eb7121c0af7e857295241",
-                "reference": "446fc9faa5c2a9ddf65eb7121c0af7e857295241",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/0f1f60250fccffeaf5dda91eea1c018aed1adc2a",
+                "reference": "0f1f60250fccffeaf5dda91eea1c018aed1adc2a",
                 "shasum": ""
             },
             "require": {
@@ -334,20 +355,25 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2020-10-15T10:06:57+00:00"
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
+            "time": "2021-04-17T09:33:01+00:00"
         },
         {
             "name": "phpmailer/phpmailer",
-            "version": "v6.5.0",
+            "version": "v6.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPMailer/PHPMailer.git",
-                "reference": "a5b5c43e50b7fba655f793ad27303cd74c57363c"
+                "reference": "baeb7cde6b60b1286912690ab0693c7789a31e71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/a5b5c43e50b7fba655f793ad27303cd74c57363c",
-                "reference": "a5b5c43e50b7fba655f793ad27303cd74c57363c",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/baeb7cde6b60b1286912690ab0693c7789a31e71",
+                "reference": "baeb7cde6b60b1286912690ab0693c7789a31e71",
                 "shasum": ""
             },
             "require": {
@@ -359,10 +385,12 @@
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
                 "doctrine/annotations": "^1.2",
+                "php-parallel-lint/php-console-highlighter": "^0.5.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
                 "phpcompatibility/php-compatibility": "^9.3.5",
                 "roave/security-advisories": "dev-latest",
-                "squizlabs/php_codesniffer": "^3.5.6",
-                "yoast/phpunit-polyfills": "^0.2.0"
+                "squizlabs/php_codesniffer": "^3.6.0",
+                "yoast/phpunit-polyfills": "^1.0.0"
             },
             "suggest": {
                 "ext-mbstring": "Needed to send email in multibyte encoding charset or decode encoded addresses",
@@ -400,118 +428,17 @@
                 }
             ],
             "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
+            "support": {
+                "issues": "https://github.com/PHPMailer/PHPMailer/issues",
+                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.5.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/Synchro",
                     "type": "github"
                 }
             ],
-            "time": "2021-06-16T14:33:43+00:00"
-        },
-        {
-            "name": "phpseclib/phpseclib",
-            "version": "2.0.32",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "f5c4c19880d45d0be3e7d24ae8ac434844a898cd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/f5c4c19880d45d0be3e7d24ae8ac434844a898cd",
-                "reference": "f5c4c19880d45d0be3e7d24ae8ac434844a898cd",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phing/phing": "~2.7",
-                "phpunit/phpunit": "^4.8.35|^5.7|^6.0|^9.4",
-                "squizlabs/php_codesniffer": "~2.0"
-            },
-            "suggest": {
-                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
-                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
-                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
-                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "phpseclib/bootstrap.php"
-                ],
-                "psr-4": {
-                    "phpseclib\\": "phpseclib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jim Wigginton",
-                    "email": "terrafrost@php.net",
-                    "role": "Lead Developer"
-                },
-                {
-                    "name": "Patrick Monnerat",
-                    "email": "pm@datasphere.ch",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Andreas Fischer",
-                    "email": "bantu@phpbb.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Hans-Jürgen Petrich",
-                    "email": "petrich@tronic-media.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Graham Campbell",
-                    "email": "graham@alt-three.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
-            "homepage": "http://phpseclib.sourceforge.net",
-            "keywords": [
-                "BigInteger",
-                "aes",
-                "asn.1",
-                "asn1",
-                "blowfish",
-                "crypto",
-                "cryptography",
-                "encryption",
-                "rsa",
-                "security",
-                "sftp",
-                "signature",
-                "signing",
-                "ssh",
-                "twofish",
-                "x.509",
-                "x509"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/terrafrost",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/phpseclib",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-06-12T12:12:59+00:00"
+            "time": "2021-11-25T16:34:11+00:00"
         },
         {
             "name": "tamtamchik/simple-flash",
@@ -570,6 +497,10 @@
                 "messages",
                 "notifications"
             ],
+            "support": {
+                "issues": "https://github.com/tamtamchik/simple-flash/issues",
+                "source": "https://github.com/tamtamchik/simple-flash/tree/master"
+            },
             "time": "2018-09-04T13:47:00+00:00"
         }
     ],
@@ -583,5 +514,5 @@
         "php": ">=7.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/includes/Classes/Files.php
+++ b/includes/Classes/Files.php
@@ -257,7 +257,7 @@ class Files
         }
 
         // Image
-        $embeddable = ["gif", "jpeg", "jfif", "png", "webp", "bmp", "svg"];
+        $embeddable = ["gif", "jpg", "jpeg", "jfif", "png", "webp", "bmp", "svg"];
         if (isImage($this->full_path) && in_array($this->extension, $embeddable)) {
             $this->embeddable = true;
             $this->embeddable_type = 'image';

--- a/includes/Classes/Files.php
+++ b/includes/Classes/Files.php
@@ -98,7 +98,7 @@ class Files
     }
 
     /**
-     * Set the properties when saving to the database (data comnes from the form)
+     * Set the properties when saving to the database (data comes from the form)
      */
     public function set($arguments = [])
     {
@@ -256,7 +256,9 @@ class Files
             return null;
         }
 
-        if ($this->isImage()) {
+        // Image
+        $embeddable = ["gif", "jpeg", "jfif", "png", "webp", "bmp", "svg"];
+        if (isImage($this->full_path) && in_array($this->extension, $embeddable)) {
             $this->embeddable = true;
             $this->embeddable_type = 'image';
         }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1542,7 +1542,7 @@ function option_file_upload( $file, $validate_ext = '', $option = '', $action = 
 	if ( !empty( $validate_ext ) ) {
 		switch ( $validate_ext ) {
 			case 'image':
-				$validate_types = "/^\.(jpg|jpeg|gif|png){1}$/i";
+				$validate_types = "/^\.(jpg|jfif|jpeg|gif|png){1}$/i";
 				break;
 			default:
 				break;

--- a/manage-files.php
+++ b/manage-files.php
@@ -637,7 +637,11 @@ include_once ADMIN_VIEWS_DIR . DS . 'header.php';
                                 $preview_cell = '<button class="btn btn-warning btn-sm btn-wide get-preview" data-url="'.BASE_URI.'process.php?do=get_preview&file_id='.$file->id.'">'.__('Preview', 'cftp_admin').'</button>';
                             }
                             if ( file_is_image( $file->full_path ) ) {
-                                $thumbnail = make_thumbnail( $file->full_path, null, 50, 50 );
+                                if ($file->embeddable) {
+                                    $thumbnail = make_thumbnail( $file->full_path, null, 50, 50 );
+                                } else {
+                                    $thumbnail = make_thumbnail( "", null, 50, 50 );
+                                }
                                 if ( !empty( $thumbnail['thumbnail']['url'] ) ) {
                                     $preview_cell = '<a href="#" class="get-preview" data-url="'.BASE_URI.'process.php?do=get_preview&file_id='.$file->id.'">
                                         <img src="' . $thumbnail['thumbnail']['url'] . '" class="thumbnail" />

--- a/templates/default/template.php
+++ b/templates/default/template.php
@@ -218,7 +218,12 @@ define('TEMPLATE_THUMBNAILS_HEIGHT', '50');
                                 $preview_cell = '';
                                 if ( $file->expired == false) {
                                     if ( $file->isImage() ) {
-                                        $thumbnail = make_thumbnail( $file->full_path, null, TEMPLATE_THUMBNAILS_WIDTH, TEMPLATE_THUMBNAILS_HEIGHT );
+                                        if ($file->embeddable) {
+                                            $thumbnail = make_thumbnail( $file->full_path, null, TEMPLATE_THUMBNAILS_WIDTH, TEMPLATE_THUMBNAILS_HEIGHT );
+                                        } else {
+                                            $thumbnail = make_thumbnail( "", null, TEMPLATE_THUMBNAILS_WIDTH, TEMPLATE_THUMBNAILS_HEIGHT );
+                                        }
+                                        
                                         if ( !empty( $thumbnail['thumbnail']['url'] ) ) {
                                             $preview_cell = '
                                                 <a href="#" class="get-preview" data-url="'.BASE_URI.'process.php?do=get_preview&file_id='.$file->id.'">

--- a/upload/files/.htaccess
+++ b/upload/files/.htaccess
@@ -3,7 +3,7 @@ Options -Indexes
 <FilesMatch "\.(html|htm|asp|js|ico|swp)$">
     Order Deny,Allow
     Deny from all
-</Files>
+</FilesMatch>
 
 <Files *.php>
     Order Deny,Allow


### PR DESCRIPTION
Closes #1048 

Currently, if a file returns TRUE for isImage() (which checks vs mimetype), but isn't supported by SimpleImage, we get a broken link
![CUPjBteTCt](https://user-images.githubusercontent.com/81652082/146601104-4113b78b-614f-4e12-b327-bf42abe49e49.png).

SimpleImage supports "gif", "jpg", "jpeg", "png", "webp", and "bmp" formats (also "jfif" which is just another jpg variant). We also have a way to handle svg file previews.

As such, I am validating whether an image is embeddable vs these extensions, and I've changed the structure of the preview generation in `manage-files.php` and `template.php` to generate the graceful `/thumbnail-unavailable.png`
![lm09Kcbnie](https://user-images.githubusercontent.com/81652082/146603655-3369b567-eb09-4862-b68b-c9879c38933b.png) 
![image](https://user-images.githubusercontent.com/81652082/146604419-56fb5307-7767-4073-acb3-aeb40c2011e3.png)

Ultimately I'd like to keep isImage() filtering by mimetype and then have an exception from SimpleImage's failure to generate a thumbnail fail us over into a matching icon from [danhendricks' file-icon-vectors](https://github.com/dmhendricks/file-icon-vectors/). 

However, I'm having trouble figuring out how to get Composer to download the package. What calls it and when? Putting it in `composer.json` hasn't worked.

```php
"require": {
    "php": ">=7.0",
    "claviska/simpleimage": "~3",
    "enshrined/svg-sanitize": "^0.13",
    "moxiecode/plupload": "3.1.2",
    "paragonie/random_compat": "^2.0",
    "phpmailer/phpmailer": "~6.1",
    "tamtamchik/simple-flash": "^1.2",
    "hybridauth/hybridauth": "^3.0",
    "dmhendricks/file-icon-vectors": "^1.0"
}
```
What am I missing?