### PR TITLE
Update functions.php

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1104,7 +1104,10 @@ function get_real_size($file)
         elseif (PHP_OS == 'Darwin') {
             $ff = trim(shell_exec("stat -L -f %z " . escapeshellarg($file)));
         }
-        elseif ((PHP_OS == 'Linux') || (PHP_OS == 'FreeBSD') || (PHP_OS == 'Unix') || (PHP_OS == 'SunOS')) {
+        elseif (PHP_OS == 'FreeBSD') {
+            $ff = trim(shell_exec("stat -L -f%z " . escapeshellarg($file)));
+        }
+        elseif ((PHP_OS == 'Linux') || (PHP_OS == 'Unix') || (PHP_OS == 'SunOS')) {
             $ff = trim(shell_exec("stat -L -c%s " . escapeshellarg($file)));
         }
     }


### PR DESCRIPTION
Fix for https://github.com/projectsend/projectsend/issues/1105

The cronjob was giving errors on FreeBSD due to a difference in options in the 'stat' command. Separated the FreeBSD stat section from the generic linux one and changed the options according to the manpage https://www.unix.com/man-page/FreeBSD/1/stat/