### PR TITLE
Say which step is missing instead of failing blankly

### DIFF
--- a/bootstrap/preflight.php
+++ b/bootstrap/preflight.php
@@ -54,9 +54,90 @@ function projectsend_preflight_env(string $key): ?string
  * either null (configured — hand back to Laravel) or a [title, reason, fix]
  * triple describing what to do. No output, no exit — so it is testable.
  *
+ * The order of the three questions is deliberate and not alphabetical:
+ * missing dependencies come first because the fix the configuration branch
+ * prints — `php artisan key:generate` — cannot itself run without the
+ * autoloader, so reporting the key first would earn somebody a second and
+ * more confusing error. Assets come last because a missing key is the more
+ * fundamental problem of the two.
+ *
  * @return array{0: string, 1: string, 2: string}|null
  */
 function projectsend_preflight_failure(string $root): ?array
+{
+    return projectsend_preflight_dependencies_failure($root)
+        ?? projectsend_preflight_configuration_failure($root)
+        ?? projectsend_preflight_assets_failure($root);
+}
+
+/**
+ * Composer has never run here.
+ *
+ * Only reachable from source: a release zip ships vendored, which is the
+ * whole reason INSTALL.md can promise you need neither Composer nor npm on
+ * the server. On a `git clone`, public/index.php requires this file's
+ * absence into a bare fatal on the very next line — no page, no log entry,
+ * nothing to search for. Reported as exactly that by somebody following the
+ * README's old quickstart (#1627).
+ *
+ * @return array{0: string, 1: string, 2: string}|null
+ */
+function projectsend_preflight_dependencies_failure(string $root): ?array
+{
+    if (is_file($root.'/vendor/autoload.php')) {
+        return null;
+    }
+
+    return [
+        'ProjectSend is not installed yet',
+        'The PHP dependencies are missing — there is no <code>vendor/autoload.php</code>. A release '
+            .'zip ships with them already in place; a <code>git clone</code> does not, and installs '
+            .'them as its first step.',
+        "Install the dependencies:
+
+composer install
+
+"
+            .'On the development Docker stack: docker compose exec app composer install',
+    ];
+}
+
+/**
+ * The frontend has never been built.
+ *
+ * `public/hot` counts as built: laravel-vite-plugin writes it while
+ * `npm run dev` is running, and every asset is then served by that dev
+ * server rather than out of public/build. Stopping a developer who has a dev
+ * server running would make this guard worse than the exception it replaces.
+ *
+ * @return array{0: string, 1: string, 2: string}|null
+ */
+function projectsend_preflight_assets_failure(string $root): ?array
+{
+    if (is_file($root.'/public/build/manifest.json') || is_file($root.'/public/hot')) {
+        return null;
+    }
+
+    return [
+        'ProjectSend is not built yet',
+        'The frontend has not been compiled — there is no '
+            .'<code>public/build/manifest.json</code>. A release zip ships it already built; a '
+            .'<code>git clone</code> does not. Without it every page fails while rendering, which '
+            .'is a stack trace rather than an answer.',
+        "Build the frontend:
+
+npm ci
+npm run build",
+    ];
+}
+
+/**
+ * Whether this installation has been configured at all — the original and
+ * most common first-run failure, kept exactly as it was.
+ *
+ * @return array{0: string, 1: string, 2: string}|null
+ */
+function projectsend_preflight_configuration_failure(string $root): ?array
 {
     $appKey = projectsend_preflight_env('APP_KEY');
     $envFile = $root.'/.env';

--- a/compose.yaml
+++ b/compose.yaml
@@ -74,6 +74,11 @@ services:
     volumes:
       - .:/var/www/html
       - ../packages:/var/www/packages
+    # Same reason the worker has one, plus a second: on a fresh clone this
+    # exits until `composer install` has run, and without a restart policy it
+    # then stays exited — scheduled work silently never happens, on the one
+    # setup where nobody would think to check.
+    restart: unless-stopped
     depends_on:
       db:
         condition: service_healthy

--- a/docker/app/entrypoint.sh
+++ b/docker/app/entrypoint.sh
@@ -20,6 +20,23 @@ mkdir -p storage/app/files storage/app/private storage/app/public storage/app/up
 chown www-data:www-data storage storage/app storage/app/files storage/app/private storage/app/public
 chown -R www-data:www-data storage/app/uploads-tmp storage/framework storage/logs bootstrap/cache
 
+# The worker and the scheduler exec straight into artisan, which cannot run
+# without the autoloader — so on a fresh clone, before `composer install`,
+# both died instantly and `restart: unless-stopped` brought them back to die
+# again, once a second, forever. The log that was filling up is the same one
+# somebody needs to read to find out what to do (#1627).
+#
+# Exit rather than wait: this container has nothing useful to do until the
+# dependencies exist, and compose will keep retrying — but slowly enough to
+# leave the log readable, and it recovers on its own the moment they appear.
+if [ "$1" != "php-fpm" ] && [ ! -f vendor/autoload.php ]; then
+    echo "projectsend: the PHP dependencies are not installed — there is no vendor/autoload.php." >&2
+    echo "projectsend: run 'docker compose exec app composer install' (see CONTRIBUTING.md)." >&2
+    sleep 15
+
+    exit 1
+fi
+
 # First-boot bootstrap runs only for the FPM service (the worker execs
 # straight through) and only when the app is actually installed.
 if [ "$1" = "php-fpm" ] && [ -f vendor/autoload.php ]; then

--- a/tests/Unit/PreflightTest.php
+++ b/tests/Unit/PreflightTest.php
@@ -9,8 +9,13 @@ require_once __DIR__.'/../../bootstrap/preflight.php';
 /**
  * A fixture directory, optionally with a .env whose APP_KEY line is $appKey
  * (null = no APP_KEY line at all; '' = present but empty).
+ *
+ * $installed and $built are the two things a release zip ships and a `git
+ * clone` does not — vendored dependencies and a compiled frontend. They are
+ * present by default so that the configuration cases below test only the
+ * thing they name, and each has its own test further down.
  */
-function preflightFixture(?string $appKey, bool $withEnvFile): string
+function preflightFixture(?string $appKey, bool $withEnvFile, bool $installed = true, bool $built = true): string
 {
     $dir = sys_get_temp_dir().'/preflight-'.bin2hex(random_bytes(6));
     mkdir($dir);
@@ -22,6 +27,16 @@ function preflightFixture(?string $appKey, bool $withEnvFile): string
         }
         $lines[] = 'DB_CONNECTION=mysql';
         file_put_contents($dir.'/.env', implode("\n", $lines)."\n");
+    }
+
+    if ($installed) {
+        mkdir($dir.'/vendor');
+        file_put_contents($dir.'/vendor/autoload.php', '<?php');
+    }
+
+    if ($built) {
+        mkdir($dir.'/public/build', 0777, true);
+        file_put_contents($dir.'/public/build/manifest.json', '{}');
     }
 
     return $dir;
@@ -107,4 +122,55 @@ it('lets the real environment override an empty .env key', function (): void {
     putenv('APP_KEY=base64:'.base64_encode(random_bytes(32)));
 
     expect(projectsend_preflight_failure(preflightFixture('', true)))->toBeNull();
+});
+
+// Only reachable from source — a release zip ships vendored. public/index.php
+// requires the autoloader on the line after this guard, so without the check
+// this state is a bare fatal with an empty log (#1627).
+it('fails when Composer has never run', function (): void {
+    $failure = projectsend_preflight_failure(
+        preflightFixture('base64:'.base64_encode(random_bytes(32)), true, installed: false)
+    );
+
+    expect($failure)->not->toBeNull()
+        ->and($failure[0])->toBe('ProjectSend is not installed yet')
+        ->and(projectsend_preflight_command($failure[2]))->toContain('composer install');
+});
+
+// The fix the .env branch prints is `php artisan key:generate`, which cannot
+// run without the autoloader — so telling somebody about the key first would
+// hand them a second, more confusing error.
+it('reports missing dependencies before a missing .env', function (): void {
+    $failure = projectsend_preflight_failure(preflightFixture(null, false, installed: false));
+
+    expect($failure[0])->toBe('ProjectSend is not installed yet');
+});
+
+it('fails when the frontend has never been built', function (): void {
+    $failure = projectsend_preflight_failure(
+        preflightFixture('base64:'.base64_encode(random_bytes(32)), true, built: false)
+    );
+
+    expect($failure)->not->toBeNull()
+        ->and($failure[0])->toBe('ProjectSend is not built yet')
+        ->and(projectsend_preflight_command($failure[2]))->toContain('npm run build');
+});
+
+// laravel-vite-plugin writes public/hot while `npm run dev` runs, and the dev
+// server serves the assets. Blocking a developer mid-session would make this
+// guard worse than the exception it replaces.
+it('treats a running vite dev server as built', function (): void {
+    $dir = preflightFixture('base64:'.base64_encode(random_bytes(32)), true, built: false);
+    mkdir($dir.'/public');
+    file_put_contents($dir.'/public/hot', 'http://localhost:5173');
+
+    expect(projectsend_preflight_failure($dir))->toBeNull();
+});
+
+// A key is the more fundamental problem of the two, and its message is the
+// one that has to survive.
+it('reports a missing APP_KEY before unbuilt assets', function (): void {
+    $failure = projectsend_preflight_failure(preflightFixture('', true, built: false));
+
+    expect($failure[0])->toBe('ProjectSend is not configured yet');
 });


### PR DESCRIPTION
Part one of #1627 — the half that can merge immediately. The documentation half (pointing users at the published image rather than at a clone) follows separately, because it depends on that image existing on Docker Hub.

A user followed the README's Docker quickstart, which starts the **development** stack, and got three failures in a row with nothing to search for. None of them is wrong behaviour for a clone — `vendor/` and `public/build/` are deliberately not in git — but every one kept its cause to itself.

## What changes

**`bootstrap/preflight.php`** answers two more questions. It already exists to turn "this was never set up" into a sentence, and it runs before the autoloader precisely so it can:

- **dependencies not installed** — today `public/index.php` requires the missing autoloader on the very next line: a bare 500, empty log;
- **frontend not built** — today a `ViteManifestNotFoundException` on every page, `/setup` included.

The dependency check goes **first, before the `.env` one**: the fix that branch prints is `php artisan key:generate`, which cannot itself run without the autoloader. A running vite dev server counts as built (`public/hot`), because blocking a developer mid-session would be worse than the exception this replaces.

**`docker/app/entrypoint.sh`** stops the crash-loop. `worker` and `scheduler` exec straight into artisan, so before `composer install` they died instantly and `restart: unless-stopped` brought them back to die again — filling the log somebody had to read to fix it. They now print what is missing, exit slowly, and recover on their own.

**`compose.yaml`** gives the scheduler the restart policy the worker already had. Without one it exits during that window and stays exited, and scheduled work then silently never happens.

## Verified on a real clone

Cloned the public repository fresh and followed the reporter's exact path:

| Stage | Before | Now |
|---|---|---|
| `docker compose up -d` | worker: PHP fatal ~1/second | two restarts in 30s, each printing `composer install (see CONTRIBUTING.md)` |
| open the site | bare 500, nothing logged | 503 **"ProjectSend is not installed yet"**, naming `composer install` |
| after composer install | — | 503 "not configured yet" (correct ordering) |
| after key:generate + migrate | `ViteManifestNotFoundException` | 503 **"ProjectSend is not built yet"**, naming `npm ci && npm run build` |
| after npm run build | — | the setup screen, 200 |

Also confirmed both background services self-heal once dependencies exist, and that a plain clone's `composer install` works for an outsider (community-modules resolves from its public repo, no auth).

1633 Pest tests (+5, and the fixture now creates `vendor/`+manifest by default so the existing cases still test what they name), PHPStan, `tsc`, ESLint, and shellcheck on the entrypoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)