### PR TITLE
Run nginx as the user php-fpm writes as

### DIFF
--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -66,6 +66,25 @@ RUN delgroup www-data 2>/dev/null || true \
     && addgroup -g 1000 www-data \
     && adduser -D -H -u 1000 -G www-data www-data
 
+# nginx must run as that same user, and the alpine package does not: it
+# ships `user nginx;` (uid 100) in its own nginx.conf. The two identities
+# have to match because php-fpm hands nginx files to serve — protected
+# downloads and thumbnails go out by X-Accel-Redirect — and the
+# application creates directories on demand at Flysystem's private mode,
+# 0700. Traversing one of those means *being* its owner; there are no
+# group or other bits to fall back on, so a differently-owned nginx worker
+# answers 403 on the first thumbnail it is asked for.
+#
+# Changing the directive is only half of it. /var/lib/nginx and its tmp/
+# come from the package owned by the old user, and a worker cannot reach
+# the temp directories underneath a parent it may not traverse — nginx
+# recreates the leaves at boot as the new user, so they look right while
+# every request nginx buffers to disk (every upload chunk, which is what
+# client_max_body_size is set high for) fails with a bare 500 that never
+# reaches php-fpm.
+RUN sed -i 's/^user nginx;/user www-data;/' /etc/nginx/nginx.conf \
+    && chown -R www-data:www-data /var/lib/nginx
+
 COPY docker/production/php.ini        /usr/local/etc/php/conf.d/projectsend.ini
 COPY docker/production/www-pool.conf  /usr/local/etc/php-fpm.d/zz-www-pool.conf
 COPY docker/production/nginx.conf     /etc/nginx/http.d/default.conf

--- a/docker/production/nginx.conf
+++ b/docker/production/nginx.conf
@@ -6,8 +6,12 @@
 # being one container instead of two:
 #
 #   1. fastcgi_pass targets 127.0.0.1, not the `app` compose service.
-#   2. There is no user/uid coordination to do: nginx and php-fpm run as
-#      the same www-data here, so storage/ needs no group juggling.
+#   2. There is no user/uid coordination to do here, because the Dockerfile
+#      has already done it: it points the `user` directive in the package's
+#      own nginx.conf at www-data, so nginx and php-fpm are the same user
+#      and storage/ needs no group juggling. Without that step nginx runs
+#      as the alpine package's `nginx` (uid 100) and cannot read what
+#      php-fpm just wrote — see the comment on that line.
 
 server {
     listen 80 default_server;


### PR DESCRIPTION
Closes #1614. Closes #1618.

The image creates a fixed-uid `www-data` for php-fpm but left nginx on the alpine package's own `user nginx;` (uid 100) — while `nginx.conf`'s header comment claimed the two already matched. They did not, and that claim is why nobody looked.

It matters because php-fpm hands nginx files to serve: protected downloads and thumbnails go out by `X-Accel-Redirect`. Directories the application creates on demand come out at Flysystem's private mode, `0700`, owned by `www-data` — and traversing one of those means *being* its owner, since there are no group or other bits to fall back on. The first thumbnail an installation renders answers 403 from nginx, with nothing in the application log to show for it.

**Pointing the directive at `www-data` is only half of it.** `/var/lib/nginx` and its `tmp/` arrive from the package owned by the old user, and nginx recreates only the *leaf* temp directories at boot — as the new user, so they look correct while their parent stays untraversable. Every request nginx buffers to disk then fails with a bare 500 that never reaches php-fpm; that is every upload chunk, which is every upload. Fixing one without the other trades a broken thumbnail for a broken upload, which is exactly what #1618 reports, so both land together.

## Verified

Built the image three ways and drove a real login, chunked upload and thumbnail request through each:

| build | part `PUT` | thumbnail |
|---|---|---|
| unchanged (`main`) | 200 | **403** — `open() .../storage/app/files/thumbnails/1.png failed (13: Permission denied)`, with `drwx------ www-data:www-data` on the directory and workers running as `nginx` |
| `user www-data;` only | **500** — `open() "/var/lib/nginx/tmp/client_body/0000000001" failed (13: Permission denied)`, `/var/lib/nginx` still `nginx:nginx` | 200 |
| both (this PR) | 200 | 200 |

On the fixed image: the 2,431,703-byte upload completes, its thumbnail renders (272 KB), `/files/1/download` returns the original byte for byte, `/files/1/preview` and `/dashboard` are 200, and there is not a single permission complaint in the container logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)