### PR TITLE
Don't abort an update over a symlink's ownership

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -564,7 +564,16 @@ If you know what you are doing, re-run with --force."
     rm -f "$INSTALL_DIR"/bootstrap/cache/*.php
     cp -a "$TMP_DIR"/. "$INSTALL_DIR"/
 
-    chown -R "$WEB_USER:$WEB_GROUP" "$INSTALL_DIR"
+    # Symlinks are skipped on purpose. A symlink's own ownership decides
+    # nothing — access is governed by whatever it points at — and some
+    # filesystems refuse to change it at all: a bind mount from a host
+    # (public/storage on a developer's box is where this turned up), an NFS
+    # export with root_squash. Aborting an update over a cosmetic detail on
+    # a link is not a trade worth making, so they are left alone rather than
+    # tolerated by ignoring errors that might have mattered.
+    find "$INSTALL_DIR" \! -type l -exec chown "$WEB_USER:$WEB_GROUP" {} + \
+        || warn "Some files could not be given to $WEB_USER. Check ownership under $INSTALL_DIR before trusting this install."
+
     chmod -R u+rwX "$INSTALL_DIR/storage" "$INSTALL_DIR/bootstrap/cache"
 
     say "Bringing the installation in line with the new code"


### PR DESCRIPTION
Found by running `update.sh` on a real manual install rather than by reading it.

`chown -R "$WEB_USER:$WEB_GROUP" "$INSTALL_DIR"` also tries to change the ownership of `public/storage`, which is a symlink. Some filesystems refuse that even for root — it surfaced on a bind-mounted install (a `fakeowner` mount refuses `lchown` outright), and would equally surface on an NFS export with `root_squash`.

The update stopped exactly there: **files replaced, database not yet migrated**, which is the worst place for an update to stop.

```diff
-    chown -R "$WEB_USER:$WEB_GROUP" "$INSTALL_DIR"
+    find "$INSTALL_DIR" \! -type l -exec chown "$WEB_USER:$WEB_GROUP" {} + \
+        || warn "Some files could not be given to $WEB_USER. …"
```

Symlinks are skipped rather than having their errors ignored: a symlink's own ownership decides nothing (access is governed by its target), while an ignored error somewhere that *did* matter would be a silent half-broken install.

Verified on the filesystem where the old form failed — the new one returns 0 — and shellcheck is still clean. The interrupted install recovered by re-running the script, which takes the same-version repair path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)