### PR TITLE
Explain why a non-standard port disappears from every link

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -478,6 +478,21 @@ report the problem on the settings screen instead. If you are stuck anyway, add
 `php artisan projectsend:captcha-off`. Your keys are kept either way. To check a key without
 locking anything, `php artisan projectsend:captcha-test` asks the provider directly.
 
+**Links and redirects drop the port number** (you are served on `:8080`, and the site sends you to
+port 80).
+Recent Debian and Ubuntu nginx packages set `HTTP_HOST` to `$host` in `/etc/nginx/fastcgi_params`,
+deliberately — it stops a client-supplied `Host` header reaching the application — and `$host`
+carries no port. On 80 or 443 that changes nothing. On any other port, every absolute URL the
+application builds loses it. Add this to the `location ~ \.php$` block, **after** `include
+fastcgi_params;`:
+
+```nginx
+fastcgi_param HTTP_HOST $http_host;
+```
+
+On nginx 1.30 and later the safer form is `$host$is_request_port$request_port`. Either way this only
+applies to a non-standard port; behind a TLS proxy on 443 you do not need it.
+
 **Emails and links point at `localhost` or the wrong domain.**
 `APP_URL` in `.env`. Fix it and run `php artisan optimize:clear`.
 


### PR DESCRIPTION
Found on a manual install of our own: the site answered 200 and the browser still got a 404.

Recent Debian and Ubuntu nginx packages set `HTTP_HOST` to `$host` in `/etc/nginx/fastcgi_params`, deliberately — it keeps a client-supplied `Host` header away from the application — and `$host` carries no port. Their own comment says as much: *"Existing deployments that rely on `$http_host` containing a port number may therefore break."*

On 80 and 443 nobody notices. Serve the site on 8185, as our test box does, and every absolute URL the application builds points at port 80: `GET /` returns a perfectly good 302 to `http://localhost/login`, which answers nothing. It reads as ProjectSend being broken rather than as a web server default having changed.

Adds a troubleshooting entry naming the symptom, the cause and the one-line fix (`fastcgi_param HTTP_HOST $http_host;` after the include, or `$host$is_request_port$request_port` on nginx ≥ 1.30), and says plainly that it only applies to a non-standard port.

**The official image is unaffected** — Alpine's `fastcgi_params` has no such override, so nginx passes the Host header with its port intact. Verified both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)