### PR TITLE
Add the option Create own folders under the menu item User Roles. The…

### DIFF
--- a/includes/Classes/Permissions.php
+++ b/includes/Classes/Permissions.php
@@ -30,6 +30,11 @@ class Permissions {
                 'label' => __('Upload files', 'cftp_admin'),
                 'description' => __('Allow user to upload new files', 'cftp_admin')
             ],
+            'create_own_folders' => [
+                'category' => 'files',
+                'label' => __('Create own folders', 'cftp_admin'),
+                'description' => __('Allow user to create folders for organizing their own files', 'cftp_admin')
+            ],
             'edit_files' => [
                 'category' => 'files',
                 'label' => __('Edit own files', 'cftp_admin'),

--- a/includes/ajax.process.php
+++ b/includes/ajax.process.php
@@ -19,6 +19,10 @@ header('Content-Type: application/json');
 
 switch ($_GET['do']) {
     case 'folder_create':
+        if (!current_user_can('create_own_folders')) {
+            die_with_error_code(403);
+        }
+
         $folder = new \ProjectSend\Classes\Folder();
         $folder->set([
             'name' => $_POST['folder_name'],

--- a/includes/upgrades/2026060301.php
+++ b/includes/upgrades/2026060301.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Add create_own_folders permission and grant it to existing roles by default.
+ */
+function upgrade_2026060301()
+{
+    global $dbh;
+
+    $permission_key = 'create_own_folders';
+
+    $check_permission = "SELECT COUNT(*) FROM " . TABLE_PERMISSIONS . " WHERE permission_key = :permission_key";
+    $statement = $dbh->prepare($check_permission);
+    $statement->execute(['permission_key' => $permission_key]);
+
+    if ($statement->fetchColumn() == 0) {
+        $insert_permission = "INSERT INTO " . TABLE_PERMISSIONS . "
+            (permission_key, name, description, category, is_system_permission, active)
+            VALUES (:permission_key, :name, :description, :category, 1, 1)";
+        $statement = $dbh->prepare($insert_permission);
+        $statement->execute([
+            'permission_key' => $permission_key,
+            'name' => __('Create own folders', 'cftp_admin'),
+            'description' => __('Allow user to create folders for organizing their own files', 'cftp_admin'),
+            'category' => 'files',
+        ]);
+    }
+
+    $check_column = "SHOW COLUMNS FROM " . TABLE_ROLE_PERMISSIONS . " LIKE 'role_id'";
+    $statement = $dbh->prepare($check_column);
+    $statement->execute();
+    $has_role_id = $statement->rowCount() > 0;
+
+    $check_column = "SHOW COLUMNS FROM " . TABLE_ROLE_PERMISSIONS . " LIKE 'role_level'";
+    $statement = $dbh->prepare($check_column);
+    $statement->execute();
+    $has_role_level = $statement->rowCount() > 0;
+
+    if ($has_role_id && $has_role_level && table_exists(TABLE_ROLES)) {
+        $role_levels = [
+            'Client' => 0,
+            'Uploader' => 7,
+            'Account Manager' => 8,
+            'System Administrator' => 9,
+        ];
+
+        $roles_query = "SELECT id, name FROM " . TABLE_ROLES;
+        $statement = $dbh->prepare($roles_query);
+        $statement->execute();
+        $roles = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+        $update_permission = "UPDATE " . TABLE_ROLE_PERMISSIONS . "
+            SET role_id = :role_id, granted = 1
+            WHERE role_level = :role_level AND permission = :permission";
+        $update_statement = $dbh->prepare($update_permission);
+
+        $insert_permission = "INSERT IGNORE INTO " . TABLE_ROLE_PERMISSIONS . "
+            (role_level, role_id, permission, granted)
+            VALUES (:role_level, :role_id, :permission, 1)";
+        $insert_statement = $dbh->prepare($insert_permission);
+
+        foreach ($roles as $role) {
+            if (!isset($role_levels[$role['name']])) {
+                continue;
+            }
+
+            $params = [
+                'role_level' => $role_levels[$role['name']],
+                'role_id' => $role['id'],
+                'permission' => $permission_key,
+            ];
+
+            $update_statement->execute($params);
+            $insert_statement->execute($params);
+        }
+
+        return;
+    }
+
+    if ($has_role_id && table_exists(TABLE_ROLES)) {
+        $roles_query = "SELECT id FROM " . TABLE_ROLES;
+        $statement = $dbh->prepare($roles_query);
+        $statement->execute();
+        $roles = $statement->fetchAll(PDO::FETCH_COLUMN);
+
+        $grant_permission = "INSERT IGNORE INTO " . TABLE_ROLE_PERMISSIONS . "
+            (role_id, permission, granted)
+            VALUES (:role_id, :permission, 1)";
+        $statement = $dbh->prepare($grant_permission);
+
+        foreach ($roles as $role_id) {
+            $statement->execute([
+                'role_id' => $role_id,
+                'permission' => $permission_key,
+            ]);
+        }
+
+        return;
+    }
+
+    if ($has_role_level) {
+        $role_levels = [0, 7, 8, 9];
+        $grant_permission = "INSERT IGNORE INTO " . TABLE_ROLE_PERMISSIONS . "
+            (role_level, permission, granted)
+            VALUES (:role_level, :permission, 1)";
+        $statement = $dbh->prepare($grant_permission);
+
+        foreach ($role_levels as $role_level) {
+            $statement->execute([
+                'role_level' => $role_level,
+                'permission' => $permission_key,
+            ]);
+        }
+
+        return;
+    }
+}

--- a/manage-files.php
+++ b/manage-files.php
@@ -433,26 +433,30 @@ if (!$count) {
 }
 
 // Header buttons
-if (current_user_can_upload()) {
-    $header_action_buttons = [
-        [
-            'url' => '#',
-            'label' => __('New folder', 'cftp_admin'),
-            'id' => 'btn_header_folder_create',
-            'data-attributes' => [
-                'modal-title' => __('New folder', 'cftp_admin'),
-                'modal-label' => __('Name', 'cftp_admin'),
-                'modal-title-invalid' => __('Name is not valid', 'cftp_admin'),
-                'parent' => $current_folder,
-                'process-url' => AJAX_PROCESS_URL.'?do=folder_create',
-                'folder-url' => BASE_URI.'manage-files.php?folder_id={folder_id}',
-            ],
-        ],
-        [
-            'url' => 'upload.php',
-            'label' => __('Upload files', 'cftp_admin'),
+$header_action_buttons = [];
+if (current_user_can('create_own_folders')) {
+    $header_action_buttons[] = [
+        'url' => '#',
+        'label' => __('New folder', 'cftp_admin'),
+        'id' => 'btn_header_folder_create',
+        'data-attributes' => [
+            'modal-title' => __('New folder', 'cftp_admin'),
+            'modal-label' => __('Name', 'cftp_admin'),
+            'modal-title-invalid' => __('Name is not valid', 'cftp_admin'),
+            'parent' => $current_folder,
+            'process-url' => AJAX_PROCESS_URL.'?do=folder_create',
+            'folder-url' => BASE_URI.'manage-files.php?folder_id={folder_id}',
         ],
     ];
+}
+if (current_user_can_upload()) {
+    $header_action_buttons[] = [
+        'url' => 'upload.php',
+        'label' => __('Upload files', 'cftp_admin'),
+    ];
+}
+if (empty($header_action_buttons)) {
+    unset($header_action_buttons);
 }
 
 // Search + filters bar data

--- a/role-permissions.php
+++ b/role-permissions.php
@@ -28,6 +28,7 @@ $page_id = 'role_permissions';
 // Define Client role editable permissions
 $client_editable_permissions = [
     'upload',
+    'create_own_folders',
     'delete_files',
     'set_file_expiration_date',
     'upload_public',


### PR DESCRIPTION
… default checkbox will be ON for the Client Role.  No functionality is taken away.

<img width="2344" height="363" alt="Create_folder_button" src="https://github.com/user-attachments/assets/7f26d343-7291-4704-9053-1dcb7f8d0785" />
<img width="2083" height="1143" alt="Create_folder_right" src="https://github.com/user-attachments/assets/a8c16a44-498b-438e-9caa-ab3c8244774f" />

Includes database upgrade script: includes/upgrades/2026060301.php

The script adds the create_own_folders permission and grants it to existing roles by default so current behavior is preserved after upgrade.