### PR TITLE
Fix double "x" in close preview modal button

### DIFF
--- a/assets/src/js/parts/file_preview_modal.js
+++ b/assets/src/js/parts/file_preview_modal.js
@@ -10,7 +10,7 @@
                     <div class="modal-content">
                         <div class="modal-header">
                             <h5 class="modal-title"></h5>
-                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">×</button>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                         </div>
                         <div class="modal-body">
                         </div>


### PR DESCRIPTION
Thank you for this great project!

The close button on the preview modal currently has two `X`'s on top of each other. [Bootstrap 5 modals](https://getbootstrap.com/docs/5.3/components/modal/#dismiss) provide the `X` as a properly sized SVG via the CSS `background` property so the `'x'` text within the HTML `<button>` is not needed.

### Before:

![project-send-screenshot-modal-duplicate-x-close-btn](https://github.com/projectsend/projectsend/assets/16749343/38bac948-f7b8-4553-8c6c-3641c8fdbe71)

### After:

![project-send-screenshot-modal-duplicate-x-close-btn-after-fix](https://github.com/projectsend/projectsend/assets/16749343/a57b8dc0-e200-4ff8-b119-7207d31af16b)

I did a search in this repo's issues and found that this was reported once in #1225 but there is also an unrelated issue reported in that one so I didn't want to automatically close it with this PR.  At least mentioning it here will link this PR to that issue.