### PR TITLE
Fix 403 error on first new client login requiring password change: replace obsolete edit_own_client_profile

### DIFF
--- a/clients-edit.php
+++ b/clients-edit.php
@@ -3,7 +3,7 @@
  * Show the form to edit an existing client.
  */
 require_once 'bootstrap.php';
-check_access_enhanced(['manage_clients', 'edit_clients', 'create_clients', 'edit_own_client_profile'], 'any');
+check_access_enhanced(['manage_clients', 'edit_clients', 'create_clients', 'edit_self_account'], 'any');
 
 $active_nav = 'clients';
 


### PR DESCRIPTION
## 403 error
In **r1945**, the permissions system was refactored and the constant `edit_own_client_profile` was **removed** in favor of `edit_self_account` is my best guess from what is currently available.