### PR TITLE
Fix bug where delete_expired_files log is overwritten by delete_orphan_files

### DIFF
--- a/includes/Classes/Cron.php
+++ b/includes/Classes/Cron.php
@@ -193,7 +193,7 @@ class Cron
             'elements' => [],
         ];
 
-        if (get_option('cron_delete_expired_files') == '1') {
+        if (get_option('cron_delete_orphan_files') == '1') {
             $files = [];
             $object = new \ProjectSend\Classes\OrphanFiles;
             $orphan_files = $object->getFiles();
@@ -238,7 +238,7 @@ class Cron
             }
         }
 
-        $this->results['delete_expired_files'] = $results;
+        $this->results['delete_orphan_files'] = $results;
         $this->formatResultsForDisplay($results);
     }
 

--- a/includes/upgrades/2025092004.php
+++ b/includes/upgrades/2025092004.php
@@ -121,6 +121,8 @@ function upgrade_2025092004()
             // Drop role_level column and update primary key
             try {
                 $alter_sql = "ALTER TABLE " . TABLE_ROLE_PERMISSIONS . "
+                             ADD UNIQUE KEY (id),
+                             DROP KEY role_permission,
                              DROP COLUMN role_level,
                              DROP PRIMARY KEY,
                              ADD PRIMARY KEY (role_id, permission)";

--- a/includes/upgrades/2025092004.php
+++ b/includes/upgrades/2025092004.php
@@ -121,8 +121,6 @@ function upgrade_2025092004()
             // Drop role_level column and update primary key
             try {
                 $alter_sql = "ALTER TABLE " . TABLE_ROLE_PERMISSIONS . "
-                             ADD UNIQUE KEY (id),
-                             DROP KEY role_permission,
                              DROP COLUMN role_level,
                              DROP PRIMARY KEY,
                              ADD PRIMARY KEY (role_id, permission)";


### PR DESCRIPTION
Hi! I found a bug in runTaskDeleteOrphanFiles() within Cron.php.

It incorrectly checks cron_delete_expired_files instead of cron_delete_orphan_files.

At the end of the method, it overwrites $this->results['delete_expired_files'] with the empty orphan files log, causing the actual expired files deletion log to disappear (always outputting empty []).

I have fixed it to correctly check cron_delete_orphan_files and use the proper array key delete_orphan_files. Please review it. Thank you!
