### PR TITLE
Reduce a manual update to one command that asks first

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -227,8 +227,9 @@ git pull                       # or unpack the new release over the directory
 docker compose up -d --build
 ```
 
-The app container migrates the database itself on boot and verifies its reference data, so there is
-no separate migration step. Take a database dump first anyway — migrations move forwards, not
+The app container runs `php artisan projectsend:update` itself on boot — the same command a
+manual install runs — so it migrates the database and verifies its reference data with no separate
+step. Take a database dump first anyway — migrations move forwards, not
 backwards, and the one time you skip it will be the time you want it.
 
 If you run the published image rather than building your own, it is `docker compose pull` followed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -382,8 +382,8 @@ sudo -u www-data php artisan view:cache
 sudo -u www-data php artisan event:cache
 ```
 
-Re-run them after every update. If you change your mind, `php artisan optimize:clear` undoes all
-three.
+You only run these once: `projectsend:update` notices they are in place and rebuilds them for you
+after every update. If you change your mind, `php artisan optimize:clear` undoes all three.
 
 #### One command to skip: `config:cache`
 
@@ -405,43 +405,34 @@ of the person who actually downloaded the file. Both are the kind of thing you d
 later, from a complaint.
 
 If you have already run it — or ran `php artisan optimize`, which includes it — `php artisan
-config:clear` puts things back immediately. The three commands above are safe and give you nearly
+config:clear` puts things back immediately, and every update clears it too, saying why. The three commands above are safe and give you nearly
 all of the speed anyway; `config:cache` was always the smallest win of the four.
 
 ---
 
 ## Updating to a new version
 
-The short version, for a server installed the way this document describes.
-**[UPDATE.md](UPDATE.md)** is the full procedure — backups, both Docker paths, how to check it
-worked, and how to go back.
+```sh
+cd /var/www/projectsend
+sudo ./update.sh
+```
 
-1. **Back up first** — the database, the `.env` file, and `storage/app/files/`. Every time.
-2. Put the site in maintenance mode: `sudo -u www-data php artisan down`
-3. Unpack the new zip over the install directory. Keep your `.env` and your `storage/` folder —
-   the zip does not contain either, but check your unzip tool is not helpfully deleting things.
-4. Run the updates:
+The script ships with every release, in this directory. It asks whether to check GitHub for a newer
+version, whether to download it (checking the published checksum), and whether you have a backup —
+then takes the site down, unpacks the release, migrates the database, rebuilds whichever caches you
+were using, reloads PHP-FPM, restarts the worker and brings the site back up. Your `.env`, your
+uploads and your `public/storage` link are never touched.
 
-   ```sh
-   sudo -u www-data php artisan migrate --force
-   sudo -u www-data php artisan projectsend:ensure-roles
-   sudo -u www-data php artisan optimize:clear
-   sudo -u www-data php artisan queue:restart
-   ```
+`sudo ./update.sh --zip ~/projectsend-2.1.0.zip` applies a zip you downloaded yourself, and
+`./update.sh --check` just reports what is available.
 
-5. **Reload PHP-FPM**: `sudo systemctl reload php8.4-fpm`
+**[UPDATE.md](UPDATE.md)** is the full reference: what it does in order, every option, the same
+steps done by hand, how to check it worked, and how to go back. Read it before your first update —
+particularly the part about reloading PHP-FPM, which is the step that decides whether an update
+takes effect at all.
 
-   Not optional, and the step people skip. With OPcache set the way production guides recommend
-   (`opcache.validate_timestamps=0`), PHP never re-reads a file it has already compiled: the
-   database ends up on the new version while every visitor is still served the old code, and
-   `php artisan` reports the new version the whole time you are trying to work out why.
-
-6. If you use the optional caches from [Making it faster](#making-it-faster), re-run them —
-   step 4 cleared them.
-7. Bring it back: `sudo -u www-data php artisan up`
-
-`projectsend:ensure-roles` teaches the built-in roles about any permissions the new version added.
-It never touches permissions you have customised yourself.
+Back up first, every time. The script can dump the database for you (`--backup`), but your uploaded
+files in `storage/app/files/` are yours to look after.
 
 ---
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -18,7 +18,7 @@ Which path you are on decides the rest:
 |---|---|---|
 | The official Docker image (`projectsend/projectsend`) | Pull a new image, recreate the container | None — the container migrates itself |
 | Docker Compose built from source (DOCKER.md) | New code, rebuild the image | None — same entrypoint |
-| A release zip on your own server (INSTALL.md) | Replace the files, run five commands | All of them, including a PHP-FPM reload |
+| A release zip on your own server (INSTALL.md) | Download the zip, run one script | `sudo ./update.sh`, and answer three questions |
 
 ProjectSend also tells you which of these you are on: the **System** card on the dashboard prints
 the update instructions for *this* server, and the notice that appears when a new version is
@@ -91,11 +91,11 @@ The entrypoint runs before the web server accepts a single request, in this orde
    every existing session invalid and every encrypted column unreadable.
 2. Waits up to 60 seconds for the database to accept connections, so a slow-starting database is a
    pause rather than a crash loop.
-3. Runs `php artisan migrate --force`.
-4. Runs `php artisan storage:link` and `php artisan projectsend:ensure-roles` — the latter teaches
-   the built-in roles about any permission the new version added, without touching roles you have
-   customised.
-5. Clears compiled views, then starts php-fpm, nginx, the queue worker and the scheduler.
+3. Runs `php artisan projectsend:update` — the same command a manual install runs, and the only
+   definition of what an update does. It migrates the database, restores any built-in role a new
+   version added a permission to (without touching roles you customised), relinks storage, clears
+   the compiled caches and records the version it applied.
+4. Starts php-fpm, nginx, the queue worker and the scheduler.
 
 The queue worker and scheduler run inside that same container, so they are replaced with it and
 never keep running old code.
@@ -128,107 +128,84 @@ a half-updated site serving traffic: nginx is not started until the entrypoint f
 
 ## Updating a manual installation
 
-This is the path with steps you have to perform, and one of them — the PHP-FPM reload — is easy to
-miss and hard to diagnose. The order below matters.
+```sh
+cd /var/www/projectsend
+sudo ./update.sh
+```
 
-Run everything as the user your web server runs as (`www-data` in INSTALL.md's examples).
+That is the whole procedure. It asks three questions — whether to check GitHub for a newer release,
+whether to download it (verifying the checksum published beside it), and whether you have a backup —
+then does the rest. If you would rather fetch the zip yourself, hand it over instead:
 
-### 1. Take the site down
+```sh
+sudo ./update.sh --zip ~/projectsend-2.1.0.zip
+```
+
+`./update.sh --check` reports what is installed and what is available, changes nothing, and does not
+need root.
+
+### What it does, in order
+
+1. Refuses to run inside a container, where updating means pulling a new image.
+2. Works out who your web server runs as, from the owner of `public/index.php`.
+3. Reads the version out of the zip and refuses to go backwards — migrations only move forwards —
+   unless you pass `--force`. The *same* version is accepted, and is how you restore files that were
+   modified or lost.
+4. Takes a database dump, if you asked for one (`--backup`).
+5. Puts the site into maintenance mode, and guarantees it comes back out: if anything fails, or you
+   interrupt it, the site is brought back up before the script exits.
+6. Unpacks the release over your installation, leaving `.env`, `storage/` and `public/storage`
+   alone, and replacing `vendor/` and `public/build/` wholesale rather than merging them.
+7. Runs `php artisan projectsend:update`, which migrates the database, restores the built-in roles,
+   relinks storage, clears the compiled caches, rebuilds the optional ones **if you were using
+   them**, and records the version it applied.
+8. Reloads PHP-FPM and restarts the queue worker.
+9. Brings the site back up and tells you what is running.
+
+### Useful options
+
+| Option | What for |
+|---|---|
+| `--zip <path>` | Apply a zip you downloaded yourself. |
+| `--backup` | Dump the database first, to `/var/backups/projectsend` (`--backup-dir` to change). |
+| `--check` | Report versions and stop. No root needed. |
+| `--user`, `--php-fpm`, `--worker` | Override what it detected. |
+| `--no-restart` | Leave systemd alone. You must then reload PHP-FPM yourself. |
+| `-y`, `--yes` | Unattended. Requires `--backup` or `--i-have-a-backup`. |
+| `--force` | Apply an older release. Read the sentence about migrations again first. |
+
+### Doing it by hand
+
+The script is not magic, and there is no harm in running the steps yourself:
 
 ```sh
 cd /var/www/projectsend
 sudo -u www-data php artisan down
-```
-
-Visitors get a maintenance page instead of a half-updated application.
-
-### 2. Replace the files
-
-The release zip is flat — its contents unpack straight into the install directory, with no wrapper
-folder. It contains no `.env`, no uploads, and no `public/storage` symlink, so unpacking it cannot
-take yours with it.
-
-```sh
-cd /tmp
-unzip projectsend-2.0.1.zip -d projectsend-new
-sudo cp -a projectsend-new/. /var/www/projectsend/
-sudo chown -R www-data:www-data /var/www/projectsend
-```
-
-**A cleaner alternative, if you can:** unpack the new release into a directory of its own, copy your
-`.env` and `storage/` across, and swap the two directories. Copying over an existing install leaves
-behind any file the new version deleted; swapping directories does not, and rolling back is renaming
-one directory instead of restoring an archive.
-
-Either way, `storage/` and `.env` are yours and must survive. Everything else in the tree comes from
-the zip.
-
-### 3. Run the updates
-
-```sh
-sudo -u www-data php artisan migrate --force
-sudo -u www-data php artisan projectsend:ensure-roles
-sudo -u www-data php artisan optimize:clear
-sudo -u www-data php artisan queue:restart
-```
-
-`projectsend:ensure-roles` gives the built-in roles any permission the new version added. It never
-touches a permission you changed yourself.
-
-`queue:restart` asks the background worker to finish its current job and exit; whatever supervises
-it (systemd, supervisor) starts a fresh one on the new code. The cron entry that drives the
-scheduler needs nothing — it starts a new process every minute anyway.
-
-### 4. Reload PHP-FPM
-
-```sh
-sudo systemctl reload php8.4-fpm
-```
-
-**Do not skip this.** If your server has OPcache configured the way production guides recommend
-(`opcache.validate_timestamps=0`, which is also what our own Docker image uses), PHP does not
-re-read a file it has already compiled. Replacing the files changes nothing for the running site: the
-database is on the new version and the web server is still executing the old code. `php artisan`
-shows you the new version from the command line while every visitor gets the old one, which is a
-miserable thing to debug.
-
-If you have never touched your OPcache settings, the reload is harmless — do it anyway rather than
-finding out which kind of server you have during an update.
-
-### 5. Put the caches back, if you use them
-
-`optimize:clear` in step 3 cleared the optional caches from INSTALL.md's *Making it faster*
-section. If you had run them, run them again now:
-
-```sh
-sudo -u www-data php artisan route:cache
-sudo -u www-data php artisan view:cache
-sudo -u www-data php artisan event:cache
-```
-
-Still **not** `config:cache` — see [INSTALL.md](INSTALL.md#one-command-to-skip-configcache) for why
-that one stays off on this application.
-
-### 6. Bring it back
-
-```sh
+# unpack the release over this directory, keeping .env and storage/
+sudo chown -R www-data:www-data .
+sudo -u www-data php artisan projectsend:update
+sudo systemctl reload php8.4-fpm        # not optional — see below
+sudo systemctl restart projectsend-worker
 sudo -u www-data php artisan up
 ```
 
-### 7. Check it worked
+**The reload is the step that matters.** With OPcache configured the way production guides recommend
+(`opcache.validate_timestamps=0`, which our own Docker image uses), PHP does not re-read a file it
+has already compiled. Replacing the files changes nothing for the running site: the database ends up
+on the new version and the web server keeps serving the old code, while `php artisan` reports the
+new version the whole time you are trying to work out why.
 
-- The dashboard's **System** card shows the new version. If it still shows the old one, step 4 did
-  not happen — reload PHP-FPM and reload the page.
-- **System → Settings → Scheduler** shows tasks running and no new failures.
-- Download a file. It is the one path that goes through nginx, PHP and your storage at once.
+If it happens anyway, ProjectSend now says so: staff see a banner naming the version being served,
+the version that was installed, and the command that fixes it.
 
 ---
 
 ## When it goes wrong
 
 **The site shows the old version after updating.**
-Stale OPcache — step 4. `php artisan` reading the new version while the browser reads the old one is
-this exact symptom.
+Stale OPcache — reload PHP-FPM. `php artisan` reporting the new version while the browser reads the
+old one is this exact symptom, and staff now see a banner saying so, naming both versions and the
+command that fixes it. `sudo ./update.sh` does the reload for you unless you passed `--no-restart`.
 
 **500 errors on every page, right after an update.**
 Usually compiled caches from the previous version. `php artisan optimize:clear`, then reload
@@ -253,6 +230,9 @@ same requirement as [INSTALL.md](INSTALL.md) step 4.
 
 1. Restore the code: the previous image tag (Docker), or the previous directory or zip (manual).
 2. Restore the database dump you took before starting.
+3. On a manual install, run `sudo -u www-data php artisan projectsend:update` afterwards, so the
+   installation agrees with the code you restored. (A container does this itself on boot.) Until it
+   runs, staff see the banner described above — which is correct: the database is ahead of the code.
 
 Restore both, not one. A newer database against older code is the one combination nothing in this
 application expects, because migrations only ever move forwards.

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -20,6 +20,7 @@ use App\Modules\Platform\Localization\TimezoneRegistry;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
 use App\Modules\Platform\Updates\LatestReleaseInfo;
+use App\Modules\Platform\Updates\RunningCodeState;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
@@ -96,6 +97,7 @@ class HandleInertiaRequests extends Middleware
             'password_policy' => app(PasswordPolicy::class)->descriptor(),
             'pending' => $this->pendingCounts($request),
             'update_notice' => $this->updateNotice($request),
+            'code_notice' => $this->codeNotice($request),
             'locale' => app()->getLocale(),
             // The clock this viewer reads dates by, and whether it is a
             // choice or a fallback. The frontend needs both: the first to
@@ -215,6 +217,28 @@ class HandleInertiaRequests extends Middleware
         return $release === null
             ? null
             : [...$release, 'install_kind' => app(Installation::class)->kind()->value];
+    }
+
+    /**
+     * Whether this process is running the code the installation was last
+     * updated to — see RunningCodeState for the failure it catches.
+     *
+     * Gated on view_system_info rather than manage_updates: the latter is
+     * edition-gated (Capability::SystemUpdates), and a server executing
+     * code that does not match its own database is not a feature anyone
+     * buys, it is a fact about the machine.
+     *
+     * @return array{reason: string, applied: string, running: string, applied_at: string, install_kind: string}|null
+     */
+    protected function codeNotice(Request $request): ?array
+    {
+        $user = $request->user();
+
+        if ($user === null || ! app(PermissionChecker::class)->allows($user, Permission::ViewSystemInfo)) {
+            return null;
+        }
+
+        return app(RunningCodeState::class)->current();
     }
 
     /**

--- a/app/Modules/Platform/PlatformServiceProvider.php
+++ b/app/Modules/Platform/PlatformServiceProvider.php
@@ -23,6 +23,7 @@ use App\Modules\Platform\Theming\Console\GenerateThemePreviewDataCommand;
 use App\Modules\Platform\Theming\EmailThemeRegistry;
 use App\Modules\Platform\Theming\PublicThemeRegistry;
 use App\Modules\Platform\Updates\Console\CheckForUpdatesCommand;
+use App\Modules\Platform\Updates\Console\UpdateCommand;
 use Illuminate\Console\Events\ScheduledTaskFailed;
 use Illuminate\Console\Events\ScheduledTaskFinished;
 use Illuminate\Notifications\Channels\MailChannel;
@@ -71,6 +72,7 @@ class PlatformServiceProvider extends ServiceProvider
             $this->commands([
                 GenerateThemePreviewDataCommand::class,
                 CheckForUpdatesCommand::class,
+                UpdateCommand::class,
                 FetchNewsCommand::class,
                 DisableCaptchaCommand::class,
                 TestCaptchaCommand::class,

--- a/app/Modules/Platform/Settings/Setting.php
+++ b/app/Modules/Platform/Settings/Setting.php
@@ -232,6 +232,22 @@ enum Setting: string
     case LatestReleaseUrl = 'latest_release_url';
     case LatestReleasePublishedAt = 'latest_release_published_at';
 
+    // The version `projectsend:update` last brought this database in line
+    // with — written by that command only, never by a settings form.
+    //
+    // Its whole purpose is to be compared against config('projectsend.version')
+    // as read by the *web* process, which is not the same number when a
+    // manual install replaced its files and never reloaded PHP-FPM: OPcache
+    // keeps serving the code it compiled before the update, silently, while
+    // artisan reports the new version to the person trying to work out why.
+    // See RunningCodeState.
+    //
+    // Written downwards as well as upwards, because the command runs on
+    // every container boot and on every update.sh run — including the ones
+    // that go backwards.
+    case AppliedVersion = 'applied_version';
+    case AppliedVersionAt = 'applied_version_at';
+
     // Cached result of the last dashboard news feed fetch — never written
     // directly by a settings form, only by FetchNewsCommand. Both editions
     // see this (unlike CheckForUpdates above, which is Community-only);
@@ -280,6 +296,8 @@ enum Setting: string
             self::LatestReleaseNotes,
             self::LatestReleaseUrl,
             self::LatestReleasePublishedAt,
+            self::AppliedVersion,
+            self::AppliedVersionAt,
             self::NewsLastFetchedAt,
             self::CaptchaProvider,
             self::CaptchaKeySource,
@@ -402,6 +420,11 @@ enum Setting: string
             self::LatestReleaseNotes => '',
             self::LatestReleaseUrl => '',
             self::LatestReleasePublishedAt => '',
+            // Empty means no update has ever been applied through the
+            // command — a fresh install, or one that predates it. Never a
+            // notice, in either direction.
+            self::AppliedVersion => '',
+            self::AppliedVersionAt => '',
             self::NewsLastFetchedAt => '',
 
             self::NewsItems => [],

--- a/app/Modules/Platform/Updates/Console/UpdateCommand.php
+++ b/app/Modules/Platform/Updates/Console/UpdateCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Updates\Console;
+
+use App\Modules\Platform\Installation\Installation;
+use App\Modules\Platform\Installation\InstallationKind;
+use App\Modules\Platform\Updates\UpdateInstallation;
+use Illuminate\Console\Command;
+
+/**
+ * Bring this installation in line with the code that is on disk.
+ *
+ * No options, deliberately: the container entrypoints, update.sh and an
+ * administrator typing it all invoke the identical string, which is what
+ * makes "one definition of an update" true rather than aspirational.
+ * UpdateInstallation holds the sequence and the reasoning.
+ */
+class UpdateCommand extends Command
+{
+    protected $signature = 'projectsend:update';
+
+    protected $description = 'Bring the database, roles and caches in line with the installed code (idempotent; run on every boot)';
+
+    public function handle(UpdateInstallation $update, Installation $installation): int
+    {
+        $result = $update->run($this->output);
+
+        if (! $result['ok']) {
+            foreach ($result['warnings'] as $warning) {
+                $this->error($warning);
+            }
+
+            return self::FAILURE;
+        }
+
+        $this->info('System roles are in place.');
+
+        if ($result['cleared'] !== []) {
+            $this->info('Cleared the compiled configuration, events, routes and views.');
+        }
+
+        if ($result['rewarmed'] !== []) {
+            $this->info('Rebuilt the route, event and view caches — they were in place before.');
+        }
+
+        $this->info('Asked the background workers to restart.');
+
+        foreach ($result['warnings'] as $warning) {
+            $this->warn($warning);
+        }
+
+        $this->newLine();
+        $this->info($this->summary($result['from'], $result['to']));
+
+        // A container is replaced rather than reloaded, and its operator
+        // has no systemd to reload anything with — printing this there
+        // would send them looking for a service that does not exist.
+        if ($installation->kind() === InstallationKind::Manual) {
+            $this->newLine();
+            $this->warn('The web server is still running the code it compiled before this ran.');
+            $this->warn('Reload PHP-FPM now, or it will keep serving it:  sudo systemctl reload php8.4-fpm');
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function summary(string $from, string $to): string
+    {
+        if ($from === '') {
+            return "Applied {$to}.";
+        }
+
+        if ($from === $to) {
+            return "Re-applied {$to}.";
+        }
+
+        return "Updated from {$from} to {$to}.";
+    }
+}

--- a/app/Modules/Platform/Updates/RunningCodeState.php
+++ b/app/Modules/Platform/Updates/RunningCodeState.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Updates;
+
+use App\Modules\Platform\Installation\Installation;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+
+/**
+ * Whether the code this process is executing is the code the installation
+ * was last brought in line with.
+ *
+ * It exists because of a failure with no symptom. On a server with OPcache
+ * set the way production guides recommend — `validate_timestamps=0`, which
+ * this project's own image ships — replacing the files changes nothing for
+ * the running site: PHP never re-reads a file it has already compiled. The
+ * database ends up on the new version while every visitor is served the
+ * old code, and `php artisan` reports the new version throughout, because
+ * a fresh CLI process compiles the new files. Nothing errors. The only
+ * outward sign is behaviour that quietly does not match the release notes.
+ *
+ * `projectsend:update` records the version it applied, and this compares
+ * that against what *this* process compiled. The two answers differ in
+ * both directions, and both are worth saying:
+ *
+ *   applied > running  — files were updated, PHP was never reloaded.
+ *   applied < running  — new files are in place and the update never ran,
+ *                        so the schema is behind the code.
+ *
+ * Not gated on an edition. `manage_updates` maps to a Community-only
+ * capability, but what code a server is executing is not a feature — it is
+ * a fact about the machine, which is what view_system_info governs.
+ */
+class RunningCodeState
+{
+    public function __construct(
+        private readonly Settings $settings,
+        private readonly Installation $installation,
+    ) {}
+
+    /**
+     * @return array{reason: string, applied: string, running: string, applied_at: string, install_kind: string}|null
+     */
+    public function current(): ?array
+    {
+        $applied = $this->settings->get(Setting::AppliedVersion);
+        $running = (string) config('projectsend.version');
+
+        // No update has ever been applied through the command: a fresh
+        // install, or one older than the command itself. Nothing to say in
+        // either direction.
+        if (! is_string($applied) || $applied === '' || $running === '') {
+            return null;
+        }
+
+        $reason = match (true) {
+            version_compare($applied, $running, '>') => 'stale_code',
+            version_compare($applied, $running, '<') => 'pending_update',
+            default => null,
+        };
+
+        if ($reason === null) {
+            return null;
+        }
+
+        $appliedAt = $this->settings->get(Setting::AppliedVersionAt);
+
+        return [
+            'reason' => $reason,
+            'applied' => $applied,
+            'running' => $running,
+            'applied_at' => is_string($appliedAt) ? $appliedAt : '',
+            'install_kind' => $this->installation->kind()->value,
+        ];
+    }
+}

--- a/app/Modules/Platform/Updates/UpdateInstallation.php
+++ b/app/Modules/Platform/Updates/UpdateInstallation.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Updates;
+
+use App\Modules\Identity\Permissions\EnsureSystemRoles;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Facades\Artisan;
+use Throwable;
+
+/**
+ * Everything that has to happen after new code lands, and that the
+ * application can do to itself.
+ *
+ * One definition, three callers: the two container entrypoints run it on
+ * every boot, and update.sh runs it after unpacking a release on a server
+ * somebody administers by hand. Before this existed the sequence was
+ * written out in five places — both entrypoints, INSTALL.md, UPDATE.md and
+ * a code block in the dashboard — and they had already drifted: only the
+ * documents mentioned the queue, only the container relinked storage, and
+ * none of them agreed on which caches to clear.
+ *
+ * The order is the design. Each constraint below cost something to find:
+ *
+ *   - migrate first, because everything after it assumes tables exist;
+ *   - queue:restart last, because it writes its signal *into the cache*,
+ *     so anything that clears the cache afterwards deletes the signal and
+ *     leaves a worker running the old code forever;
+ *   - the caches are cleared one command at a time rather than through
+ *     optimize:clear, which also runs cache:clear — and Laravel's Redis
+ *     cache store implements that as FLUSHDB. On the default config the
+ *     cache sits on its own database and that is harmless; on a managed
+ *     Redis offering one database, or any install that pointed cache and
+ *     sessions at the same one, an update would sign every user out and
+ *     delete the queue. Nothing here needs the data cache dropped:
+ *     Settings::set() already forgets its own key, and cached values whose
+ *     shape changes get a new key. A human who suspects a stale value has
+ *     `php artisan cache:clear`, which UPDATE.md points at.
+ *
+ * What it deliberately does not do is maintenance mode. `php artisan down`
+ * writes storage/framework/maintenance.php, and in the official image
+ * storage/ is the persisted volume — a container that died between `down`
+ * and `up` would come back down, and stay down through every recreation.
+ * update.sh owns maintenance mode, where a trap can guarantee the site
+ * comes back. This is why the command is safe to run on every boot.
+ */
+class UpdateInstallation
+{
+    public function __construct(
+        private readonly Application $app,
+        private readonly EnsureSystemRoles $roles,
+        private readonly Settings $settings,
+    ) {}
+
+    /**
+     * @return array{
+     *     from: string,
+     *     to: string,
+     *     migrated: bool,
+     *     cleared: list<string>,
+     *     rewarmed: list<string>,
+     *     warnings: list<string>,
+     *     ok: bool,
+     * }
+     */
+    public function run(?OutputStyle $output = null): array
+    {
+        $running = (string) config('projectsend.version');
+
+        $result = [
+            'from' => '',
+            'to' => $running,
+            'migrated' => false,
+            'cleared' => [],
+            'rewarmed' => [],
+            'warnings' => [],
+            'ok' => false,
+        ];
+
+        // Caught rather than left to surface as a stack trace: the most
+        // likely failure here is a database that is unreachable or refusing
+        // the credentials, and forty frames of Laravel internals is a worse
+        // answer to that than one sentence naming it.
+        try {
+            $migrated = $this->artisan('migrate', ['--force' => true], $output) === 0;
+        } catch (Throwable $exception) {
+            $result['warnings'][] = 'The database migration failed: '.$exception->getMessage();
+            $result['warnings'][] = 'Nothing else was changed.';
+
+            return $result;
+        }
+
+        if (! $migrated) {
+            $result['warnings'][] = 'The database migration failed. Nothing else was changed.';
+
+            return $result;
+        }
+
+        $result['migrated'] = true;
+        $result['from'] = $this->previouslyApplied();
+
+        $this->roles->ensure();
+
+        // Not parity with the old entrypoint line — a fix. The release zip
+        // ships no public/storage symlink (the build refuses symlinks
+        // outright, they do not survive zipping), so an installation that
+        // followed UPDATE.md's "unpack beside it and swap the directories"
+        // advice loses the link entirely, and nothing in the documented
+        // sequence ever put it back.
+        $this->artisan('storage:link', ['--force' => true], $output);
+
+        // Read before anything is cleared: this is the only moment the
+        // question "was this installation using the optional caches?" can
+        // still be answered.
+        $warm = $this->warmCaches();
+
+        foreach (['config:clear', 'clear-compiled', 'event:clear', 'route:clear', 'view:clear'] as $command) {
+            if ($this->artisan($command, [], $output) === 0) {
+                $result['cleared'][] = $command;
+            }
+        }
+
+        if ($warm['config']) {
+            $result['warnings'][] = 'A cached configuration was found and cleared. Do not run config:cache on this'
+                .' application — it stops TRUSTED_PROXIES from being read at all. See INSTALL.md.';
+        }
+
+        foreach ($this->cachesToRewarm($warm) as $command) {
+            // A route table that will not compile is a slower site; a
+            // failed update is a broken one. Never fatal.
+            if ($this->artisan($command, [], $output) === 0) {
+                $result['rewarmed'][] = $command;
+
+                continue;
+            }
+
+            $result['warnings'][] = "{$command} failed, so that cache is not in place. The site runs without it.";
+        }
+
+        $this->settings->set(Setting::AppliedVersion, $running);
+        $this->settings->set(Setting::AppliedVersionAt, now()->toIso8601String());
+
+        // Last, and after every cache operation above — see the class
+        // docblock. A worker only learns to exit by reading this signal.
+        $this->artisan('queue:restart', [], $output);
+
+        $result['ok'] = true;
+
+        return $result;
+    }
+
+    /**
+     * What the previous run of this recorded, or '' when there was none.
+     *
+     * Swallows failures on purpose: by this point the schema is current,
+     * but a cache store that is momentarily unreachable must not fail a
+     * container boot over a line of reporting.
+     */
+    private function previouslyApplied(): string
+    {
+        try {
+            $applied = $this->settings->get(Setting::AppliedVersion);
+
+            return is_string($applied) ? $applied : '';
+        } catch (Throwable) {
+            return '';
+        }
+    }
+
+    /**
+     * Which optional caches this installation had in place.
+     *
+     * Asked through the framework's own path accessors rather than the
+     * filenames: `routes-v7.php` is an internal that changes with major
+     * versions. And by file_exists() rather than $app->routesAreCached(),
+     * which memoises at bootstrap and would still answer true after
+     * route:clear ran in this same process.
+     *
+     * @return array{route: bool, event: bool, config: bool}
+     */
+    protected function warmCaches(): array
+    {
+        return [
+            'route' => file_exists($this->app->getCachedRoutesPath()),
+            'event' => file_exists($this->app->getCachedEventsPath()),
+            'config' => file_exists($this->app->getCachedConfigPath()),
+        ];
+    }
+
+    /**
+     * Views have no honest signal of their own — storage/framework/views
+     * fills up from ordinary traffic, cached deliberately or not. So the
+     * route and event caches stand in for the set: their presence means
+     * this installation followed INSTALL.md's "Making it faster", which
+     * lists all three together. A container caches none of them and so
+     * rebuilds nothing, which keeps boot as fast as it is today.
+     *
+     * config:cache is never rebuilt, at any time, for any installation.
+     *
+     * @param  array{route: bool, event: bool, config: bool}  $warm
+     * @return list<string>
+     */
+    private function cachesToRewarm(array $warm): array
+    {
+        if (! $warm['route'] && ! $warm['event']) {
+            return [];
+        }
+
+        return ['route:cache', 'event:cache', 'view:cache'];
+    }
+
+    /**
+     * Protected so a test can watch the sequence without running it. The
+     * ordering constraints in run() are invisible in its result and
+     * catastrophic when wrong, and an ordered list of calls is the only
+     * thing that can assert them.
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    protected function artisan(string $command, array $parameters = [], ?OutputStyle $output = null): int
+    {
+        return Artisan::call($command, $parameters, $output);
+    }
+}

--- a/docker/app/entrypoint.sh
+++ b/docker/app/entrypoint.sh
@@ -23,9 +23,10 @@ chown -R www-data:www-data storage/app/uploads-tmp storage/framework storage/log
 # First-boot bootstrap runs only for the FPM service (the worker execs
 # straight through) and only when the app is actually installed.
 if [ "$1" = "php-fpm" ] && [ -f vendor/autoload.php ]; then
-    su-exec www-data php artisan migrate --force
-    su-exec www-data php artisan storage:link --force
-    su-exec www-data php artisan projectsend:ensure-roles
+    # The same command the official image and update.sh run — migrate,
+    # roles, storage link, compiled caches, workers. See
+    # UpdateInstallation; there is deliberately only one definition of it.
+    su-exec www-data php artisan projectsend:update
 
     # Unattended provisioning: create the first administrator from the
     # environment. Without these, the web setup screen prompts instead.

--- a/docker/production/entrypoint.sh
+++ b/docker/production/entrypoint.sh
@@ -70,9 +70,13 @@ if [ "$1" = "supervisord" ] || [ "$1" = "/usr/bin/supervisord" ]; then
         sleep 1
     done
 
-    su-exec www-data php artisan migrate --force
-    su-exec www-data php artisan storage:link --force
-    su-exec www-data php artisan projectsend:ensure-roles
+    # One command, shared with update.sh and with the dev image: migrate,
+    # ensure the roles, relink storage, clear the compiled caches, restart
+    # the workers, record the version applied. See UpdateInstallation for
+    # why the order is what it is, and why maintenance mode is not part of
+    # it (`artisan down` would write its flag onto this container's
+    # persisted storage volume and outlive the container that wrote it).
+    su-exec www-data php artisan projectsend:update
 
     # Unattended provisioning: create the first administrator from the
     # environment. Without these, the web setup screen prompts instead.
@@ -82,10 +86,6 @@ if [ "$1" = "supervisord" ] || [ "$1" = "/usr/bin/supervisord" ]; then
             --email="$ADMIN_EMAIL" \
             --password="$ADMIN_PASSWORD"
     fi
-
-    # Cheap and safe to repeat; keeps a restarted container from serving
-    # stale compiled views after an image upgrade.
-    su-exec www-data php artisan view:clear
 fi
 
 exec "$@"

--- a/resources/js/components/code-notice-banner.tsx
+++ b/resources/js/components/code-notice-banner.tsx
@@ -1,0 +1,85 @@
+import { usePage } from '@inertiajs/react';
+import { AlertTriangle } from 'lucide-react';
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { useTranslation } from '@/hooks/use-translation';
+import { type SharedData } from '@/types';
+
+/**
+ * Says out loud that this server is not running the code it was updated
+ * to — the one update failure that has no other symptom.
+ *
+ * With OPcache configured the way production guides recommend, replacing
+ * the files and reloading nothing leaves the database on the new version
+ * and every visitor on the old code, indefinitely and without an error
+ * anywhere. `projectsend:update` records what it applied; this compares it
+ * with what the process rendering this page actually compiled.
+ *
+ * Deliberately on every staff page rather than the dashboard alone: the
+ * person who missed the reload has no reason to suspect anything, so the
+ * notice has to find them rather than wait to be visited.
+ */
+export function CodeNoticeBanner() {
+    const { t } = useTranslation();
+    const { code_notice: notice } = usePage<SharedData>().props;
+
+    if (!notice) {
+        return null;
+    }
+
+    const container = notice.install_kind === 'container';
+
+    // Stated as a fact first, cause second. A deliberate rollback lands
+    // here too, and telling somebody to reload PHP-FPM when they meant to
+    // go back a version would send them the wrong way.
+    const title =
+        notice.reason === 'stale_code'
+            ? t('This server is running version :running, but version :applied is installed', {
+                  running: notice.running,
+                  applied: notice.applied,
+              })
+            : t('Version :running is installed, but the update has not been run', { running: notice.running });
+
+    return (
+        <Alert variant={notice.reason === 'stale_code' ? 'destructive' : 'warning'}>
+            <AlertTriangle className="size-4" />
+            <AlertTitle>{title}</AlertTitle>
+            <AlertDescription className="space-y-2">
+                {notice.reason === 'stale_code' ? (
+                    <>
+                        <p>
+                            {container
+                                ? t('The database was updated to :applied, and this container is still running the code it started with.', {
+                                      applied: notice.applied,
+                                  })
+                                : t(
+                                      'The database was updated to :applied, and PHP is still serving the code it had compiled before that. Reloading it clears this notice.',
+                                      { applied: notice.applied },
+                                  )}
+                        </p>
+                        <Command>{container ? 'docker compose up -d --force-recreate' : 'sudo systemctl reload php8.4-fpm'}</Command>
+                        {!container && (
+                            <p className="text-xs">
+                                {t('If you rolled back on purpose, run php artisan projectsend:update so the database matches the code you restored.')}
+                            </p>
+                        )}
+                    </>
+                ) : (
+                    <>
+                        <p>
+                            {t(
+                                'New files are in place, but the database has only been brought up to :applied. Until the update runs, this installation is running code its database does not match.',
+                                { applied: notice.applied },
+                            )}
+                        </p>
+                        <Command>{container ? 'docker compose up -d --force-recreate' : 'sudo ./update.sh'}</Command>
+                    </>
+                )}
+            </AlertDescription>
+        </Alert>
+    );
+}
+
+function Command({ children }: { children: string }) {
+    return <code className="bg-background/60 inline-block rounded px-2 py-1 font-mono text-xs">{children}</code>;
+}

--- a/resources/js/components/update-instructions.tsx
+++ b/resources/js/components/update-instructions.tsx
@@ -14,14 +14,15 @@ export type InstallKind = 'container' | 'manual';
  * have, for a stack they are not using, at the exact moment they were trying
  * to do the right thing.
  *
- * `compact` is for the dashboard card, a narrow column beside other widgets:
- * the manual sequence is seven lines and would swamp it, so there it points
- * at the dialog, which has the room. `codeClassName` exists for the same
- * caller — its code sits inside a warning alert and has to match it.
+ * `compact` is for the dashboard card, a narrow column beside other widgets.
+ * `codeClassName` exists for the same caller — its code sits inside a warning
+ * alert and has to match it.
  *
- * The full manual sequence is deliberately the whole thing, backup included.
- * It is the order INSTALL.md gives, and the step people skip is the one that
- * matters: migrations move forwards, not backwards.
+ * This used to print the whole nine-command sequence, which was a third copy
+ * of something that also lived in INSTALL.md and UPDATE.md and had already
+ * drifted from both. It is now one script, and the reason it can be is that
+ * projectsend:update owns every part of an update that does not need root —
+ * see UpdateInstallation.
  */
 export function UpdateInstructions({
     kind,
@@ -45,27 +46,25 @@ export function UpdateInstructions({
     if (compact) {
         return (
             <p className="text-muted-foreground">
-                {t('To update, follow the steps in INSTALL.md — back up first, then unpack the release and run the migrations.')}
+                {t('To update, run sudo ./update.sh in the install directory — it asks before it downloads or changes anything.')}
             </p>
         );
     }
 
     return (
         <>
-            <p className="text-muted-foreground mb-1">{t('To update, back up your database and files, then:')}</p>
+            <p className="text-muted-foreground mb-1">{t('To update, run this in the install directory:')}</p>
             <code className={cn('block rounded px-2 py-1.5 whitespace-pre-wrap', codeClassName ?? 'bg-muted')}>
                 {[
-                    'php artisan down',
-                    '# unpack the new release over this directory, keeping .env and storage/',
-                    'php artisan migrate --force',
-                    'php artisan projectsend:ensure-roles',
-                    'php artisan optimize:clear',
-                    'php artisan queue:restart',
-                    '# reload PHP-FPM, or OPcache keeps serving the old code',
-                    'php artisan up',
+                    'cd /var/www/projectsend',
+                    'sudo ./update.sh',
                 ].join('\n')}
             </code>
-            <p className="text-muted-foreground mt-1 text-xs">{t('Run these as the user your web server runs as. INSTALL.md has the full procedure.')}</p>
+            <p className="text-muted-foreground mt-1 text-xs">
+                {t(
+                    'It asks before checking for a release, before downloading one, and before touching your installation — and verifies the checksum of what it downloads. UPDATE.md has the full procedure.',
+                )}
+            </p>
         </>
     );
 }

--- a/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -2,6 +2,7 @@ import { AppContent } from '@/components/app-content';
 import { AppShell } from '@/components/app-shell';
 import { AppSidebar } from '@/components/app-sidebar';
 import { AppSidebarHeader } from '@/components/app-sidebar-header';
+import { CodeNoticeBanner } from '@/components/code-notice-banner';
 import { Toaster } from '@/components/toaster';
 import { type BreadcrumbItem } from '@/types';
 
@@ -11,6 +12,13 @@ export default function AppSidebarLayout({ children, breadcrumbs = [] }: { child
             <AppSidebar />
             <AppContent variant="sidebar">
                 <AppSidebarHeader breadcrumbs={breadcrumbs} />
+                {/* Renders nothing unless this process is running code the
+                    installation was not updated to — see RunningCodeState.
+                    Here rather than on the dashboard because the person it
+                    is for has no reason to go looking. */}
+                <div className="px-6 pt-4 empty:hidden md:px-4">
+                    <CodeNoticeBanner />
+                </div>
                 {children}
             </AppContent>
             <Toaster />

--- a/resources/js/pages/system/settings/general.tsx
+++ b/resources/js/pages/system/settings/general.tsx
@@ -121,7 +121,7 @@ export default function SystemSettings({
                             </div>
                             <p className="text-muted-foreground text-sm">
                                 {t(
-                                    "Periodically checks projectsend.org's public repository for a newer release and shows a notice on the dashboard. Nothing is ever downloaded or applied automatically.",
+                                    "Periodically checks projectsend.org's public repository for a newer release and shows a notice on the dashboard. Nothing is ever downloaded or applied automatically — updating is always something you run, and the update script asks before each step.",
                                 )}
                             </p>
                         </div>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -107,6 +107,21 @@ export interface SharedData {
         /** Decides which upgrade instructions the dialog prints. */
         install_kind: InstallKind;
     } | null;
+    /**
+     * Set when the code this process is running is not the code the
+     * installation was last updated to — see RunningCodeState. Almost
+     * always a PHP-FPM that was never reloaded after an update, which is
+     * otherwise completely silent.
+     */
+    code_notice: {
+        reason: 'stale_code' | 'pending_update';
+        /** What the last update applied. */
+        applied: string;
+        /** What this process compiled. */
+        running: string;
+        applied_at: string;
+        install_kind: InstallKind;
+    } | null;
     locale: string;
     /**
      * The IANA zone this viewer reads dates in — their own preference, or

--- a/tests/Feature/Platform/StaleCodeNoticeTest.php
+++ b/tests/Feature/Platform/StaleCodeNoticeTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Identity\Models\Role;
+use App\Modules\Identity\Permissions\SystemRole;
+use App\Modules\Platform\Capabilities\Edition;
+use App\Modules\Platform\Installation\Installation;
+use App\Modules\Platform\Installation\InstallationKind;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+
+/**
+ * There is no way to be in a container and not in one within a single test
+ * run, so the detection is answered for — same seam and same reasoning as
+ * InstallationKindTest's own fake.
+ */
+class NoticeInstallation extends Installation
+{
+    public function __construct(private readonly bool $container) {}
+
+    protected function inContainer(): bool
+    {
+        return $this->container;
+    }
+}
+
+function applied(string $version): void
+{
+    app(Settings::class)->set(Setting::AppliedVersion, $version);
+    app(Settings::class)->set(Setting::AppliedVersionAt, now()->toIso8601String());
+}
+
+/**
+ * The shared prop as the page would receive it. Read out of the root
+ * view's data rather than through assertInertia's callback, because most
+ * of these assert the notice's *absence* — and a callback that never runs
+ * proves nothing.
+ *
+ * @return array<string, string>|null
+ */
+function noticeFor(User $user): ?array
+{
+    $page = test()->actingAs($user)
+        ->get('/dashboard')
+        ->assertSuccessful()
+        ->viewData('page');
+
+    return $page['props']['code_notice'] ?? null;
+}
+
+beforeEach(function () {
+    $this->admin = User::factory()->create();
+    config()->set('projectsend.version', '2.1.0');
+});
+
+test('nothing is said when the applied version is the running one', function () {
+    applied('2.1.0');
+
+    expect(noticeFor($this->admin))->toBeNull();
+});
+
+test('nothing is said on an installation that has never applied an update', function () {
+    expect(app(Settings::class)->get(Setting::AppliedVersion))->toBe('')
+        ->and(noticeFor($this->admin))->toBeNull();
+});
+
+// The failure this exists for: files replaced, PHP never reloaded, so the
+// database is ahead of the code every visitor is being served.
+test('an applied version ahead of the running code reports stale code', function () {
+    applied('2.2.0');
+
+    $notice = noticeFor($this->admin);
+
+    expect($notice)->not->toBeNull()
+        ->and($notice['reason'])->toBe('stale_code')
+        ->and($notice['applied'])->toBe('2.2.0')
+        ->and($notice['running'])->toBe('2.1.0');
+});
+
+// The other half of the same mistake: new files unpacked, the update never
+// run, so the schema is behind the code.
+test('an applied version behind the running code reports a pending update', function () {
+    applied('2.0.0');
+
+    expect(noticeFor($this->admin)['reason'])->toBe('pending_update');
+});
+
+test('it is gated on view_system_info', function () {
+    applied('2.2.0');
+
+    $uploader = User::factory()->create([
+        'role_id' => Role::query()->where('name', SystemRole::AccountManager->value)->value('id'),
+    ]);
+
+    expect(noticeFor($uploader))->toBeNull()
+        ->and(noticeFor($this->admin))->not->toBeNull();
+})->skip(fn (): bool => Role::query()->where('name', SystemRole::AccountManager->value)->doesntExist(), 'needs the seeded roles');
+
+// Unlike update_notice, which is edition-gated: what code a server is
+// executing is a fact about the machine, not a feature of an edition.
+test('it is not gated on the edition', function () {
+    config()->set('projectsend.edition', Edition::Cloud);
+    applied('2.2.0');
+
+    expect(noticeFor($this->admin))->not->toBeNull();
+});
+
+test('it names the command this kind of installation can actually run', function (bool $container, string $expected) {
+    app()->instance(Installation::class, new NoticeInstallation($container));
+    applied('2.2.0');
+
+    expect(noticeFor($this->admin)['install_kind'])->toBe($expected);
+})->with([
+    'a container' => [true, InstallationKind::Container->value],
+    'a server somebody administers' => [false, InstallationKind::Manual->value],
+]);
+
+// The rollback story, asserted end to end: whatever the marker said, the
+// command rewrites it to whatever is actually running.
+test('running the update clears the notice', function () {
+    applied('2.2.0');
+    expect(noticeFor($this->admin))->not->toBeNull();
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect(noticeFor($this->admin))->toBeNull();
+});

--- a/tests/Feature/Platform/UpdateCommandTest.php
+++ b/tests/Feature/Platform/UpdateCommandTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Modules\Identity\Permissions\SystemRole;
+use App\Modules\Identity\Models\Role;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+use App\Modules\Platform\Updates\UpdateInstallation;
+use Illuminate\Console\OutputStyle;
+
+/**
+ * The ordering constraints inside UpdateInstallation are invisible in its
+ * result and expensive when wrong — a queue:restart before a cache clear
+ * leaves a worker on old code indefinitely, and config:cache breaks
+ * TRUSTED_PROXIES silently. An ordered list of the commands it ran is the
+ * only thing that can assert them, so the artisan call is a seam.
+ */
+class RecordingUpdate extends UpdateInstallation
+{
+    /** @var list<string> */
+    public array $calls = [];
+
+    /** @var array<string, int> */
+    public array $exitCodes = [];
+
+    /** @var array{route: bool, event: bool, config: bool} */
+    public array $warm = ['route' => false, 'event' => false, 'config' => false];
+
+    protected function artisan(string $command, array $parameters = [], ?OutputStyle $output = null): int
+    {
+        $this->calls[] = $command;
+
+        return $this->exitCodes[$command] ?? 0;
+    }
+
+    protected function warmCaches(): array
+    {
+        return $this->warm;
+    }
+}
+
+/**
+ * @param  array{route?: bool, event?: bool, config?: bool}  $warm
+ * @param  array<string, int>  $exitCodes
+ */
+function recordingUpdate(array $warm = [], array $exitCodes = []): RecordingUpdate
+{
+    $fake = new RecordingUpdate(
+        app(Illuminate\Contracts\Foundation\Application::class),
+        app(App\Modules\Identity\Permissions\EnsureSystemRoles::class),
+        app(Settings::class),
+    );
+
+    $fake->warm = [...$fake->warm, ...$warm];
+    $fake->exitCodes = $exitCodes;
+
+    app()->instance(UpdateInstallation::class, $fake);
+
+    return $fake;
+}
+
+test('it migrates, ensures roles, links storage and restarts the queue', function () {
+    $fake = recordingUpdate();
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect($fake->calls)->toContain('migrate', 'storage:link', 'queue:restart')
+        ->and(array_search('migrate', $fake->calls, true))->toBe(0);
+});
+
+// queue:restart writes its signal into the cache. Anything that clears the
+// cache afterwards deletes it, and the worker keeps running the old code
+// with nothing to show for it.
+test('queue:restart is the last thing it does', function () {
+    $fake = recordingUpdate();
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect(array_key_last($fake->calls))->toBe(array_search('queue:restart', $fake->calls, true));
+});
+
+// config:cache stops TRUSTED_PROXIES from being read at all — see
+// INSTALL.md. Nothing in an update may ever put one in place.
+test('it never caches the configuration', function () {
+    $fake = recordingUpdate(['config' => true]);
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect($fake->calls)->toContain('config:clear')
+        ->and($fake->calls)->not->toContain('config:cache');
+});
+
+// Laravel's Redis cache store implements cache:clear as FLUSHDB, which on
+// a single-database Redis takes the sessions and the queue with it.
+test('it does not flush the application cache', function () {
+    $fake = recordingUpdate();
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect($fake->calls)->not->toContain('cache:clear')
+        ->and($fake->calls)->not->toContain('optimize:clear');
+});
+
+test('it rebuilds only the caches that were in place beforehand', function (array $warm, array $expected) {
+    $fake = recordingUpdate($warm);
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    $rebuilt = array_values(array_filter($fake->calls, fn (string $call): bool => str_ends_with($call, ':cache')));
+
+    expect($rebuilt)->toBe($expected);
+})->with([
+    'nothing cached — a container, or an install that never optimised' => [[], []],
+    'routes only' => [['route' => true], ['route:cache', 'event:cache', 'view:cache']],
+    'events only' => [['event' => true], ['route:cache', 'event:cache', 'view:cache']],
+    'both' => [['route' => true, 'event' => true], ['route:cache', 'event:cache', 'view:cache']],
+]);
+
+test('a failed migration stops everything and records nothing', function () {
+    $fake = recordingUpdate([], ['migrate' => 1]);
+
+    $this->artisan('projectsend:update')->assertFailed();
+
+    expect($fake->calls)->toBe(['migrate'])
+        ->and(app(Settings::class)->get(Setting::AppliedVersion))->toBe('');
+});
+
+// A route file that will not compile leaves a slower site. Failing the
+// update over it would leave a broken one.
+test('a cache that will not rebuild is a warning, not a failure', function () {
+    recordingUpdate(['route' => true], ['route:cache' => 1]);
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect(app(Settings::class)->get(Setting::AppliedVersion))->toBe(config('projectsend.version'));
+});
+
+test('it records the version it applied', function () {
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect(app(Settings::class)->get(Setting::AppliedVersion))->toBe(config('projectsend.version'))
+        ->and(app(Settings::class)->get(Setting::AppliedVersionAt))->not->toBe('');
+});
+
+// The real thing, not the seam: both entrypoints run this on every boot,
+// so a second run has to be as uneventful as the first.
+test('running it twice is uneventful', function () {
+    $this->artisan('projectsend:update')->assertSuccessful();
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect(app(Settings::class)->get(Setting::AppliedVersion))->toBe(config('projectsend.version'));
+});
+
+// Not through the seam: this is the one assertion that the real wiring
+// runs, and EnsureSystemRoles is the part of an update that a migration
+// cannot do for itself. AccountManager rather than Uploader — the latter
+// is legacy and deliberately never seeded.
+test('it puts back a system role somebody deleted', function () {
+    Role::query()->where('name', SystemRole::AccountManager->value)->delete();
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect(Role::query()->where('name', SystemRole::AccountManager->value)->exists())->toBeTrue();
+});
+
+// The two shell files are the one place the sequence could quietly grow a
+// second definition again, and nothing else in the suite would notice.
+test('both container entrypoints run the command rather than their own sequence', function () {
+    foreach (['docker/production/entrypoint.sh', 'docker/app/entrypoint.sh'] as $entrypoint) {
+        $contents = file_get_contents(base_path($entrypoint));
+
+        expect($contents)->toContain('projectsend:update')
+            ->and($contents)->not->toContain('projectsend:ensure-roles')
+            ->and($contents)->not->toContain('migrate --force');
+    }
+});

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,628 @@
+#!/usr/bin/env bash
+#
+# Updates a ProjectSend installation that runs from files on a server —
+# the release-zip path in INSTALL.md, not the Docker one.
+#
+# It replaces a sequence of nine commands, of which one (reloading PHP-FPM)
+# is silently fatal to skip: with OPcache set the way production guides
+# recommend, PHP never re-reads a file it has already compiled, so the
+# database ends up updated while every visitor is still served the old
+# code — and `php artisan` reports the new version throughout.
+#
+# What it will not do is decide anything for you. It asks before checking
+# GitHub, asks before downloading, verifies the checksum of what it
+# downloaded, and asks whether you have a backup before it touches a
+# single file. The application itself still never downloads or applies
+# anything: this runs when you run it.
+#
+# Usage:
+#   sudo ./update.sh                      # ask what is available, then apply it
+#   sudo ./update.sh --zip ~/ps-2.1.0.zip # apply a zip you already have
+#   ./update.sh --check                   # only report; changes nothing, needs no root
+#
+set -euo pipefail
+
+REPO_API="https://api.github.com/repos/projectsend/projectsend/releases/latest"
+RELEASES_PAGE="https://github.com/projectsend/projectsend/releases"
+
+ZIP=""
+CHECK_ONLY=0
+ASSUME_YES=0
+FORCE=0
+BACKUP=0
+HAVE_BACKUP=0
+NO_RESTART=0
+KEEP_DOWNLOAD=0
+WEB_USER=""
+FPM_SERVICE=""
+WORKER_SERVICE=""
+BACKUP_DIR="/var/backups/projectsend"
+DOWNLOAD_DIR=""
+
+usage() {
+    cat <<'USAGE'
+Usage: sudo ./update.sh [options]
+
+  With no options it asks whether to check GitHub for a newer release,
+  whether to download it, and whether you have a backup — then applies it.
+
+  --zip <path>        Apply this release zip instead of asking about a
+                      download. You fetch it; this never downloads a file
+                      you did not ask for.
+  --check             Report the installed and latest versions and stop.
+                      Changes nothing and does not need root.
+  --backup            Dump the database before applying anything.
+  --backup-dir <dir>  Where dumps go. Default: /var/backups/projectsend
+  --i-have-a-backup   Skip the backup question (for unattended runs).
+  --force             Apply a zip older than what is installed, or one
+                      whose version cannot be read. Migrations do not roll
+                      back; this is not a casual flag.
+  --user <name>       The user the web server runs as. Default: whoever
+                      owns public/index.php.
+  --php-fpm <unit>    PHP-FPM service to reload. Default: detected.
+  --worker <unit>     Queue worker service to restart. Default:
+                      projectsend-worker.service, if it exists.
+  --no-restart        Do not touch systemd. You are then responsible for
+                      reloading PHP-FPM; until you do, ProjectSend shows
+                      your staff a banner saying so.
+  --download-dir <d>  Where a downloaded zip goes. Default: a temp dir.
+  --keep-download     Keep the downloaded zip after a successful update.
+  -y, --yes           Answer yes to every question. Requires --backup or
+                      --i-have-a-backup, so an unattended run cannot
+                      quietly skip both.
+  -h, --help          This.
+USAGE
+}
+
+say()  { printf '==> %s\n' "$*"; }
+note() { printf '    %s\n' "$*"; }
+warn() { printf '\033[33m    %s\033[0m\n' "$*" >&2; }
+fail() { printf '\033[31m%s\033[0m\n' "$*" >&2; exit 1; }
+
+# Prompts read from the terminal rather than stdin: this script may be
+# piped or run from a wrapper, and a question nobody can answer would
+# otherwise be answered by whatever happened to be on stdin.
+ask() {
+    local prompt="$1" default="$2" reply
+
+    # --yes means yes to everything, not "take the default" — the two
+    # questions whose default is No are precisely the ones an unattended
+    # run still has to clear. That is why --yes is only accepted alongside
+    # --backup or --i-have-a-backup.
+    if [[ "$ASSUME_YES" == "1" ]]; then
+        printf '%s y\n' "$prompt"
+
+        return 0
+    fi
+
+    if [[ ! -r /dev/tty ]]; then
+        fail "No terminal to ask '$prompt'. Pass --yes (and --backup or --i-have-a-backup) for an unattended run."
+    fi
+
+    read -r -p "$prompt " reply < /dev/tty || true
+    reply="${reply:-$default}"
+
+    [[ "${reply,,}" == "y" || "${reply,,}" == "yes" ]]
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --zip)              ZIP="${2:-}"; shift 2 ;;
+            --check)            CHECK_ONLY=1; shift ;;
+            --backup)           BACKUP=1; shift ;;
+            --backup-dir)       BACKUP_DIR="${2:-}"; shift 2 ;;
+            --i-have-a-backup)  HAVE_BACKUP=1; shift ;;
+            --force)            FORCE=1; shift ;;
+            --user)             WEB_USER="${2:-}"; shift 2 ;;
+            --php-fpm)          FPM_SERVICE="${2:-}"; shift 2 ;;
+            --worker)           WORKER_SERVICE="${2:-}"; shift 2 ;;
+            --no-restart)       NO_RESTART=1; shift ;;
+            --download-dir)     DOWNLOAD_DIR="${2:-}"; shift 2 ;;
+            --keep-download)    KEEP_DOWNLOAD=1; shift ;;
+            -y|--yes)           ASSUME_YES=1; shift ;;
+            -h|--help)          usage; exit 0 ;;
+            *) usage >&2; echo >&2; echo "Unknown option: $1" >&2; exit 2 ;;
+        esac
+    done
+
+    if [[ -n "$ZIP" && "$ZIP" =~ ^https?:// ]]; then
+        usage >&2
+        echo >&2
+        echo "--zip takes a file, not a URL. Run without --zip and answer yes to the download question, or fetch it yourself first." >&2
+        exit 2
+    fi
+
+    if [[ "$ASSUME_YES" == "1" && "$BACKUP" == "0" && "$HAVE_BACKUP" == "0" && "$CHECK_ONLY" == "0" ]]; then
+        fail "--yes needs either --backup (take one now) or --i-have-a-backup (you already did). An unattended update must not skip both."
+    fi
+}
+
+# The version literal, read without booting PHP: config/projectsend.php
+# references an application enum, so it cannot simply be required.
+#
+# `| head -1` is deliberately absent from these pipelines. Under
+# `set -o pipefail` head closes the pipe as soon as it has its line, the
+# process feeding it dies of SIGPIPE, and the whole command substitution
+# then reports failure — intermittently, depending on whether the producer
+# finished first. Taking the first line in bash afterwards has no such race.
+first_line() {
+    printf '%s' "${1%%$'\n'*}"
+}
+
+version_in_file() {
+    first_line "$(sed -n "s/^ *'version' *=> *'\([^']*\)'.*/\1/p" "$1" || true)"
+}
+
+version_in_zip() {
+    first_line "$(unzip -p "$1" config/projectsend.php 2>/dev/null | sed -n "s/^ *'version' *=> *'\([^']*\)'.*/\1/p" || true)"
+}
+
+# Compares the numeric cores only. GNU sort -V puts 2.1.0-rc.1 *after*
+# 2.1.0, which is backwards for SemVer, so a prerelease is never compared
+# here — the caller refuses that case instead.
+version_newer() {
+    local a="${1%%-*}" b="${2%%-*}"
+    [[ "$a" != "$b" ]] && [[ "$(printf '%s\n%s\n' "$a" "$b" | sort -V | tail -1)" == "$a" ]]
+}
+
+in_container() {
+    [[ -f /.dockerenv || -f /run/.containerenv ]]
+}
+
+resolve_install_dir() {
+    # After the re-exec below this script no longer lives in the install,
+    # so the directory is passed through the environment instead.
+    if [[ -n "${PROJECTSEND_UPDATE_DIR:-}" ]]; then
+        INSTALL_DIR="$PROJECTSEND_UPDATE_DIR"
+    else
+        INSTALL_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+    fi
+
+    for required in artisan public/index.php config/projectsend.php; do
+        [[ -e "$INSTALL_DIR/$required" ]] \
+            || fail "$INSTALL_DIR does not look like a ProjectSend installation ($required is missing). Run this from the install directory."
+    done
+}
+
+# Runs before anything can overwrite this file. The release zip contains
+# update.sh, step "Replace the files" writes it, and bash reads its own
+# script lazily by byte offset — it would carry on executing whatever
+# happened to be at that offset in the new file.
+reexec_from_copy() {
+    [[ "${PROJECTSEND_UPDATE_REEXEC:-}" == "1" ]] && return 0
+
+    local self
+    # Template ends in X's with no suffix: busybox mktemp rejects
+    # anything after them, and the official image is Alpine.
+    self="$(mktemp "${TMPDIR:-/tmp}/projectsend-update-XXXXXX")"
+    cp -- "${BASH_SOURCE[0]}" "$self"
+
+    export PROJECTSEND_UPDATE_REEXEC=1 PROJECTSEND_UPDATE_DIR="$INSTALL_DIR" PROJECTSEND_UPDATE_SELF="$self"
+    exec bash "$self" "$@"
+}
+
+latest_release() {
+    command -v curl >/dev/null 2>&1 || { warn "curl is not installed, so this cannot check for a release."; return 1; }
+
+    local body
+    body="$(curl -fsS --max-time 10 -H 'User-Agent: ProjectSend' "$REPO_API" 2>/dev/null)" || {
+        warn "Could not reach GitHub. Look at $RELEASES_PAGE yourself, then re-run with --zip."
+        return 1
+    }
+
+    LATEST_VERSION="$(first_line "$(printf '%s' "$body" | sed -n 's/.*"tag_name" *: *"v\{0,1\}\([^"]*\)".*/\1/p' || true)")"
+    LATEST_URL="$(first_line "$(printf '%s' "$body" | tr ',' '\n' | sed -n 's/.*"browser_download_url" *: *"\([^"]*projectsend-[0-9][^"]*\.zip\)".*/\1/p' || true)")"
+
+    # v1's tags are still an r-number scheme on that repository, and
+    # comparing 2.0.1 with r2098 is meaningless — the same guard
+    # CheckForUpdatesCommand applies.
+    if [[ ! "$LATEST_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+        warn "The latest tag ($LATEST_VERSION) is not a version this can compare. See $RELEASES_PAGE."
+        return 1
+    fi
+
+    return 0
+}
+
+download_release() {
+    local target="$1"
+
+    say "Downloading $(basename "$LATEST_URL")"
+    curl -fL --progress-bar -o "$target" "$LATEST_URL" || fail "The download failed. Nothing has been changed."
+
+    # Published beside the zip by the release process. Its absence is worth
+    # saying out loud rather than passing over quietly.
+    # -L, like the download above: GitHub redirects release assets to
+    # object storage, and without it curl cheerfully saves the redirect
+    # body and reports success.
+    if curl -fsSL --max-time 30 -o "$target.sha256" "$LATEST_URL.sha256" 2>/dev/null; then
+        say "Verifying the checksum"
+
+        # Compared by hand rather than with `sha256sum -c`: GNU spells the
+        # quiet flag --status and busybox spells it -s, and the official
+        # image is busybox. Comparing two strings needs neither.
+        local expected actual
+        expected="$(first_line "$(cat "$target.sha256")")"
+        expected="${expected%% *}"
+        actual="$(sha256sum "$target" | awk '{print $1}')"
+
+        [[ -n "$expected" && "$expected" == "$actual" ]] \
+            || fail "Checksum mismatch on $target.
+  expected: ${expected:-<none published>}
+  got:      $actual
+That is not the file this release published. It has been left in place for you to look at."
+
+        note "Checksum matches."
+    else
+        warn "No .sha256 was published beside this release, so the download could not be verified."
+        ask "Continue with an unverified download? [y/N]" "n" || fail "Stopped. Nothing has been changed."
+    fi
+}
+
+detect_web_user() {
+    if [[ -z "$WEB_USER" ]]; then
+        WEB_USER="$(stat -c '%U' "$INSTALL_DIR/public/index.php" 2>/dev/null || echo www-data)"
+    fi
+
+    id -u "$WEB_USER" >/dev/null 2>&1 || fail "No such user: $WEB_USER. Pass --user with the account your web server runs as."
+    WEB_GROUP="$(id -gn "$WEB_USER")"
+}
+
+as_web_user() {
+    if command -v runuser >/dev/null 2>&1; then
+        ( cd "$INSTALL_DIR" && runuser -u "$WEB_USER" -- "$@" )
+    else
+        ( cd "$INSTALL_DIR" && su -s /bin/sh "$WEB_USER" -c "$(printf '%q ' "$@")" )
+    fi
+}
+
+detect_services() {
+    command -v systemctl >/dev/null 2>&1 || { SYSTEMD=0; return 0; }
+    SYSTEMD=1
+
+    if [[ -z "$FPM_SERVICE" ]]; then
+        local candidates
+        candidates="$(systemctl list-unit-files --no-legend --type=service 'php*fpm*.service' 2>/dev/null | awk '{print $1}')"
+
+        case "$(printf '%s' "$candidates" | grep -c . || true)" in
+            0) FPM_SERVICE="" ;;
+            1) FPM_SERVICE="$candidates" ;;
+            *)
+                FPM_SERVICE="$(first_line "$(printf '%s\n' "$candidates" | while read -r unit; do
+                    systemctl is-active --quiet "$unit" && echo "$unit"
+                done || true)")"
+                ;;
+        esac
+
+        if [[ -z "$FPM_SERVICE" ]]; then
+            warn "Could not work out which PHP-FPM service to reload. Pass --php-fpm <unit>, or reload it yourself afterwards."
+        fi
+    fi
+
+    if [[ -z "$WORKER_SERVICE" ]]; then
+        local worker
+        worker="$(systemctl list-unit-files --no-legend 'projectsend-worker.service' 2>/dev/null || true)"
+
+        # An `[[ ... ]] && assignment` here would be the function's last
+        # command, so a missing worker unit would return 1 and take the
+        # whole script down with it under `set -e`.
+        if [[ -n "$worker" ]]; then
+            WORKER_SERVICE="projectsend-worker.service"
+        fi
+    fi
+
+    return 0
+}
+
+env_value() {
+    local raw
+    raw="$(first_line "$(sed -n "s/^$1=//p" "$INSTALL_DIR/.env" 2>/dev/null || true)")"
+    raw="${raw%\"}"; raw="${raw#\"}"
+    raw="${raw%\'}"; raw="${raw#\'}"
+
+    printf '%s' "$raw"
+}
+
+take_backup() {
+    local connection database host port user password stamp target
+    connection="$(env_value DB_CONNECTION)"; connection="${connection:-mysql}"
+    database="$(env_value DB_DATABASE)"
+    host="$(env_value DB_HOST)"; host="${host:-127.0.0.1}"
+    port="$(env_value DB_PORT)"; port="${port:-3306}"
+    user="$(env_value DB_USERNAME)"
+    password="$(env_value DB_PASSWORD)"
+    stamp="$(date -u +%Y%m%d-%H%M%S)"
+
+    [[ "$BACKUP_DIR" == "$INSTALL_DIR/public"* ]] && fail "Refusing to write a database dump under public/ — it would be downloadable."
+
+    mkdir -p "$BACKUP_DIR"
+    chmod 700 "$BACKUP_DIR"
+
+    case "$connection" in
+        mysql|mariadb)
+            target="$BACKUP_DIR/projectsend-$INSTALLED_VERSION-$stamp.sql"
+            say "Dumping the database to $target"
+            # Password through the environment: an argument would be
+            # readable in `ps` by every user on the machine.
+            MYSQL_PWD="$password" mysqldump --single-transaction --routines --triggers \
+                -h "$host" -P "$port" -u "$user" "$database" > "$target" \
+                || fail "The database dump failed. Nothing has been changed — fix this, or re-run without --backup once you have a backup of your own."
+            ;;
+        pgsql)
+            target="$BACKUP_DIR/projectsend-$INSTALLED_VERSION-$stamp.sql"
+            say "Dumping the database to $target"
+            PGPASSWORD="$password" pg_dump -h "$host" -p "$port" -U "$user" "$database" > "$target" \
+                || fail "The database dump failed. Nothing has been changed."
+            ;;
+        sqlite)
+            target="$BACKUP_DIR/projectsend-$INSTALLED_VERSION-$stamp.sqlite"
+            say "Copying the database to $target"
+            cp -- "$database" "$target" || fail "Could not copy the SQLite database. Nothing has been changed."
+            ;;
+        *)
+            fail "Unknown DB_CONNECTION '$connection' — take a backup yourself and re-run with --i-have-a-backup."
+            ;;
+    esac
+
+    BACKUP_TAKEN="$target"
+    note "This is the database only. Your uploaded files in storage/app/files/ are not in it."
+}
+
+cleanup() {
+    local status=$?
+
+    if [[ "${SITE_IS_DOWN:-0}" == "1" ]]; then
+        as_web_user php artisan up >/dev/null 2>&1 || true
+        SITE_IS_DOWN=0
+    fi
+
+    [[ -n "${TMP_DIR:-}" && -d "${TMP_DIR:-}" ]] && rm -rf "$TMP_DIR"
+    [[ -n "${PROJECTSEND_UPDATE_SELF:-}" && -f "${PROJECTSEND_UPDATE_SELF:-}" ]] && rm -f "$PROJECTSEND_UPDATE_SELF"
+
+    if [[ "$status" != "0" && "${APPLYING:-0}" == "1" ]]; then
+        echo >&2
+        warn "The update did not finish."
+        warn "The site has been taken out of maintenance mode, but its files may be part-way updated."
+        [[ -n "${BACKUP_TAKEN:-}" ]] && warn "Your database dump is at $BACKUP_TAKEN."
+
+        # Skipped when the failure already printed instructions of its own,
+        # so the operator is never given two different sets at once.
+        if [[ "${RECOVERY_PRINTED:-0}" != "1" ]]; then
+            warn "To finish by hand:  cd $INSTALL_DIR && sudo -u $WEB_USER php artisan projectsend:update"
+            [[ -n "${FPM_SERVICE:-}" ]] && warn "Then reload PHP:    sudo systemctl reload $FPM_SERVICE"
+        fi
+    fi
+
+    exit $status
+}
+
+report_versions() {
+    note "Installed: $INSTALLED_VERSION"
+
+    if latest_release; then
+        if version_newer "$LATEST_VERSION" "$INSTALLED_VERSION"; then
+            note "Latest:    $LATEST_VERSION"
+            echo
+            note "Read the changelog for $LATEST_VERSION first, and make sure you have a backup."
+            if in_container; then
+                note "This is a container, so its code comes from its image:"
+                note "  docker compose pull && docker compose up -d"
+            else
+                note "Then:  sudo ./update.sh"
+            fi
+        else
+            note "Latest:    $LATEST_VERSION — you are up to date."
+            note "Re-applying the same release with --zip restores files that were modified or lost."
+        fi
+    fi
+}
+
+main() {
+    parse_args "$@"
+    resolve_install_dir
+
+    INSTALLED_VERSION="$(version_in_file "$INSTALL_DIR/config/projectsend.php")"
+    [[ -n "$INSTALLED_VERSION" ]] || INSTALLED_VERSION="unknown"
+
+    if [[ "$CHECK_ONLY" == "1" ]]; then
+        say "ProjectSend at $INSTALL_DIR"
+        report_versions
+        exit 0
+    fi
+
+    if in_container; then
+        note "Installed: $INSTALLED_VERSION"
+        echo
+        fail "This is a container: its code comes from its image, and replacing files inside it would be undone by the next recreate.
+Update it with:  docker compose pull && docker compose up -d"
+    fi
+
+    [[ "$EUID" -eq 0 ]] || fail "This needs root, to reload PHP-FPM and to write files owned by the web server user. Run: sudo ./update.sh"
+
+    reexec_from_copy "$@"
+
+    trap cleanup EXIT INT TERM
+
+    say "ProjectSend at $INSTALL_DIR"
+
+    # ---- what to apply -------------------------------------------------
+    if [[ -z "$ZIP" ]]; then
+        note "Installed: $INSTALLED_VERSION"
+
+        if ask "Check GitHub for a newer release? [Y/n]" "y" && latest_release; then
+            note "Latest:    $LATEST_VERSION"
+
+            if ! version_newer "$LATEST_VERSION" "$INSTALLED_VERSION"; then
+                note "You are already on the latest release."
+                ask "Download and re-apply $LATEST_VERSION anyway, to restore modified files? [y/N]" "n" \
+                    || { note "Nothing to do."; exit 0; }
+            fi
+
+            if ask "Download $(basename "$LATEST_URL") and verify its checksum? [Y/n]" "y"; then
+                DOWNLOAD_DIR="${DOWNLOAD_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/projectsend-download.XXXXXX")}"
+                mkdir -p "$DOWNLOAD_DIR"
+                ZIP="$DOWNLOAD_DIR/$(basename "$LATEST_URL")"
+                download_release "$ZIP"
+            else
+                note "Download it yourself, then run:"
+                note "  sudo ./update.sh --zip $(basename "$LATEST_URL")"
+                note "  $LATEST_URL"
+                exit 0
+            fi
+        fi
+    fi
+
+    [[ -n "$ZIP" ]] || fail "Nothing to apply. Pass --zip <file>, or re-run and let it fetch the release."
+    [[ -f "$ZIP" ]] || fail "No such file: $ZIP"
+
+    # ---- is it sane, and is it forwards? -------------------------------
+    NEW_VERSION="$(version_in_zip "$ZIP")"
+
+    if [[ -z "$NEW_VERSION" ]]; then
+        [[ "$FORCE" == "1" ]] || fail "Could not read a version out of $ZIP. If you are sure it is a ProjectSend release, re-run with --force."
+        NEW_VERSION="unknown"
+    fi
+
+    # `unzip -p` rather than parsing a listing: it answers "is this exact
+    # entry there" on both Info-ZIP and busybox, and it involves no pipe —
+    # `unzip -l | grep -q` looks equivalent but is not, because grep -q
+    # closes the pipe, unzip takes SIGPIPE, and pipefail then reports a
+    # perfectly good zip as broken.
+    for entry in artisan public/index.php vendor/autoload.php; do
+        unzip -p "$ZIP" "$entry" >/dev/null 2>&1 \
+            || fail "$ZIP has no $entry at its root — that is not a ProjectSend release zip.
+If it unpacks into a folder of its own, this is not the file we publish; use the one from $RELEASES_PAGE."
+    done
+
+    if unzip -p "$ZIP" '.env' >/dev/null 2>&1; then
+        fail "$ZIP contains a .env. A release zip never does; refusing to overwrite your configuration."
+    fi
+
+    if [[ "$NEW_VERSION" != "unknown" && "$NEW_VERSION" != "$INSTALLED_VERSION" ]] && ! version_newer "$NEW_VERSION" "$INSTALLED_VERSION"; then
+        [[ "$FORCE" == "1" ]] || fail "$ZIP is version $NEW_VERSION and this installation is on $INSTALLED_VERSION.
+Migrations only move forwards — there is no command that undoes them. To go back, restore the database dump you took before updating.
+If you know what you are doing, re-run with --force."
+    fi
+
+    detect_web_user
+    detect_services
+
+    # ---- the backup question -------------------------------------------
+    if [[ "$HAVE_BACKUP" == "0" && "$BACKUP" == "0" ]]; then
+        if ! ask "Have you backed up the database and your files? [y/N]" "n"; then
+            warn "An update that goes wrong can lose data, and a migration cannot be undone."
+            ask "Continue anyway? [y/N]" "n" || fail "Stopped. Nothing has been changed."
+
+            if ask "Take a database dump now? [Y/n]" "y"; then
+                BACKUP=1
+            else
+                warn "Continuing without a backup, at your own risk."
+            fi
+        fi
+    fi
+
+    # ---- confirm --------------------------------------------------------
+    echo
+    say "About to update this installation"
+    note "Directory:  $INSTALL_DIR"
+    note "Version:    $INSTALLED_VERSION -> $NEW_VERSION"
+    note "Zip:        $ZIP"
+    note "As user:    $WEB_USER"
+    [[ "$BACKUP" == "1" ]] && note "Backup:     yes, to $BACKUP_DIR"
+    if [[ "$NO_RESTART" == "1" || "${SYSTEMD:-0}" == "0" ]]; then
+        note "Restart:    nothing (you must reload PHP-FPM yourself)"
+    else
+        note "Restart:    ${FPM_SERVICE:-<none found>}${WORKER_SERVICE:+, $WORKER_SERVICE}"
+    fi
+    echo
+
+    ask "Proceed? [y/N]" "n" || fail "Stopped. Nothing has been changed."
+
+    APPLYING=1
+
+    [[ "$BACKUP" == "1" ]] && take_backup
+
+    # ---- apply ----------------------------------------------------------
+    say "Putting the site into maintenance mode"
+    as_web_user php artisan down --retry=60 >/dev/null
+    SITE_IS_DOWN=1
+
+    say "Unpacking $ZIP"
+    TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/projectsend-unpack.XXXXXX")"
+    unzip -q "$ZIP" -d "$TMP_DIR"
+
+    # Belt and braces. The zip has no storage/ content and no .env, but
+    # this is the copy that could destroy somebody's library, so it is
+    # made structurally impossible rather than merely unlikely.
+    rm -rf "$TMP_DIR/storage" "$TMP_DIR/.env"
+
+    say "Replacing the application files"
+    # vendor/ and public/build/ belong wholly to the release: merged, they
+    # keep orphaned classes and orphaned hashed assets from the old one.
+    rm -rf "$INSTALL_DIR/vendor" "$INSTALL_DIR/public/build"
+    rm -f "$INSTALL_DIR"/bootstrap/cache/*.php
+    cp -a "$TMP_DIR"/. "$INSTALL_DIR"/
+
+    chown -R "$WEB_USER:$WEB_GROUP" "$INSTALL_DIR"
+    chmod -R u+rwX "$INSTALL_DIR/storage" "$INSTALL_DIR/bootstrap/cache"
+
+    say "Bringing the installation in line with the new code"
+
+    # The command comes from the code that was just unpacked, so a release
+    # older than this script does not have it. Only reachable by re-applying
+    # or forcing an old release — but the error Symfony prints for an unknown
+    # command is a list of thirteen unrelated ones, which is no help at all
+    # to somebody whose site is in maintenance mode.
+    local commands
+    commands="$(as_web_user php artisan list --raw --no-ansi 2>/dev/null || true)"
+
+    if [[ "$commands" != *"projectsend:update"* ]]; then
+        # The generic recovery block in cleanup() would otherwise name the
+        # very command this release does not have.
+        RECOVERY_PRINTED=1
+        fail "The release you unpacked ($NEW_VERSION) predates this update script: it has no projectsend:update command.
+Finish it by hand, as $WEB_USER:
+  php artisan migrate --force
+  php artisan projectsend:ensure-roles
+  php artisan optimize:clear
+  php artisan queue:restart
+Then reload PHP-FPM, and bring the site back with: php artisan up"
+    fi
+
+    as_web_user php artisan projectsend:update
+
+    # ---- restart --------------------------------------------------------
+    if [[ "$NO_RESTART" == "1" ]]; then
+        warn "Not touching systemd, as asked."
+        warn "PHP is still running the old code until you reload it — ProjectSend will keep telling your staff so."
+    elif [[ "${SYSTEMD:-0}" == "1" && -n "${FPM_SERVICE:-}" ]]; then
+        say "Reloading $FPM_SERVICE"
+        systemctl reload "$FPM_SERVICE" 2>/dev/null || systemctl restart "$FPM_SERVICE" \
+            || warn "Could not reload $FPM_SERVICE. Do it yourself, or PHP keeps serving the old code."
+
+        if [[ -n "${WORKER_SERVICE:-}" ]]; then
+            say "Restarting $WORKER_SERVICE"
+            systemctl restart "$WORKER_SERVICE" || warn "Could not restart $WORKER_SERVICE."
+        fi
+    else
+        warn "No PHP-FPM service was found to reload. Reload PHP yourself now, or it keeps serving the old code."
+    fi
+
+    say "Bringing the site back up"
+    as_web_user php artisan up >/dev/null
+    SITE_IS_DOWN=0
+
+    if [[ "$KEEP_DOWNLOAD" == "0" && -n "${DOWNLOAD_DIR:-}" && "$ZIP" == "$DOWNLOAD_DIR"/* ]]; then
+        rm -rf "$DOWNLOAD_DIR"
+    fi
+
+    APPLYING=0
+
+    echo
+    say "ProjectSend $NEW_VERSION is installed and running."
+    [[ -n "${BACKUP_TAKEN:-}" ]] && note "Database dump: $BACKUP_TAKEN"
+    note "Check the dashboard's System card, then System -> Settings -> Scheduler, then download a file."
+}
+
+main "$@"


### PR DESCRIPTION
Updating a server install cost nine artisan invocations plus a PHP-FPM reload, written out in three places that had already drifted. One of those steps is silently fatal to skip: with `opcache.validate_timestamps=0` the database moves to the new version while every visitor keeps being served the old code — and `artisan` reports the new version throughout.

## What ships

**`sudo ./update.sh`** — the whole manual procedure. It asks whether to check GitHub, asks whether to download the release and **verifies the checksum published beside it**, and asks whether you have a backup, offering to dump the database when the answer is no. Then: maintenance mode, replace files, update, reload PHP-FPM, restart the worker, back up. `--check` reports without touching anything; `--zip` applies a file you fetched yourself.

The application still has no self-updater — nothing is fetched or applied unless somebody runs this and answers yes. The settings screen's promise is unchanged and now says so explicitly.

**`php artisan projectsend:update`** — everything an update does that needs no root, and now the *only* definition of it. Both container entrypoints call it instead of carrying their own copy, so the two paths cannot drift again. A test asserts that.

**A banner for the reload nobody remembers.** The command records the version it applied; any staff page compares that against what the running process actually compiled. The same check catches the mirror image — new files in place, update never run.

## Three findings, all from rehearsing rather than reasoning

- **`queue:restart` has to come last.** It writes its signal *into the cache*, so clearing the cache afterwards deletes it and the worker runs old code indefinitely.
- **`optimize:clear` is not safe to recommend** — which the old docs did. It runs `cache:clear`, and Laravel's Redis store implements that as `FLUSHDB`: harmless on the default two-database layout, but on a single-database Redis it takes the sessions and the queue with it. The compiled caches are now cleared individually.
- **`update.sh` overwrites itself mid-run**, because the release zip contains it and bash reads its own script lazily by byte offset. It re-execs from a temp copy before touching anything.

Plus a handful of portability bugs the rehearsal caught that reading never would: busybox `mktemp` rejecting a suffix after the X's, busybox `sha256sum` having no `--status`, `curl` without `-L` saving GitHub's redirect body as the checksum, and two `set -e`/`pipefail` traps (`grep -q` closing a pipe, and a function ending in `[[ … ]] && …`).

## Verified

- **Container upgrade**, real images: 69 → 73 migrations applied on boot, `APP_KEY` and data intact, healthy, marker written.
- **Scripted update** on a real nginx + php-fpm install with OPcache pinned: the *web process* moved 2.1.0 → 2.1.1, `.env`, uploads and `public/storage` untouched.
- **The skipped reload**: `--no-restart` reproduces the stale state, the banner appears naming both versions, and it clears the moment PHP-FPM is reloaded.
- **Refusals**: downgrade without `--force`, a zip with no `artisan` at its root, a truncated zip, a URL passed to `--zip`, running as non-root — each stops before the site goes down.
- **A database taken down mid-update**: one clear sentence instead of forty frames, the site comes out of maintenance mode by itself, no maintenance flag left behind, and recovery instructions that do not contradict each other.
- **A real download** of the published 2.0.0 zip with its checksum verified.
- 1624 Pest tests (+23), PHPStan, `tsc`, ESLint, and `shellcheck` on the script.

New UI strings are English-only until the next `/update-translations` pass, which the release build gates on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)