### PR TITLE
File downloads limit are not enforced on public files

### DIFF
--- a/download.php
+++ b/download.php
@@ -41,7 +41,16 @@ if (!empty($_GET['token']) && !empty($_GET['id'])) {
 
     if ($can_download == true) {
         if (isset($_GET['download'])) {
-            record_new_download(0, $file->id);
+            $download_result = record_new_download(0, $file->id);
+
+            // Check if download limit was reached
+            if (is_array($download_result) && !$download_result['allowed']) {
+                header("HTTP/1.0 403 Forbidden");
+                header("Content-Type: text/html; charset=UTF-8");
+                $msg = $download_result['message'];
+                echo system_message('danger', $msg);
+                exit;
+            }
 
             /** Record the action log */
             $logger = new \ProjectSend\Classes\ActionsLog;


### PR DESCRIPTION
Logic would say that if in the GUI one is allowed to set expirations and file downloads limits (i.e. 2 downloads then expire) on all files, including public files, this would be enforced. But it is silently ignored, and users don't understand why they still can download a file that has some downloads limits set...

