### PR TITLE
Set an explicit Content-Type on a stored upload part's response

### DIFF
--- a/app/Modules/Files/Http/Controllers/ChunkedUploadsController.php
+++ b/app/Modules/Files/Http/Controllers/ChunkedUploadsController.php
@@ -208,7 +208,18 @@ class ChunkedUploadsController extends Controller
             }
         }
 
-        return response('', 200, ['ETag' => '"'.$etag.'"']);
+        return response('', 200, [
+            'ETag' => '"'.$etag.'"',
+            // Stated rather than left to Symfony, whose default for an
+            // empty body is text/html. A CDN that rewrites HTML — as
+            // Cloudflare's Email Obfuscation and Automatic HTTPS Rewrites
+            // do — drops the origin's ETag from an HTML response, since a
+            // rewritten body would no longer match it. Nothing on this side
+            // would notice (LocalPartStore keeps its own record of every
+            // part), but the client never learns the part landed, so the
+            // upload stalls at 100% with no error anywhere.
+            'Content-Type' => 'application/octet-stream',
+        ]);
     }
 
     /**


### PR DESCRIPTION
Closes #1616.

An empty response gets Symfony's default `Content-Type`, `text/html`, and a CDN in front of the app takes that at its word: Cloudflare's Email Obfuscation and Automatic HTTPS Rewrites both rewrite HTML bodies, so they drop the origin's `ETag` — a rewritten body would no longer match it.

That `ETag` is the client's only signal that a part landed. Nothing on this side notices its loss (`LocalPartStore` keeps its own record of every part, and `complete()` never reads a client-supplied one), so the upload reaches 100% and stops with no error at either end. The reporter saw Uppy's "Could not read the ETag header" message, which names CORS and sends you chasing a preflight that same-origin requests never make.

Naming the content type accurately keeps the response out of every HTML-rewriting path, rather than asking each CDN-fronted install to discover this for itself.

## Verified

- **Baseline reproduced:** the part `PUT` answered `200`, empty body, `Content-Type: text/html; charset=utf-8`.
- **Through nginx:** full chunked upload over `/api/v1` — `application/octet-stream`, `ETag` intact, file created.
- **Real browser:** headless Chrome drove the actual Uppy dashboard through a 45 MB upload (3 parts) — every part `200` with a readable `ETag`, no console errors, file stored at the exact byte count.
- **Checks:** 1600 Pest tests, PHPStan, `tsc` and ESLint all clean.

The rationale sits inside the header array rather than above the `return`: Scramble reads a comment attached to a return statement as that response's `description` in the published OpenAPI document, and this controller is mounted on the API routes too. `docs/api-checklist.md` now warns about that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)