### PR TITLE
Show Manage files only when user has option

### DIFF
--- a/includes/layout/main-menu.php
+++ b/includes/layout/main-menu.php
@@ -295,15 +295,17 @@ else {
         );
     }
 
-    $items['manage_files'] = array(
-        'nav' => 'manage',
-        'level' => array(9, 8, 7, 0),
-        'main' => array(
-            'label' => __('Manage files', 'cftp_admin'),
-            'link' => 'manage-files.php',
-            'icon' => 'file',
-        ),
-    );
+    if (get_option('clients_can_upload') == 1 || get_option('clients_can_delete_own_files') == 1 || get_option('clients_can_set_expiration_date') == 1 || get_option('clients_can_set_public') == 1) {
+        $items['manage_files'] = array(
+            'nav' => 'manage',
+            'level' => array(9, 8, 7, 0),
+            'main' => array(
+                'label' => __('Manage files', 'cftp_admin'),
+                'link' => 'manage-files.php',
+                'icon' => 'file',
+            ),
+        );
+    }
 
     $items['view_files'] = array(
         'nav' => 'template',


### PR DESCRIPTION
Client with read only access should have only View my files option enabled in the menu, I saw there are different options for clients which relate to files so I listed all of them.

Fixes #1078 if I understood the comment