### PR TITLE
Fix a little typo at commit 7f230183862566b98be74a0d2afe85a01bb78dba

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1077,7 +1077,7 @@ function get_current_url()
 
 function file_is_allowed($filename)
 {
-    if (!defined(CURRENT_USER_ID)) {
+    if (!defined('CURRENT_USER_ID')) {
         return false;
     }
 


### PR DESCRIPTION
Hello!

As addressed within #1213, a check for constant `CURRENT_USER_ID` is needed to allow cron to properly run. But declare require single quotes. 

This small PR fixes this syntax and this PR was validated in production using https://github.com/ZenithTecnologia/projectsend-docker image using my repository fork.

As this one is merged, I'll build from upstream again.

@ignacionelson can you please merge it?

Thank you so much for creating and mantaining projectsend!