### PR TITLE
Fixes issue preventing underscore in username

### DIFF
--- a/includes/Classes/Validation.php
+++ b/includes/Classes/Validation.php
@@ -91,7 +91,7 @@ class Validation
 
     private function alpha_underscores($value)
     {
-        return (preg_match('/[^0-9A-Za-z.]/', $value) != true);
+        return (preg_match('/[^0-9A-Za-z._]/', $value) != true);
     }
 
     private function password($value)


### PR DESCRIPTION
Resolves #1378 by adding back the underscore to the alpha_underscores regex. Usernames with an underscore now validate properly.