### PR TITLE
Put the update in the activity log

### DIFF
--- a/app/Modules/Audit/Action.php
+++ b/app/Modules/Audit/Action.php
@@ -15,6 +15,7 @@ enum Action: string
     // Platform / lifecycle (v1 action 0: "ProjectSend has been installed")
     case SetupCompleted = 'setup.completed';
     case SettingsUpdated = 'settings.updated';
+    case ApplicationUpdated = 'application.updated';
 
     // Identity
     case Login = 'auth.login';
@@ -142,6 +143,7 @@ enum Action: string
     {
         return match ($this) {
             self::SetupCompleted => 'Installed ProjectSend',
+            self::ApplicationUpdated => 'Updated ProjectSend to :to, from :from',
             self::SettingsUpdated => 'Updated the system settings (:section)',
             self::Login => 'Logged in',
             self::Logout => 'Logged out',
@@ -242,6 +244,7 @@ enum Action: string
     {
         return match ($this) {
             self::SetupCompleted => 'ProjectSend was installed',
+            self::ApplicationUpdated => 'ProjectSend was updated to a new version',
             self::SettingsUpdated => 'System settings were updated',
             self::Login => 'Logged in',
             self::Logout => 'Logged out',

--- a/app/Modules/Platform/Updates/UpdateInstallation.php
+++ b/app/Modules/Platform/Updates/UpdateInstallation.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace App\Modules\Platform\Updates;
 
+use App\Modules\Audit\Action;
+use App\Modules\Audit\ActivityLogger;
 use App\Modules\Identity\Permissions\EnsureSystemRoles;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Throwable;
 
 /**
@@ -54,6 +58,7 @@ class UpdateInstallation
         private readonly Application $app,
         private readonly EnsureSystemRoles $roles,
         private readonly Settings $settings,
+        private readonly ActivityLogger $activity,
     ) {}
 
     /**
@@ -80,6 +85,12 @@ class UpdateInstallation
             'warnings' => [],
             'ok' => false,
         ];
+
+        // Asked before migrating, because afterwards there is no way to tell
+        // a fresh installation from an existing one — and the difference
+        // decides whether this run is an update worth logging or the first
+        // boot of a brand new install.
+        $existingInstall = $this->hasRunMigrationsBefore();
 
         // Caught rather than left to surface as a stack trace: the most
         // likely failure here is a database that is unreachable or refusing
@@ -144,6 +155,12 @@ class UpdateInstallation
         $this->settings->set(Setting::AppliedVersion, $running);
         $this->settings->set(Setting::AppliedVersionAt, now()->toIso8601String());
 
+        $warning = $this->recordTheUpdate($existingInstall, $result['from'], $running);
+
+        if ($warning !== null) {
+            $result['warnings'][] = $warning;
+        }
+
         // Last, and after every cache operation above — see the class
         // docblock. A worker only learns to exit by reading this signal.
         $this->artisan('queue:restart', [], $output);
@@ -151,6 +168,56 @@ class UpdateInstallation
         $result['ok'] = true;
 
         return $result;
+    }
+
+    /**
+     * Put the update in the activity log — the one place an administrator
+     * looks to answer "what changed on this installation, and when".
+     *
+     * Only a genuine version change is recorded. The container entrypoint
+     * runs this on every boot, so logging unconditionally would bury the
+     * log under an entry per restart; and a fresh installation is an
+     * install, not an update, which SetupCompleted already covers.
+     *
+     * "Fresh" is decided by whether migrations had ever run before this
+     * one, rather than by whether a version was recorded: the first update
+     * of any installation older than this command finds no recorded
+     * version, and that update is exactly the one worth logging.
+     */
+    private function recordTheUpdate(bool $existingInstall, string $from, string $to): ?string
+    {
+        if (! $existingInstall || $from === $to) {
+            return null;
+        }
+
+        try {
+            $this->activity->logSystem(Action::ApplicationUpdated, [
+                // Empty whenever the previous version predates this command
+                // — which every installation hits exactly once.
+                'from' => $from !== '' ? $from : 'an unrecorded version',
+                'to' => $to,
+            ]);
+        } catch (Throwable $exception) {
+            // An update that worked must not report failure because its own
+            // paperwork did.
+            return 'The update could not be written to the activity log: '.$exception->getMessage();
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether this database has been migrated before — i.e. whether there
+     * was an installation here at all before this run.
+     */
+    protected function hasRunMigrationsBefore(): bool
+    {
+        try {
+            return Schema::hasTable('migrations') && DB::table('migrations')->exists();
+        } catch (Throwable) {
+            // No database yet is not an existing installation.
+            return false;
+        }
     }
 
     /**

--- a/tests/Feature/Platform/UpdateCommandTest.php
+++ b/tests/Feature/Platform/UpdateCommandTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Modules\Audit\Action;
+use App\Modules\Audit\ActivityLog;
 use App\Modules\Identity\Permissions\SystemRole;
 use App\Modules\Identity\Models\Role;
 use App\Modules\Platform\Settings\Setting;
@@ -27,6 +29,9 @@ class RecordingUpdate extends UpdateInstallation
     /** @var array{route: bool, event: bool, config: bool} */
     public array $warm = ['route' => false, 'event' => false, 'config' => false];
 
+    /** The test database is always migrated, so this cannot be observed for real. */
+    public bool $existingInstall = true;
+
     protected function artisan(string $command, array $parameters = [], ?OutputStyle $output = null): int
     {
         $this->calls[] = $command;
@@ -37,6 +42,11 @@ class RecordingUpdate extends UpdateInstallation
     protected function warmCaches(): array
     {
         return $this->warm;
+    }
+
+    protected function hasRunMigrationsBefore(): bool
+    {
+        return $this->existingInstall;
     }
 }
 
@@ -50,6 +60,7 @@ function recordingUpdate(array $warm = [], array $exitCodes = []): RecordingUpda
         app(Illuminate\Contracts\Foundation\Application::class),
         app(App\Modules\Identity\Permissions\EnsureSystemRoles::class),
         app(Settings::class),
+        app(App\Modules\Audit\ActivityLogger::class),
     );
 
     $fake->warm = [...$fake->warm, ...$warm];
@@ -174,4 +185,58 @@ test('both container entrypoints run the command rather than their own sequence'
             ->and($contents)->not->toContain('projectsend:ensure-roles')
             ->and($contents)->not->toContain('migrate --force');
     }
+});
+
+// An update is exactly the kind of thing the activity log exists for: it is
+// the one place an administrator looks to find out what changed on this
+// installation and when.
+test('it writes the update to the activity log, naming both versions', function () {
+    app(Settings::class)->set(Setting::AppliedVersion, '2.0.0');
+    config()->set('projectsend.version', '2.1.0');
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    $entry = ActivityLog::query()->where('action', Action::ApplicationUpdated)->sole();
+
+    expect($entry->context['from'])->toBe('2.0.0')
+        ->and($entry->context['to'])->toBe('2.1.0')
+        // Nobody's account did this — a scheduled boot or a shell did.
+        ->and($entry->actor_id)->toBeNull();
+});
+
+// The container entrypoint runs this on every start. One log entry per
+// restart would bury everything else in it.
+test('re-running on the same version logs nothing', function () {
+    app(Settings::class)->set(Setting::AppliedVersion, config('projectsend.version'));
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect(ActivityLog::query()->where('action', Action::ApplicationUpdated)->count())->toBe(0);
+});
+
+// The first update of any installation older than this command finds no
+// recorded version — and that update is precisely the one worth logging.
+test('an update from a version that was never recorded is still logged', function () {
+    expect(app(Settings::class)->get(Setting::AppliedVersion))->toBe('');
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    $entry = ActivityLog::query()->where('action', Action::ApplicationUpdated)->sole();
+
+    expect($entry->context['from'])->toBe('an unrecorded version')
+        ->and($entry->context['to'])->toBe(config('projectsend.version'));
+});
+
+// A first boot is an installation, not an update — SetupCompleted already
+// records that, and the container runs this before anybody has installed
+// anything.
+test('a fresh installation logs no update', function () {
+    $fake = recordingUpdate();
+    $fake->existingInstall = false;
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect(ActivityLog::query()->where('action', Action::ApplicationUpdated)->count())->toBe(0)
+        ->and(app(Settings::class)->get(Setting::AppliedVersion))->toBe(config('projectsend.version'));
 });


### PR DESCRIPTION
Reported from a real install: an update ran, and `/activity` said nothing about it.

The activity log is where an administrator goes to answer *what changed on this installation, and when* — and the largest change of all was missing from it. A new version arrived, the schema moved, behaviour changed, and the log recorded a couple of logins.

`projectsend:update` now writes it as a **system** action naming both versions:

> **(system)** — Updated ProjectSend to 2.1.0, from 2.0.1

It shows up in the log's own action filter with no extra work, because that list is built from the `Action` enum.

## Two judgement calls, both in the code's comments

**Only a real version change is logged.** The container entrypoint runs this command on every boot, so logging unconditionally would bury the log under one entry per restart.

**A first boot is an installation, not an update** — `SetupCompleted` already covers that. "First boot" is decided by whether any migration had run *before* this one, rather than by whether a version was recorded: the first update of any installation older than this command finds no recorded version, and that update is exactly the one worth logging. It reads "from an unrecorded version", once, ever.

Writing the entry can't fail the update — an update that worked must not report failure because its own paperwork did.

## Verified

On the manual test install, updated 2.0.2 → 2.0.3 with the real script, then read the rendered page in a browser: **"Updated ProjectSend to 2.0.3, from 2.0.2"**, attributed to the system.

1628 Pest tests (+4 covering: both versions recorded, a same-version re-run logging nothing, an update from an unrecorded version still logged, and a fresh install logging nothing), PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)