### PR TITLE
Encrypt Email and Address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ Thumbs.db
 
 # macOS
 .DS_Store
+._.DS_Store
+._README.md
 
 # VSCode Files
 .vscode
@@ -63,3 +65,8 @@ test-results
 
 # Misc
 .idea/
+tmp/*
+*.orig
+*.rej
+._*
+*.diff

--- a/ENCRYPTION.md
+++ b/ENCRYPTION.md
@@ -1,0 +1,42 @@
+# Encryption added
+For security reasons there has been added encryption and decryption for email and address data.
+
+## Config File Modifications
+In the configuration file a new **DEFINE** is introduced to control if encryption is used.
+
+```
+define('ENCRYPT_PI', True||False);
+```
+
+## Database Modifications
+
+As the length of the encrypted email is much longer than the varchar defined in the database there must be a column change:
+
+```
+alter table tbl_users modify column email text NOT NULL;
+```
+
+## Encryption Keys
+For this purpose encryption keys need to be defined and added to the application either as a separate include or within **sys.config.php**.
+Example of encryption keys:
+
+```
+define(('FIRSTKEY','sK7qcOKwDP20oA8GP0goV9UwIjMCUWFPAf6lHMSUUjU=');
+define(('SECONDKEY','OqKx6DYPxAh6wWa+ohhUDFmHCncSDJLmo+szbJafhkz/589tfY59zDeWvoI69lOm4lhQRmrV+MRii1L3+3eV6w==');
+```
+
+These keys can be generated with the script **create_encryption_keys.php** in the install directory.
+
+The output of this script is in form of a php include:
+
+```
+<?php
+define('FIRSTKEY','sK7qcOKwDP20oA8GP0goV9UwIjMCUWFPAf6lHMSUUjU=');
+define('SECONDKEY','OqKx6DYPxAh6wWa+ohhUDFmHCncSDJLmo+szbJafhkz/589tfY59zDeWvoI69lOm4lhQRmrV+MRii1L3+3eV6w==');
+?>
+```
+
+The user can decide if he adds the **define** statements themself to the end of the **sys.config.php** file or
+creates a separate file which is included in the application.
+
+More sophisticated solutions get the encryption keys from an external api.

--- a/clients-requests.php
+++ b/clients-requests.php
@@ -437,7 +437,7 @@ include_once ADMIN_VIEWS_DIR . DS . 'header.php';
                                                             'content'		=> html_output( $row["user"] ),
                                                         ),
                                                     array(
-                                                            'content'		=> html_output( $row["email"] ),
+                                                            'content'		=> ENCRYPT_PI ? decrypt_output( $row['email'] ) : html_output( llll$row['email'] ),
                                                         ),
                                                     array(
                                                             'content'		=> $account_request,
@@ -477,4 +477,4 @@ include_once ADMIN_VIEWS_DIR . DS . 'header.php';
     </div>
 </div>
 <?php
-    include_once ADMIN_VIEWS_DIR . DS . 'footer.php';
+    include_once ADMIN_VIEWS_DIR . DS . 'footer.php‘;

--- a/includes/Classes/Auth.php
+++ b/includes/Classes/Auth.php
@@ -59,11 +59,18 @@ class Auth
             return false;
 
 		/** Look up the system users table to see if the entered username exists */
-		$statement = $this->dbh->prepare("SELECT * FROM " . TABLE_USERS . " WHERE user=:username OR email=:email");
-		$statement->execute([
+                if ( ENCRYPT_PI ) {
+		  $statement = $this->dbh->prepare("SELECT * FROM " . TABLE_USERS . " WHERE user=:username");
+		  $statement->execute([
+            ':username' => $username
+        ]);
+                } else {
+		  $statement = $this->dbh->prepare("SELECT * FROM " . TABLE_USERS . " WHERE user=:username OR email=:email");
+		  $statement->execute([
             ':username' => $username,
             ':email' => $username,
         ]);
+                }
 		$count_user = $statement->rowCount();
 		if ($count_user > 0) {
 			/** If the username was found on the users table */

--- a/includes/forms/login.php
+++ b/includes/forms/login.php
@@ -12,7 +12,7 @@
     <input type="hidden" name="do" value="login">
     <fieldset>
         <div class="form-group">
-            <label for="username"><?php _e('Username','cftp_admin'); ?> / <?php _e('E-mail','cftp_admin'); ?></label>
+            <label for="username"><?php _e('Username','cftp_admin'); if ( ! ENCRYPT_PI ) { echo " / "; _e('E-mail','cftp_admin'); } ?></label>
             <input type="text" name="username" id="username" value="<?php if (isset($sysuser_username)) { echo htmlspecialchars($sysuser_username); } ?>" class="form-control" autofocus />
         </div>
 
@@ -46,8 +46,6 @@
                 ?>
             </select>
         </div>
-
-        <?php recaptcha2RenderWidget(); ?>
 
         <div class="inside_form_buttons">
             <button type="submit" id="btn_submit" class="btn btn-wide btn-primary" data-text="<?php echo $json_strings['login']['button_text']; ?>" data-loading-text="<?php echo $json_strings['login']['logging_in']; ?>"><?php echo $json_strings['login']['button_text']; ?></button>

--- a/includes/sys.config.sample.php
+++ b/includes/sys.config.sample.php
@@ -81,3 +81,15 @@ define('MAX_FILESIZE',2048);
  * Encoding to use on the e-mails sent to new clients, users, files, etc.
  */
 define('EMAIL_ENCODING', 'utf-8');
+
+/**
+ * Define encryption of personal identifiable data (PI Data)
+ * if "ENCRYPT_PI" is True you need to add the relevant keys as well.
+ * As an Example:
+ *    define('FIRSTKEY','..................................................................');
+ *    define('SECONDKEY','...................................');
+ * These can be created with the script in the install subdirectory install/create_encryption_keys.php.
+ * 
+ */
+define('ENCRYPT_PI', False);
+

--- a/install/create_encryption_keys.php
+++ b/install/create_encryption_keys.php
@@ -1,0 +1,7 @@
+<?php
+// Create The First Key
+echo "<?php\ndefine('FIRSTKEY','" . base64_encode(openssl_random_pseudo_bytes(32)) . "');\n";
+
+// Create The Second Key
+echo "define('SECONDKEY','" . base64_encode(openssl_random_pseudo_bytes(64)) . "');\n?>\n";
+?>

--- a/install/database.php
+++ b/install/database.php
@@ -20,7 +20,7 @@ if (defined('TRY_INSTALL')) {
                           `user` varchar('.MAX_USER_CHARS.') NOT NULL,
                           `password` varchar('.MAX_PASS_CHARS.') NOT NULL,
                           `name` text NOT NULL,
-                          `email` varchar(60) NOT NULL,
+                          `email` text NOT NULL,
                           `level` tinyint(1) NOT NULL DEFAULT \'0\',
                           `address` text COLLATE utf8_general_ci NULL,
                           `phone` varchar(32) COLLATE utf8_general_ci NULL,


### PR DESCRIPTION
In Europe there is the aim to secure personal identifiable data and to prevent data loss.
Therefore in special situations it is preferable NOT to save plaintext email or address data in the database tables.
There was a goal to encrypt and decrypt the email address and the postal address (I omitted the phone number in this phase) while saving or retrieving the data to/from the database.

I added a new DEFINE to switch the behaviour.
As encryption/decryption is activated there are some other things done.

- disable unique email checking (encrypted emails in the database are never unique)
- disable login via email, only allow username
- change the database column type to text to allow the length of an encrypted email
- add an ENCRYPTION.md
- add a script to generate encryption keys

The encryption keys should be included from a "secured" place, probably not sys.config.php

