### PR TITLE
Fix typo: securiy -> security

### DIFF
--- a/includes/forms/options/cron.php
+++ b/includes/forms/options/cron.php
@@ -53,7 +53,7 @@ $form_sections = [
             [
                 'type' => 'text',
                 'name' => 'cron_key',
-                'label' => __('Cron securiy key', 'cftp_admin'),
+                'label' => __('Cron security key', 'cftp_admin'),
                 'note' => __('This key must be present in the URL to validate the cron job and execute the required actions.', 'cftp_admin')
             ],
             [

--- a/lang/cftp_admin.pot
+++ b/lang/cftp_admin.pot
@@ -4307,7 +4307,7 @@ msgid ""
 msgstr ""
 
 #: includes/forms/options/cron.php:56
-msgid "Cron securiy key"
+msgid "Cron security key"
 msgstr ""
 
 #: includes/forms/options/cron.php:57

--- a/lang/en.po
+++ b/lang/en.po
@@ -4340,7 +4340,7 @@ msgid ""
 msgstr ""
 
 #: includes/forms/options/cron.php:56
-msgid "Cron securiy key"
+msgid "Cron security key"
 msgstr ""
 
 #: includes/forms/options/cron.php:57


### PR DESCRIPTION
./includes/forms/options/cron.php                   'label' => __('Cron securiy key', 'cftp_admin'),
./includes/forms/options/cron.php                   'label' => __('Cron security key', 'cftp_admin'),

./lang/cftp_admin.pot   msgid "Cron securiy key"
./lang/cftp_admin.pot   msgid "Cron security key"

./lang/en.po   msgid "Cron securiy key"
./lang/en.po   msgid "Cron security key"
