### PR TITLE
Fixed SMTP authentication

### DIFF
--- a/includes/Classes/Emails.php
+++ b/includes/Classes/Emails.php
@@ -14,6 +14,25 @@ class Emails
     private $header;
     private $footer;
     private $email_successful;
+    private $email_body;
+    private $groups_list;
+    private $username;
+    private$password;
+    private $name;
+    private $token;
+    private $memberships;
+    private $add_bcc_to;
+    private $mail_info;
+    private $try_bcc;
+    private $add_bcc;
+    private $files_list;
+    private $get_groups;
+    private $type;
+    private $preview;
+    private $method;
+    private $addresses;
+    private $set_bcc;
+    private $debug_result;
 
     function __construct()
     {
@@ -1084,9 +1103,11 @@ class Emails
 
                     if (get_option('mail_smtp_auth') != 'none') {
                         $email->SMTPAuth = true;
-                        $email->SMTPSecure = get_option('mail_smtp_auth');
                     } else {
                         $email->SMTPAuth = false;
+                    }
+                    if (get_option('mail_smtp_secure') != 'none') {
+                        $email->SMTPSecure = get_option('mail_smtp_secure');
                     }
                     break;
                 case 'gmail':

--- a/includes/forms/options/email.php
+++ b/includes/forms/options/email.php
@@ -127,6 +127,16 @@
 <p><?php _e('You need to include your username (usually your e-mail address) and password if you have selected either SMTP or Gmail as your mailer.','cftp_admin'); ?></p>
 
 <div class="form-group row">
+    <label for="mail_smtp_auth" class="col-sm-4 control-label"><?php _e('Authentication','cftp_admin'); ?></label>
+    <div class="col-sm-8">
+        <select class="form-select" name="mail_smtp_auth" id="mail_smtp_auth" required>
+            <option value="none" <?php echo (get_option('mail_smtp_auth') == 'none') ? 'selected="selected"' : ''; ?>><?php _e('No Authentication','cftp_admin'); ?></option>
+            <option value="use" <?php echo (get_option('mail_smtp_auth') == 'use') ? 'selected="selected"' : ''; ?>><?php _e('Username/Password', 'cftp_admin') ?></option>
+        </select>
+    </div>
+</div>
+
+<div class="form-group row">
     <label for="mail_smtp_user" class="col-sm-4 control-label"><?php _e('Username','cftp_admin'); ?></label>
     <div class="col-sm-8">
         <input type="text" name="mail_smtp_user" id="mail_smtp_user" class="mail_data form-control" value="<?php echo html_output(get_option('mail_smtp_user')); ?>" />
@@ -160,12 +170,12 @@
 </div>
 
 <div class="form-group row">
-    <label for="mail_smtp_auth" class="col-sm-4 control-label"><?php _e('Authentication','cftp_admin'); ?></label>
+    <label for="mail_smtp_secure" class="col-sm-4 control-label"><?php _e('Connection security','cftp_admin'); ?></label>
     <div class="col-sm-8">
-        <select class="form-select" name="mail_smtp_auth" id="mail_smtp_auth" required>
-            <option value="none" <?php echo (get_option('mail_smtp_auth') == 'none') ? 'selected="selected"' : ''; ?>><?php _e('None','cftp_admin'); ?></option>
-            <option value="ssl" <?php echo (get_option('mail_smtp_auth') == 'ssl') ? 'selected="selected"' : ''; ?>>SSL</option>
-            <option value="tls" <?php echo (get_option('mail_smtp_auth') == 'tls') ? 'selected="selected"' : ''; ?>>TLS</option>
+        <select class="form-select" name="mail_smtp_secure" id="mail_smtp_secure" required>
+            <option value="none" <?php echo (get_option('mail_smtp_secure') == 'none') ? 'selected="selected"' : ''; ?>><?php _e('None','cftp_admin'); ?></option>
+            <option value="ssl" <?php echo (get_option('mail_smtp_secure') == 'ssl') ? 'selected="selected"' : ''; ?>>SMTPS</option>
+            <option value="tls" <?php echo (get_option('mail_smtp_secure') == 'tls') ? 'selected="selected"' : ''; ?>>STARTTLS</option>
         </select>
     </div>
 </div>

--- a/includes/upgrades/2025071401.php
+++ b/includes/upgrades/2025071401.php
@@ -1,0 +1,6 @@
+<?php
+
+function upgrade_2025071401()
+{
+    add_option_if_not_exists('mail_smtp_secure', 'none');
+}


### PR DESCRIPTION
**Motivation:**
The email setup uses the property 'mail_smtp_auth' to set the connection type of the SMTP connection to STARTTLS OR SMPTS **and** also enabled or disabled usage of username/password for login.
The usage of SMTP login is logically disconnected from how the client talks to the SMTP server. One should be able to set login credentials without having to enable secure communications with the server, besides the obvious security issues.

This PR includes the separation of SMTP login and SMTP server communication.

**Changes:**
- new property 'mail_smtp_secure' with possible values 'none, ssl, tls' which uses the previous logic to establish the SMTP server connection.
- old property 'mail_smtp_auth' is now only used to decide if SMTP login with username/password should be done or not. New accepted values are 'non, use'