### PR TITLE
Extending Amazon S3 to support local instance

### DIFF
--- a/assets/src/js/pages/integration_form.js
+++ b/assets/src/js/pages/integration_form.js
@@ -55,6 +55,8 @@
                             const fieldNameAttr = `credentials[${fieldName}]`;
                             const isRequired = fieldConfig.required ? 'required' : '';
                             const requiredMark = fieldConfig.required ? ' *' : '';
+                            const placeholder = fieldConfig.placeholder ? `placeholder="${fieldConfig.placeholder}"` : '';
+                            const helpText = fieldConfig.help ? `<div class="form-text">${fieldConfig.help}</div>` : '';
 
                             if (fieldConfig.type === 'select' && fieldConfig.options) {
                                 fieldHtml = `
@@ -65,13 +67,24 @@
                                 Object.keys(fieldConfig.options).forEach(optionValue => {
                                     fieldHtml += `<option value="${optionValue}">${fieldConfig.options[optionValue]}</option>`;
                                 });
-                                fieldHtml += '</select>';
+                                fieldHtml += `</select>${helpText}`;
+                            } else if (fieldConfig.type === 'checkbox') {
+                                const defaultChecked = fieldConfig.default ? 'checked' : '';
+                                fieldHtml = `
+                                    <div class="form-check">
+                                        <input type="checkbox" name="${fieldNameAttr}" id="${fieldId}"
+                                               class="form-check-input" value="1" ${defaultChecked}>
+                                        <label for="${fieldId}" class="form-check-label">${fieldConfig.label}</label>
+                                    </div>
+                                    ${helpText}
+                                `;
                             } else {
                                 const inputType = fieldConfig.type === 'password' ? 'password' : 'text';
                                 fieldHtml = `
                                     <label for="${fieldId}" class="form-label">${fieldConfig.label}${requiredMark}</label>
                                     <input type="${inputType}" name="${fieldNameAttr}" id="${fieldId}"
-                                           class="form-control" ${isRequired}>
+                                           class="form-control" ${isRequired} ${placeholder}>
+                                    ${helpText}
                                 `;
                             }
 

--- a/includes/Classes/Integrations.php
+++ b/includes/Classes/Integrations.php
@@ -42,7 +42,13 @@ class Integrations
                     'ap-northeast-1' => 'Asia Pacific (Tokyo)',
                     'custom' => 'Custom (specify endpoint below)',
                 ]],
-                'endpoint' => ['type' => 'text', 'required' => false, 'label' => 'Custom Endpoint (Optional)', 'help' => 'For S3-compatible services like MinIO or SeaweedFS (e.g., https://minio.example.com or http://localhost:9000)', 'placeholder' => 'https://your-s3-server.com'],
+                'endpoint' => [
+                    'type' => 'text',
+                    'required' => false,
+                    'label' => 'Custom Endpoint (Optional)',
+                    'help' => 'For S3-compatible services like MinIO or SeaweedFS (e.g., https://minio.example.com or http://localhost:9000)',
+                    'placeholder' => 'https://your-s3-server.com'
+                ],
                 'use_path_style' => ['type' => 'checkbox', 'required' => false, 'label' => 'Use Path-Style Addressing', 'help' => 'Enable for MinIO and some S3-compatible services. Uses bucket/key instead of bucket.endpoint format', 'default' => false]
             ]
         ],

--- a/includes/Classes/Integrations.php
+++ b/includes/Classes/Integrations.php
@@ -22,13 +22,13 @@ class Integrations
     public static $available_types = [
         self::TYPE_S3 => [
             'name' => 'Amazon S3',
-            'description' => 'Amazon Simple Storage Service',
+            'description' => 'Amazon Simple Storage Service and S3-compatible storage (MinIO, SeaweedFS, etc.)',
             'class' => 'S3Storage',
             'fields' => [
-                'access_key' => ['type' => 'text', 'required' => true, 'label' => 'Access Key ID'],
-                'secret_key' => ['type' => 'password', 'required' => true, 'label' => 'Secret Access Key'],
-                'bucket_name' => ['type' => 'text', 'required' => true, 'label' => 'Bucket Name'],
-                'region' => ['type' => 'select', 'required' => true, 'label' => 'Region', 'options' => [
+                'access_key' => ['type' => 'text', 'required' => true, 'label' => 'Access Key ID', 'help' => 'Your S3 access key or API key'],
+                'secret_key' => ['type' => 'password', 'required' => true, 'label' => 'Secret Access Key', 'help' => 'Your S3 secret key'],
+                'bucket_name' => ['type' => 'text', 'required' => true, 'label' => 'Bucket Name', 'help' => 'The name of the S3 bucket to use'],
+                'region' => ['type' => 'select', 'required' => false, 'label' => 'Region', 'help' => 'AWS region (use "us-east-1" for most S3-compatible services)', 'options' => [
                     'us-east-1' => 'US East (N. Virginia)',
                     'us-east-2' => 'US East (Ohio)',
                     'us-west-1' => 'US West (N. California)',
@@ -40,7 +40,10 @@ class Integrations
                     'ap-southeast-1' => 'Asia Pacific (Singapore)',
                     'ap-southeast-2' => 'Asia Pacific (Sydney)',
                     'ap-northeast-1' => 'Asia Pacific (Tokyo)',
-                ]]
+                    'custom' => 'Custom (specify endpoint below)',
+                ]],
+                'endpoint' => ['type' => 'text', 'required' => false, 'label' => 'Custom Endpoint (Optional)', 'help' => 'For S3-compatible services like MinIO or SeaweedFS (e.g., https://minio.example.com or http://localhost:9000)', 'placeholder' => 'https://your-s3-server.com'],
+                'use_path_style' => ['type' => 'checkbox', 'required' => false, 'label' => 'Use Path-Style Addressing', 'help' => 'Enable for MinIO and some S3-compatible services. Uses bucket/key instead of bucket.endpoint format', 'default' => false]
             ]
         ],
         self::TYPE_GCS => [

--- a/includes/Classes/S3Storage.php
+++ b/includes/Classes/S3Storage.php
@@ -32,7 +32,7 @@ class S3Storage extends ExternalStorage
             $this->bucket_name = $this->credentials['bucket_name'] ?? '';
             $this->region = $this->credentials['region'] ?? 'us-east-1';
             $this->endpoint = $this->credentials['endpoint'] ?? '';
-            $this->use_path_style = isset($this->credentials['use_path_style']) && $this->credentials['use_path_style'] == '1';
+            $this->use_path_style = isset($this->credentials['use_path_style']) && $this->credentials['use_path_style'] === '1';
 
             $this->initializeS3Client();
         }

--- a/includes/Classes/S3Storage.php
+++ b/includes/Classes/S3Storage.php
@@ -14,6 +14,8 @@ class S3Storage extends ExternalStorage
     private $region;
     private $access_key;
     private $secret_key;
+    private $endpoint;
+    private $use_path_style;
 
     /**
      * Constructor
@@ -29,6 +31,8 @@ class S3Storage extends ExternalStorage
             $this->secret_key = $this->credentials['secret_key'] ?? '';
             $this->bucket_name = $this->credentials['bucket_name'] ?? '';
             $this->region = $this->credentials['region'] ?? 'us-east-1';
+            $this->endpoint = $this->credentials['endpoint'] ?? '';
+            $this->use_path_style = isset($this->credentials['use_path_style']) && $this->credentials['use_path_style'] == '1';
 
             $this->initializeS3Client();
         }
@@ -46,14 +50,28 @@ class S3Storage extends ExternalStorage
                 return;
             }
 
-            $this->s3_client = new \Aws\S3\S3Client([
+            $config = [
                 'version' => 'latest',
-                'region' => $this->region,
+                'region' => $this->region ?: 'us-east-1',
                 'credentials' => [
                     'key' => $this->access_key,
                     'secret' => $this->secret_key,
                 ],
-            ]);
+            ];
+
+            // Add custom endpoint for S3-compatible services (MinIO, SeaweedFS, etc.)
+            if (!empty($this->endpoint)) {
+                $config['endpoint'] = $this->endpoint;
+                $this->logOperation('init', '', 'info', 'Using custom endpoint: ' . $this->endpoint);
+            }
+
+            // Enable path-style addressing for MinIO and other S3-compatible services
+            if ($this->use_path_style) {
+                $config['use_path_style_endpoint'] = true;
+                $this->logOperation('init', '', 'info', 'Using path-style addressing');
+            }
+
+            $this->s3_client = new \Aws\S3\S3Client($config);
 
             $this->is_connected = true;
             $this->logOperation('init', '', 'success', 'S3 client initialized');
@@ -472,6 +490,8 @@ class S3Storage extends ExternalStorage
         $instance->secret_key = $credentials['secret_key'] ?? '';
         $instance->bucket_name = $credentials['bucket_name'] ?? '';
         $instance->region = $credentials['region'] ?? 'us-east-1';
+        $instance->endpoint = $credentials['endpoint'] ?? '';
+        $instance->use_path_style = isset($credentials['use_path_style']) && $credentials['use_path_style'] == '1';
         $instance->initializeS3Client();
         return $instance;
     }


### PR DESCRIPTION
added : new custom endpoint field in Amazon S3 configuration. set region to custom to use it


this code update based on r1945.

new field added to support local hosted endpoint ;

<img width="1064" height="854" alt="image" src="https://github.com/user-attachments/assets/94226058-06b4-4cf5-8e26-71b995874301" />


this code has been tested with my localhost minIO instance and able to import files from the bucket