### PR TITLE
deprecated creation of dynamic property

### DIFF
--- a/includes/Classes/Layout/Table.php
+++ b/includes/Classes/Layout/Table.php
@@ -7,6 +7,16 @@ namespace ProjectSend\Classes\Layout;
 
 class Table
 {
+    private $output;
+    private $contents;
+    private $current_row;
+    private $origin;
+    private $row_class;
+    private $attributes;
+    private $content;
+    private $is_checkbox;
+    private $value;
+
     function __construct($attributes)
     {
         $this->contents = $this->open($attributes);


### PR DESCRIPTION
The properties in the Table Class below the __construct function, such as contents property, current_row property, output property and so on, give a deprecated warning by PHP. Deprecated: Creation of dynamic property ProjectSend\Classes\Layout\Table::$output is deprecated. This is a fix by declaring them private in the Class.