### PR TITLE
Fix URL in manage-downloads.php - custom_downloads.php

### DIFF
--- a/manage-downloads.php
+++ b/manage-downloads.php
@@ -451,7 +451,7 @@ include_once LAYOUT_DIR . DS . 'search-filters-bar.php';
                         }
 
                         $custom_download_uri = get_option('custom_download_uri');
-                        if (!$custom_download_uri) $custom_download_uri = 'custom_downloads.php?link=';
+                        if (!$custom_download_uri) $custom_download_uri = 'custom-download.php?link=';
                         $custom_download_link = $custom_download_uri . $custom_download->link;
 
                         $title_content = '<a href="' . $custom_download_link . '" target="_blank">' . $custom_download->link . '</a>';


### PR DESCRIPTION
I encountered an issue when assigning a custom download alias. Clicking the generated link results in a 404 error. Upon investigation, it appears that the link references a file named custom_downloads.php, but the correct file is named custom-download.php. Manually correcting the URL resolves the issue, and the download functions as expected.