### PR TITLE
Fix 'remember me' when using 2fa

### DIFF
--- a/includes/Classes/Auth.php
+++ b/includes/Classes/Auth.php
@@ -62,7 +62,7 @@ class Auth
         ]);
     }
 
-    public function validate2faRequest($token, $code)
+    public function validate2faRequest($token, $code, $remember_me = false)
     {
         $auth_code = new \ProjectSend\Classes\AuthenticationCode();
         $validate = json_decode($auth_code->validateRequest($token, $code));
@@ -81,6 +81,15 @@ class Auth
         if ($user->isActive()) {
             $this->user = $user;
             $this->login($user);
+
+            // Handle remember me functionality
+            if ($remember_me && get_option('remember_me_enabled', null, '1')) {
+                $rememberMe = new \ProjectSend\Classes\RememberMe();
+                $token = $rememberMe->generateToken();
+                if ($rememberMe->storeToken($user->id, $token)) {
+                    $rememberMe->setCookie($token);
+                }
+            }
 
             $results = [
                 'status' => 'success',
@@ -125,7 +134,7 @@ class Auth
                             $results = [
                                 'status' => 'success',
                                 'user_id' => $user->id,
-                                'location' => BASE_URI."index.php?form=2fa_verify&token=".$request2fa->token,
+                                'location' => BASE_URI."index.php?form=2fa_verify&remember_me=". (int)$remember_me ."&token=".$request2fa->token,
                             ];
                         } else {
                             $this->setError($request2fa->message);

--- a/includes/forms/2fa_verify.php
+++ b/includes/forms/2fa_verify.php
@@ -7,6 +7,7 @@
     <input type="hidden" name="csrf_token" value="<?php echo $csrf_token; ?>" />
     <input type="hidden" name="do" value="2fa_verify">
     <input type="hidden" name="token" value="<?php echo htmlentities($_GET['token']); ?>">
+    <input type="hidden" name="remember_me" value="<?php echo (int)$_GET['remember_me']; ?>">
 
     <div class="form_info">
         <h2><?php _e('Verify login code','cftp_admin'); ?></h2>
@@ -35,6 +36,7 @@
     <input type="hidden" name="csrf_token" value="<?php echo $csrf_token; ?>" />
     <input type="hidden" name="do" value="2fa_request_another">
     <input type="hidden" name="token" value="<?php echo htmlentities($_GET['token']); ?>">
+    <input type="hidden" name="remember_me" value="<?php echo (int)$_GET['remember_me']; ?>">
 
     <div id="otp_request_new_container">
         <h4><?php echo __("Didn't receive the email?",'cftp_admin'); ?></h4>

--- a/index.php
+++ b/index.php
@@ -83,8 +83,9 @@ if ($_POST) {
         case '2fa_verify':
             recaptcha2_validate_request();
             $code = $_POST['n1'] . $_POST['n2'] . $_POST['n3'] . $_POST['n4'] . $_POST['n5'] . $_POST['n6'];
+	    $remember_me = !empty($_POST['remember_me']) && $_POST['remember_me'] === '1';
 
-            $login = json_decode($auth->validate2faRequest($_POST['token'], (int)$code));
+            $login = json_decode($auth->validate2faRequest($_POST['token'], (int)$code, $remember_me));
             if ($login->status == 'success') {
                 $user = new \ProjectSend\Classes\Users($login->user_id);
                 ps_redirect($login->location);


### PR DESCRIPTION
When 2FA is enabled, the "remember me" selection goes off into the void and is not honored.

Pass the option down though 2fa validation and honor the selection by setting the cookie if the user is active.