### PR TITLE
Filter out null (good) errors before evaluating.

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -169,7 +169,8 @@ include_once '../header-unlogged.php';
                     
                                     $other_errors[] = update_chmod_emails();
                                     $other_errors[] = chmod_main_files();
-
+                                    $other_errors = array_filter($other_errors);
+                                    
                                     /** Record the action log */
                                     $logger = new \ProjectSend\Classes\ActionsLog;
                                     $new_record_action = $logger->addEntry([


### PR DESCRIPTION
Filter out null (good) errors before evaluating.  Fixes #1075 wherein a success of both functions (both returning null) still triggers that errors were encountered.