### PR TITLE
Add support for Env vars for SMTP Configuration.

### DIFF
--- a/includes/Classes/Emails.php
+++ b/includes/Classes/Emails.php
@@ -1074,13 +1074,13 @@ class Emails
                 };
             }
 
-            switch (get_option('mail_system_use')) {
+            switch ($_ENV['MAIL_SYSTEM_USE'] ?? get_option('mail_system_use')) {
                 case 'smtp':
                     $email->IsSMTP();
-                    $email->Host = get_option('mail_smtp_host');
-                    $email->Port = get_option('mail_smtp_port');
-                    $email->Username = get_option('mail_smtp_user');
-                    $email->Password = get_option('mail_smtp_pass');
+                    $email->Host = $_ENV['MAIL_SMTP_HOST'] ?? get_option('mail_smtp_host');
+                    $email->Port = $_ENV['MAIL_SMTP_PORT'] ?? get_option('mail_smtp_port');
+                    $email->Username = $_ENV['MAIL_SMTP_USER'] ?? get_option('mail_smtp_user');
+                    $email->Password = $_ENV['MAIL_SMTP_PASS'] ?? get_option('mail_smtp_pass');
 
                     if (get_option('mail_smtp_auth') != 'none') {
                         $email->SMTPAuth = true;

--- a/includes/forms/options/email.php
+++ b/includes/forms/options/email.php
@@ -106,6 +106,12 @@
 <div class="form-group row">
     <label for="mail_system_use" class="col-sm-4 control-label"><?php _e('Mailer','cftp_admin'); ?></label>
     <div class="col-sm-8">
+      <?php if ($_ENV['MAIL_SYSTEM_USE'] || $_ENV['MAIL_SMTP_HOST'])
+        echo '
+            <div class="alert alert-warning" role="alert">
+              Settings overwritten by enviroment variables.
+            </div>';
+      ?>
         <select class="form-select" name="mail_system_use" id="mail_system_use" required>
             <option value="mail" <?php echo (get_option('mail_system_use') == 'mail') ? 'selected="selected"' : ''; ?>>PHP Mail (basic)</option>
             <option value="smtp" <?php echo (get_option('mail_system_use') == 'smtp') ? 'selected="selected"' : ''; ?>>SMTP</option>


### PR DESCRIPTION
Logic to allow environment variables to overwrite SMTP options. 

 When using local docker development it removes extra configuration steps. 

using https://github.com/redondi88/projectsend-docker for containerized development. 

