### PR TITLE
Category edit: Control parent value

### DIFF
--- a/includes/Classes/Categories.php
+++ b/includes/Classes/Categories.php
@@ -206,10 +206,21 @@ class Categories
       if($this->id == $this->parent)
         return false;
       else{
-          //TODO: Check if the parent is not a child of the current category id
+          //Check if the parent is not a child of the current category id
+          $category_parent_query = "select id, parent from ".TABLE_CATEGORIES;
+          $category_parent_query_statment = $this->dbh->prepare($category_parent_query);
+          $category_parent_query_statment->execute();
+
+          $array_category_parent = $category_parent_query_statment->fetchAll(PDO::FETCH_KEY_PAIR);
+
+          $point = $this->parent;
+          while($array_category_parent[$point]!=null){
+            if($array_category_parent[$point]==$this->id)
+              return false;
+            $point = $point->parent;
+          }
 
       }
-
       return true;
     }
 
@@ -224,13 +235,13 @@ class Categories
 
         $this->state = array();
 
-        $queryUpdateParent = "";
+        $query_update_parent = "";
         if($this->parent == '0' || $this->checkParentValidation() )
-          $queryUpdateParent = "parent = :parent,";
+          $query_update_parent = "parent = :parent,";
         /** SQL query */
         $this->edit_category_query = "UPDATE " . TABLE_CATEGORIES . " SET
                                     name = :name,
-                                    ".$queryUpdateParent."
+                                    ".$query_update_parent."
                                     description = :description
                                     WHERE id = :id
                                     ";
@@ -243,7 +254,7 @@ class Categories
             $this->statement->bindValue(':parent', $this->parent, PDO::PARAM_NULL);
         }
         else
-          if($queryUpdateParent!=""){
+          if($query_update_parent!=""){
             $this->statement->bindValue(':parent', $this->parent, PDO::PARAM_INT);
           }
         $this->statement->bindParam(':description', $this->description);

--- a/includes/Classes/Categories.php
+++ b/includes/Classes/Categories.php
@@ -87,7 +87,7 @@ class Categories
         if ($this->statement->rowCount() == 0) {
             return false;
         }
-    
+
         while ($this->row = $this->statement->fetch() ) {
             $this->name = html_output($this->row['name']);
             $this->parent = html_output($this->row['parent']);
@@ -111,7 +111,7 @@ class Categories
 
         return $return;
     }
- 
+
 	/**
 	 * Validate the information from the form.
 	 */
@@ -166,7 +166,7 @@ class Categories
         $this->statement = $this->dbh->prepare("INSERT INTO " . TABLE_CATEGORIES . " (name,parent,description,created_by)"
                                             ."VALUES (:name, :parent, :description, :created_by)");
         $this->statement->bindParam(':name', $this->name);
-        
+
         if (empty($this->parent)) {
             $this->parent = 0;
             $this->statement->bindValue(':parent', $this->parent, PDO::PARAM_NULL);
@@ -174,7 +174,7 @@ class Categories
         else {
             $this->statement->bindValue(':parent', $this->parent, PDO::PARAM_INT);
         }
-        
+
         $this->statement->bindParam(':description', $this->description);
         $this->statement->bindParam(':created_by', $this->created_by);
 
@@ -201,6 +201,18 @@ class Categories
         return $this->state;
     }
 
+    private function checkParentValidation()
+    {
+      if($this->id == $this->parent)
+        return false;
+      else{
+          //TODO: Check if the parent is not a child of the current category id
+
+      }
+
+      return true;
+    }
+
 	/**
 	 * Edit an existing user.
 	 */
@@ -211,11 +223,14 @@ class Categories
         }
 
         $this->state = array();
- 
+
+        $queryUpdateParent = "";
+        if($this->parent == '0' || $this->checkParentValidation() )
+          $queryUpdateParent = "parent = :parent,";
         /** SQL query */
-        $this->edit_category_query = "UPDATE " . TABLE_CATEGORIES . " SET 
+        $this->edit_category_query = "UPDATE " . TABLE_CATEGORIES . " SET
                                     name = :name,
-                                    parent = :parent,
+                                    ".$queryUpdateParent."
                                     description = :description
                                     WHERE id = :id
                                     ";
@@ -227,9 +242,10 @@ class Categories
             $this->parent == null;
             $this->statement->bindValue(':parent', $this->parent, PDO::PARAM_NULL);
         }
-        else {
+        else
+          if($queryUpdateParent!=""){
             $this->statement->bindValue(':parent', $this->parent, PDO::PARAM_INT);
-        }
+          }
         $this->statement->bindParam(':description', $this->description);
         $this->statement->bindParam(':id', $this->id, PDO::PARAM_INT);
 
@@ -268,7 +284,7 @@ class Categories
             $this->sql = $this->dbh->prepare('DELETE FROM ' . TABLE_CATEGORIES . ' WHERE id=:id');
             $this->sql->bindParam(':id', $this->id, PDO::PARAM_INT);
             $this->sql->execute();
-            
+
             /** Record the action log */
             $record = $this->logger->addEntry([
                 'action' => 36,


### PR DESCRIPTION
Hi,
I saw that when you edit a category, you can set whatever value and it's accept, but create a circular problem.

To avoid this problem, I check in edit function the value, if it's ok it add to update query the part of the parent, otherwise it bypass that part.