### PR TITLE
CAPTCHA settings bugfix

### DIFF
--- a/includes/forms/options/security.php
+++ b/includes/forms/options/security.php
@@ -85,7 +85,7 @@
     <label for="captcha_method" class="col-sm-4 control-label"><?php _e('Captcha method','cftp_admin'); ?></label>
     <div class="col-sm-8">
         <select class="form-select" name="captcha_method" id="captcha_method" required>
-            <option value="" <?php echo (get_option('captcha_method') == null) ? 'selected="selected"' : ''; ?>><?php _e('Do not use captcha','cftp_admin'); ?></option>
+            <option value="none" <?php echo (get_option('captcha_method') == 'none') ? 'selected="selected"' : ''; ?>><?php _e('Do not use captcha','cftp_admin'); ?></option>
             <?php
                 $methods = captcha_get_methods();
                 foreach ($methods as $method => $method_class) {

--- a/includes/upgrades/2025071701.php
+++ b/includes/upgrades/2025071701.php
@@ -1,0 +1,9 @@
+<?php
+
+function upgrade_2025071701()
+{
+    // Need to set the captcha_method to a default value due to UI changes
+    if(get_option('captcha_method') == null) {
+        save_option('captcha_method', 'none');
+    }
+}


### PR DESCRIPTION
**Motivation:**
When using the current state, it is impossible to save the "Security" options, due to a bug in the logic of the Captcha Selector

- A "Do not use captcha" entry is displayed, when the current property "captcha_method" == null
- This option contains the value '' (empty string)
- Trying to save this setting will fail in the Bootstrap validation code as the value of the option is '' (empty string) which is not allowed
- This make saving the Security options impossible as long as no captcha is selected

**Changes:**

- set the default value for 'captcha_method' to 'none'
- use this as value for the "Do not use captcha" entry in the selector

**Result:**

You are able to save the settings on the Security options page again.

**Note:**
This might have also been fixed somehow somewhere in the Bootstrap validation code, but I stink as Javascript and Bootstrap and all that UI stuff 😄 
This commit does nothing to the actual captcha usage which still seems broken at the point of writing this.