### PR TITLE
Greet the administrator once, on the first visit after an update

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -107,6 +107,11 @@ docker compose logs app | grep -A5 "Running migrations"
 docker compose ps            # the app container should reach "healthy"
 ```
 
+The first time the administrator opens ProjectSend after an update, they land on a page naming the
+version now running and what the release brought, read from `CHANGELOG.md` inside the release
+itself. It appears once, for the account that administers the installation; afterwards it stays
+reachable from **About**, under the version line.
+
 Then open the dashboard: the **System** card's *Version* line is the version now running, and the
 "a new version is available" notice disappears on its own once the running version has caught up —
 it compares against what is installed on every page load, so there is nothing to clear.

--- a/app/Http/Middleware/RedirectToWhatsNew.php
+++ b/app/Http/Middleware/RedirectToWhatsNew.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Modules\Platform\Updates\UpdateWelcome;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Takes the administrator to the welcome page the first time they arrive
+ * after an update.
+ *
+ * Attached to the dashboard alone rather than to the whole web group.
+ * The dashboard is where a login lands and where the sidebar's logo
+ * points, so it catches the arrival either way — including the common
+ * case on a self-hosted server, where the person who ran update.sh was
+ * already signed in and never logs in at all. Applying it to every
+ * request instead would mean intercepting somebody mid-download or
+ * mid-upload to congratulate them, which is a worse trade than missing
+ * an administrator who happens to bookmark /files.
+ */
+class RedirectToWhatsNew
+{
+    public function __construct(private readonly UpdateWelcome $welcome) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        // GET only: a redirect swallows a POST body, and nothing that
+        // writes should ever be answered with a greeting.
+        if ($request->isMethod('GET')) {
+            $user = $request->user();
+
+            if ($user !== null && $this->welcome->isWaitingFor($user)) {
+                return redirect()->route('system.whats-new');
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Modules/Identity/StaffAccounts.php
+++ b/app/Modules/Identity/StaffAccounts.php
@@ -139,6 +139,31 @@ class StaffAccounts
     }
 
     /**
+     * The installation's principal administrator: the oldest active one.
+     *
+     * "Oldest" is the account created first, which on any installation
+     * that went through setup is the person who set it up — and on one
+     * imported from v1, the first administrator that import created.
+     * There is no *flag* for this because the application deliberately has
+     * no owner concept: administrators are equal in authority, and
+     * inventing a superior one to hold this would be a real change to the
+     * permission model in exchange for a greeting.
+     *
+     * Active, so that a founder who has since left the company does not
+     * silently swallow anything addressed here; it moves to the next
+     * administrator instead.
+     */
+    public function mainAdministrator(): ?User
+    {
+        return User::query()
+            ->where('type', UserType::Staff)
+            ->where('active', true)
+            ->whereHas('role', fn ($query) => $query->where('is_administrator', true))
+            ->orderBy('id')
+            ->first();
+    }
+
+    /**
      * How many staff are active administrators right now — used to flag
      * the sole one in the UI so its delete/demote/deactivate controls
      * can be disabled before the server-side guard ever has to fire.

--- a/app/Modules/Platform/Http/Controllers/WhatsNewController.php
+++ b/app/Modules/Platform/Http/Controllers/WhatsNewController.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Modules\Platform\Updates\UpdateWelcome;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * The screen an administrator lands on the first time they open
+ * ProjectSend after an update: what it is now running, an invitation to
+ * the place where the people are, and then what the release actually
+ * brought.
+ *
+ * That order is the design. The thanks and the invitation are for the
+ * person who just did the work — a moment that exists exactly once per
+ * update and is otherwise spent staring at a dashboard that looks
+ * identical to yesterday's. The release notes are underneath because
+ * they are the part that can be read later, or not at all.
+ */
+class WhatsNewController extends Controller
+{
+    public function __construct(private readonly UpdateWelcome $welcome) {}
+
+    public function __invoke(Request $request): Response
+    {
+        $user = $request->user();
+        assert($user !== null);
+
+        // Read before dismissing: everything below describes the update
+        // that the next line forgets.
+        $props = [
+            'version' => $this->welcome->version(),
+            'previousVersion' => $this->welcome->previousVersion(),
+            'justUpdated' => $this->welcome->isFresh(),
+            'releases' => $this->welcome->releases(),
+        ];
+
+        // Only for the person it was addressed to. Another administrator
+        // opening the page from a link is reading, not receiving, and must
+        // not consume a greeting meant for somebody else.
+        if ($this->welcome->isWaitingFor($user)) {
+            $this->welcome->dismiss();
+        }
+
+        return Inertia::render('system/whats-new', $props);
+    }
+}

--- a/app/Modules/Platform/Settings/Setting.php
+++ b/app/Modules/Platform/Settings/Setting.php
@@ -248,6 +248,17 @@ enum Setting: string
     case AppliedVersion = 'applied_version';
     case AppliedVersionAt = 'applied_version_at';
 
+    // An update finished and the administrator has not been shown what it
+    // brought yet — the two versions it moved between, so the page can
+    // name every release in the gap rather than only the newest.
+    //
+    // Written by UpdateInstallation, and only for a genuine update of an
+    // existing installation: a fresh install has nothing to catch up on,
+    // and a container that reboots has not updated anything. Cleared when
+    // the page is read. Both empty means nothing is waiting.
+    case UpdateWelcomeFrom = 'update_welcome_from';
+    case UpdateWelcomeTo = 'update_welcome_to';
+
     // Cached result of the last dashboard news feed fetch — never written
     // directly by a settings form, only by FetchNewsCommand. Both editions
     // see this (unlike CheckForUpdates above, which is Community-only);
@@ -298,6 +309,8 @@ enum Setting: string
             self::LatestReleasePublishedAt,
             self::AppliedVersion,
             self::AppliedVersionAt,
+            self::UpdateWelcomeFrom,
+            self::UpdateWelcomeTo,
             self::NewsLastFetchedAt,
             self::CaptchaProvider,
             self::CaptchaKeySource,
@@ -425,6 +438,8 @@ enum Setting: string
             // notice, in either direction.
             self::AppliedVersion => '',
             self::AppliedVersionAt => '',
+            self::UpdateWelcomeFrom => '',
+            self::UpdateWelcomeTo => '',
             self::NewsLastFetchedAt => '',
 
             self::NewsItems => [],

--- a/app/Modules/Platform/Updates/ReleaseNotes.php
+++ b/app/Modules/Platform/Updates/ReleaseNotes.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Updates;
+
+/**
+ * Reads CHANGELOG.md and hands back the releases in a version range, as
+ * structure rather than as Markdown.
+ *
+ * The changelog is the source because it is the only description of a
+ * release that is *inside* the release. GitHub's release notes would need
+ * a network call at the exact moment an administrator has just updated —
+ * possibly on a server with no outbound access at all — to describe code
+ * that is already sitting on disk. This file ships in every zip
+ * (verify-release.sh refuses one without it) and therefore in the image
+ * built from it.
+ *
+ * Parsed rather than rendered: nothing here ever becomes HTML. The page
+ * gets titles and sentences and does its own formatting, so a stray
+ * `<script>` in a changelog written years from now cannot become one.
+ */
+class ReleaseNotes
+{
+    /**
+     * `## 2.1.0 — 2026-08-20`, with the date optional. The separator is an
+     * em dash in every entry written so far; a hyphen is accepted too,
+     * since which one gets typed is not something to lose a release note
+     * over.
+     */
+    private const HEADING = '/^##\s+v?(?<version>\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\s*(?:[—–-]\s*(?<date>.+?))?\s*$/u';
+
+    /**
+     * Every release later than $from, up to and including $to, newest
+     * first.
+     *
+     * An empty $from means the installation never recorded a version, so
+     * there is no gap to describe and only $to is shown. Versions are
+     * compared, not string-matched: a changelog holds every release ever
+     * made, and only the ones this update actually crossed are news.
+     *
+     * @return list<array{version: string, date: string, intro: list<string>, groups: list<array{heading: string, items: list<array{title: string, body: string}>}>}>
+     */
+    public function between(string $from, string $to, ?string $changelog = null): array
+    {
+        if ($to === '') {
+            return [];
+        }
+
+        return array_values(array_filter(
+            $this->all($changelog),
+            fn (array $release): bool => version_compare($release['version'], $to, '<=')
+                && ($from === '' ? $release['version'] === $to : version_compare($release['version'], $from, '>')),
+        ));
+    }
+
+    /**
+     * Every release in the changelog, newest first, in file order.
+     *
+     * "Unreleased" is skipped by construction: its heading carries no
+     * version number, so it never matches.
+     *
+     * @return list<array{version: string, date: string, intro: list<string>, groups: list<array{heading: string, items: list<array{title: string, body: string}>}>}>
+     */
+    public function all(?string $changelog = null): array
+    {
+        $markdown = $changelog ?? $this->read();
+
+        if ($markdown === null) {
+            return [];
+        }
+
+        $releases = [];
+        $current = null;
+
+        foreach ($this->paragraphs($markdown) as $block) {
+            if (preg_match(self::HEADING, $block, $matches) === 1) {
+                if ($current !== null) {
+                    $releases[] = $current;
+                }
+
+                $current = [
+                    'version' => $matches['version'],
+                    'date' => trim($matches['date'] ?? ''),
+                    'intro' => [],
+                    'groups' => [],
+                ];
+
+                continue;
+            }
+
+            if ($current === null) {
+                // The changelog's own preamble, before the first release.
+                continue;
+            }
+
+            $current = $this->absorb($current, $block);
+        }
+
+        if ($current !== null) {
+            $releases[] = $current;
+        }
+
+        return $releases;
+    }
+
+    /**
+     * Fold one block of the release's body into it.
+     *
+     * @param  array{version: string, date: string, intro: list<string>, groups: list<array{heading: string, items: list<array{title: string, body: string}>}>}  $release
+     * @return array{version: string, date: string, intro: list<string>, groups: list<array{heading: string, items: list<array{title: string, body: string}>}>}
+     */
+    private function absorb(array $release, string $block): array
+    {
+        if (preg_match('/^###\s+(?<heading>.+?)\s*$/u', $block, $matches) === 1) {
+            $release['groups'][] = ['heading' => $matches['heading'], 'items' => []];
+
+            return $release;
+        }
+
+        if (! str_starts_with(ltrim($block), '- ')) {
+            // Prose. Before the first "### Added" it is the release's own
+            // summary — 2.0.0 opens with three paragraphs of it. After
+            // one, it belongs to that group and is rare enough that
+            // folding it in as an untitled item beats inventing a shape
+            // for it.
+            if ($release['groups'] === []) {
+                $release['intro'][] = $this->inline($block);
+
+                return $release;
+            }
+
+            return $this->append($release, ['title' => '', 'body' => $this->inline($block)]);
+        }
+
+        foreach ($this->bullets($block) as $bullet) {
+            $release = $this->append($release, $this->item($bullet));
+        }
+
+        return $release;
+    }
+
+    /**
+     * Add an item to the release's last group, opening an unnamed one if
+     * there is nothing to add it to — the shape a small fix-only release
+     * takes when it lists changes without a `### Heading` above them.
+     *
+     * @param  array{version: string, date: string, intro: list<string>, groups: list<array{heading: string, items: list<array{title: string, body: string}>}>}  $release
+     * @param  array{title: string, body: string}  $item
+     * @return array{version: string, date: string, intro: list<string>, groups: list<array{heading: string, items: list<array{title: string, body: string}>}>}
+     */
+    private function append(array $release, array $item): array
+    {
+        if ($release['groups'] === []) {
+            $release['groups'][] = ['heading' => '', 'items' => []];
+        }
+
+        $index = count($release['groups']) - 1;
+        $group = $release['groups'][$index];
+        $group['items'][] = $item;
+        $release['groups'][$index] = $group;
+
+        return $release;
+    }
+
+    /**
+     * Split a bullet into its bold lead-in and the rest.
+     *
+     * Entries are written as `- **What changed.** Why it matters`, and
+     * that lead-in is the only part most people read, so it becomes a
+     * heading on screen.
+     *
+     * The sentence-ending punctuation *inside* the bold is what makes it a
+     * lead-in. Some bullets instead open with a bold fragment that the
+     * sentence continues through — `- **Clients sign in with their email
+     * address**, not their username` — and promoting that to a heading
+     * produces "Clients sign in with their email address. , not their
+     * username". Those keep their sentence whole and get no title.
+     *
+     * @return array{title: string, body: string}
+     */
+    private function item(string $bullet): array
+    {
+        if (preg_match('/^\*\*(?<title>.+?)\*\*(?<body>.*)$/us', $bullet, $matches) === 1) {
+            $title = $this->inline($matches['title']);
+
+            if (preg_match('/[.!?]$/u', $title) === 1) {
+                return [
+                    // The full stop belongs to the sentence, not to the
+                    // heading it becomes on screen.
+                    'title' => rtrim($title, '.'),
+                    'body' => $this->inline($matches['body']),
+                ];
+            }
+        }
+
+        return ['title' => '', 'body' => $this->inline($bullet)];
+    }
+
+    /**
+     * The bullets in one list block, each with its continuation lines
+     * joined back on. Markdown wraps at 100 columns here; a reader wants
+     * the sentence.
+     *
+     * @return list<string>
+     */
+    private function bullets(string $block): array
+    {
+        $bullets = [];
+
+        foreach (explode("\n", $block) as $line) {
+            if (preg_match('/^\s*[-*]\s+(?<text>.*)$/u', $line, $matches) === 1) {
+                $bullets[] = $matches['text'];
+
+                continue;
+            }
+
+            if ($bullets !== []) {
+                $bullets[array_key_last($bullets)] .= ' '.trim($line);
+            }
+        }
+
+        return array_values(array_filter(array_map(trim(...), $bullets), fn (string $b): bool => $b !== ''));
+    }
+
+    /**
+     * Markdown down to text, for everything that is not the bold lead-in:
+     * emphasis and code fences go, links keep their text.
+     *
+     * Kept deliberately small. This renders our own changelog, not
+     * arbitrary Markdown, and the failure mode of a light touch is a
+     * stray asterisk rather than a mangled sentence.
+     */
+    private function inline(string $text): string
+    {
+        $text = (string) preg_replace('/\[(?<text>[^]]+)]\([^)]+\)/u', '$1', $text);
+        $text = (string) preg_replace('/\*\*(?<text>.+?)\*\*/us', '$1', $text);
+        $text = (string) preg_replace('/`(?<text>[^`]+)`/u', '$1', $text);
+
+        return trim((string) preg_replace('/\s+/u', ' ', $text));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function paragraphs(string $markdown): array
+    {
+        $blocks = preg_split('/\n\s*\n/u', str_replace("\r\n", "\n", $markdown)) ?: [];
+
+        return array_values(array_filter(array_map(trim(...), $blocks), fn (string $b): bool => $b !== ''));
+    }
+
+    /**
+     * Null when there is no changelog to read — which is not a failure
+     * worth reporting: a development checkout may be mid-rewrite, and the
+     * page it feeds says thank you either way.
+     */
+    private function read(): ?string
+    {
+        $path = base_path('CHANGELOG.md');
+
+        if (! is_file($path) || ! is_readable($path)) {
+            return null;
+        }
+
+        $contents = file_get_contents($path);
+
+        return $contents === false ? null : $contents;
+    }
+}

--- a/app/Modules/Platform/Updates/UpdateInstallation.php
+++ b/app/Modules/Platform/Updates/UpdateInstallation.php
@@ -155,10 +155,26 @@ class UpdateInstallation
         $this->settings->set(Setting::AppliedVersion, $running);
         $this->settings->set(Setting::AppliedVersionAt, now()->toIso8601String());
 
-        $warning = $this->recordTheUpdate($existingInstall, $result['from'], $running);
+        // Everything that happens only when this run actually moved the
+        // installation somewhere new. Both entrypoints run this command on
+        // every boot, so "somewhere new" is the narrow case, not the
+        // common one.
+        if ($existingInstall && $result['from'] !== $running) {
+            $warning = $this->recordTheUpdate($result['from'], $running);
 
-        if ($warning !== null) {
-            $result['warnings'][] = $warning;
+            if ($warning !== null) {
+                $result['warnings'][] = $warning;
+            }
+
+            // Forwards only. Going back is a version change worth recording
+            // above, but somebody who has just restored an older release is
+            // dealing with a problem, and "thank you for keeping this
+            // current" is the wrong thing to greet them with. An unknown
+            // previous version counts as forwards: it is the first update
+            // of an installation older than this feature.
+            if ($result['from'] === '' || version_compare($running, $result['from'], '>')) {
+                $this->raiseTheWelcome($result['from'], $running);
+            }
         }
 
         // Last, and after every cache operation above — see the class
@@ -171,25 +187,44 @@ class UpdateInstallation
     }
 
     /**
+     * Leave the marker the administrator's welcome page consumes: an
+     * update landed, and this is the ground it covered.
+     *
+     * Both versions rather than just the new one, because an installation
+     * that skipped releases — anybody who updates twice a year — should be
+     * shown every release in the gap and not only the newest.
+     *
+     * Swallows failure for the reason the activity log below does: an
+     * update that worked must not report failure because of a greeting.
+     */
+    private function raiseTheWelcome(string $from, string $to): void
+    {
+        try {
+            $this->settings->set(Setting::UpdateWelcomeFrom, $from);
+            $this->settings->set(Setting::UpdateWelcomeTo, $to);
+        } catch (Throwable) {
+            // Nothing worth telling anyone: the update itself is complete,
+            // and the only casualty is a page nobody has seen yet.
+        }
+    }
+
+    /**
      * Put the update in the activity log — the one place an administrator
      * looks to answer "what changed on this installation, and when".
      *
-     * Only a genuine version change is recorded. The container entrypoint
-     * runs this on every boot, so logging unconditionally would bury the
-     * log under an entry per restart; and a fresh installation is an
-     * install, not an update, which SetupCompleted already covers.
+     * Only reached for a genuine version change (see the caller). The
+     * container entrypoint runs this on every boot, so logging
+     * unconditionally would bury the log under an entry per restart; and a
+     * fresh installation is an install, not an update, which SetupCompleted
+     * already covers.
      *
      * "Fresh" is decided by whether migrations had ever run before this
      * one, rather than by whether a version was recorded: the first update
      * of any installation older than this command finds no recorded
      * version, and that update is exactly the one worth logging.
      */
-    private function recordTheUpdate(bool $existingInstall, string $from, string $to): ?string
+    private function recordTheUpdate(string $from, string $to): ?string
     {
-        if (! $existingInstall || $from === $to) {
-            return null;
-        }
-
         try {
             $this->activity->logSystem(Action::ApplicationUpdated, [
                 // The previous version is unknown exactly once per

--- a/app/Modules/Platform/Updates/UpdateWelcome.php
+++ b/app/Modules/Platform/Updates/UpdateWelcome.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Updates;
+
+use App\Models\User;
+use App\Modules\Identity\Permissions\Permission;
+use App\Modules\Identity\Permissions\PermissionChecker;
+use App\Modules\Identity\StaffAccounts;
+use App\Modules\Platform\Capabilities\Capability;
+use App\Modules\Platform\Capabilities\CapabilityRegistry;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+
+/**
+ * "An update just landed — has the administrator been told what was in
+ * it?" One answer, shared by the middleware that redirects and the
+ * controller that renders.
+ *
+ * Deliberately one person and one time. The update happened to the
+ * *installation*, and interrupting five staff members with the same
+ * congratulation — each of whom then has to dismiss a page they did not
+ * ask for — would turn a nice moment into a nuisance that gets asked
+ * about in a support thread. So it goes to whoever administers this
+ * installation, once, and stays reachable at its own address for anybody
+ * who wants it afterwards.
+ */
+class UpdateWelcome
+{
+    public function __construct(
+        private readonly Settings $settings,
+        private readonly CapabilityRegistry $capabilities,
+        private readonly PermissionChecker $permissions,
+        private readonly StaffAccounts $staff,
+        private readonly ReleaseNotes $notes,
+    ) {}
+
+    /**
+     * Whether this user should be taken to the welcome page right now.
+     */
+    public function isWaitingFor(User $user): bool
+    {
+        return $this->pending() !== null
+            && $this->isTheMainAdministrator($user)
+            && $this->mayRead($user);
+    }
+
+    /**
+     * Whether this user may open the page at all, update or no update.
+     *
+     * Carries the About screen's environment gate verbatim — view_system_info
+     * plus SystemUpdates — because this answers the same question that one
+     * does, in more detail. The capability is what keeps it off managed
+     * installations, where nobody running this application performed an
+     * update and "thank you for updating" would be addressed to the wrong
+     * person entirely.
+     */
+    public function mayRead(User $user): bool
+    {
+        return $user->isStaff()
+            && $this->capabilities->has(Capability::SystemUpdates)
+            && $this->permissions->allows($user, Permission::ViewSystemInfo);
+    }
+
+    /**
+     * The versions an unseen update moved between, or null if there is
+     * nothing waiting.
+     *
+     * @return array{from: string, to: string}|null
+     */
+    public function pending(): ?array
+    {
+        $to = $this->string(Setting::UpdateWelcomeTo);
+
+        if ($to === '') {
+            return null;
+        }
+
+        return ['from' => $this->string(Setting::UpdateWelcomeFrom), 'to' => $to];
+    }
+
+    /**
+     * Forget the pending update, so the redirect happens exactly once.
+     *
+     * Only the marker is cleared — the page itself keeps working, and
+     * keeps describing the same release, because "I closed it by accident"
+     * should not be an unrecoverable mistake.
+     */
+    public function dismiss(): void
+    {
+        $this->settings->set(Setting::UpdateWelcomeFrom, '');
+        $this->settings->set(Setting::UpdateWelcomeTo, '');
+    }
+
+    /**
+     * What to show: every release between the version that was running and
+     * the one that is now.
+     *
+     * Falls back to the running version once the marker has been cleared,
+     * so the page still has something to say when it is opened later from
+     * a link rather than arrived at from an update.
+     *
+     * @return list<array{version: string, date: string, intro: list<string>, groups: list<array{heading: string, items: list<array{title: string, body: string}>}>}>
+     */
+    public function releases(): array
+    {
+        return $this->notes->between($this->previousVersion(), $this->version());
+    }
+
+    /**
+     * The version this page is about — the one the update arrived at, or
+     * the one running when it is opened cold.
+     */
+    public function version(): string
+    {
+        $pending = $this->pending();
+
+        return $pending === null ? (string) config('projectsend.version') : $pending['to'];
+    }
+
+    /**
+     * The version left behind, empty when unknown or when the page was
+     * opened outside an update.
+     */
+    public function previousVersion(): string
+    {
+        return $this->pending()['from'] ?? '';
+    }
+
+    /**
+     * Whether this page is being read because an update just happened, as
+     * opposed to opened from a link afterwards. The wording differs: one
+     * says "you have updated", the other only "here is what this release
+     * brought".
+     */
+    public function isFresh(): bool
+    {
+        return $this->pending() !== null;
+    }
+
+    private function isTheMainAdministrator(User $user): bool
+    {
+        return $this->staff->mainAdministrator()?->is($user) === true;
+    }
+
+    private function string(Setting $setting): string
+    {
+        $value = $this->settings->get($setting);
+
+        return is_string($value) ? $value : '';
+    }
+}

--- a/config/projectsend.php
+++ b/config/projectsend.php
@@ -87,6 +87,10 @@ return [
         // available at github.com/projectsend/legacy.
         'source' => 'https://github.com/projectsend/projectsend',
         'open_collective' => 'https://opencollective.com/projectsend',
+        // Kept identical to the invitation update.sh prints when an update
+        // finishes — the two are the same offer, made in the terminal and
+        // then again on the screen the administrator lands on.
+        'discord' => 'https://discord.gg/VT9n6cyvXT',
     ],
 
 ];

--- a/resources/js/pages/system/about.tsx
+++ b/resources/js/pages/system/about.tsx
@@ -1,5 +1,5 @@
 import { type BreadcrumbItem, type SharedData } from '@/types';
-import { Head, usePage } from '@inertiajs/react';
+import { Head, Link, usePage } from '@inertiajs/react';
 
 import Heading from '@/components/heading';
 import ProjectSendLogo from '@/components/projectsend-logo';
@@ -70,6 +70,17 @@ export default function About({ license, environment }: AboutProps) {
                         <a href={links.open_collective} target="_blank" rel="noreferrer" className="underline hover:no-underline">
                             {t('Support the project')}
                         </a>
+                        <a href={links.discord} target="_blank" rel="noreferrer" className="underline hover:no-underline">
+                            {t('Discord')}
+                        </a>
+                        {/* Same gate as the environment block below, which is
+                            why it rides on the same prop: the page it links to
+                            answers the question this one starts. */}
+                        {environment && (
+                            <Link href={route('system.whats-new')} className="underline hover:no-underline">
+                                {t("What's new")}
+                            </Link>
+                        )}
                     </div>
 
                     {environment && (

--- a/resources/js/pages/system/whats-new.tsx
+++ b/resources/js/pages/system/whats-new.tsx
@@ -1,0 +1,142 @@
+import { type BreadcrumbItem, type SharedData } from '@/types';
+import { Head, Link, usePage } from '@inertiajs/react';
+import { ArrowRight, CircleCheck, MessagesSquare } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { useTranslation } from '@/hooks/use-translation';
+import AppLayout from '@/layouts/app-layout';
+
+interface ReleaseItem {
+    /** The bold lead-in of a changelog bullet; empty when it has none. */
+    title: string;
+    body: string;
+}
+
+interface ReleaseGroup {
+    /** "Added", "Improved", … — empty for a list written without one. */
+    heading: string;
+    items: ReleaseItem[];
+}
+
+interface Release {
+    version: string;
+    date: string;
+    intro: string[];
+    groups: ReleaseGroup[];
+}
+
+interface WhatsNewProps {
+    version: string;
+    /** Empty when the previous version was never recorded. */
+    previousVersion: string;
+    /** False when the page is opened from a link rather than after an update. */
+    justUpdated: boolean;
+    releases: Release[];
+}
+
+export default function WhatsNew({ version, previousVersion, justUpdated, releases }: WhatsNewProps) {
+    const { t } = useTranslation();
+    const { links } = usePage<SharedData>().props;
+
+    const breadcrumbs: BreadcrumbItem[] = [{ title: t("What's new"), href: '/system/whats-new' }];
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title={t("What's new")} />
+
+            <div className="px-4 py-6">
+                <div className="mx-auto max-w-2xl space-y-10">
+                    <div className="space-y-3 text-center">
+                        <CircleCheck className="text-primary mx-auto size-12" strokeWidth={1.5} />
+
+                        <h1 className="text-2xl font-semibold tracking-tight">
+                            {justUpdated ? t('ProjectSend is now on :version', { version }) : t('ProjectSend :version', { version })}
+                        </h1>
+
+                        <p className="text-muted-foreground text-sm">
+                            {justUpdated
+                                ? previousVersion !== ''
+                                    ? t('The update from :previous finished, and everything came back up. Thank you for keeping it current.', {
+                                          previous: previousVersion,
+                                      })
+                                    : t('The update finished, and everything came back up. Thank you for keeping it current.')
+                                : t('What each release brought to this installation.')}
+                        </p>
+                    </div>
+
+                    {/* The invitation, above the notes on purpose: it is the
+                        part with a person on the other end of it. */}
+                    <div className="bg-muted/40 flex flex-col items-center gap-4 rounded-lg border p-6 text-center">
+                        <MessagesSquare className="text-muted-foreground size-8" strokeWidth={1.5} />
+
+                        <div className="space-y-1">
+                            <p className="font-medium">{t('Come and say hello')}</p>
+                            <p className="text-muted-foreground text-sm">
+                                {t(
+                                    'ProjectSend has a Discord: release news, help when something is not behaving, and other people running the same software. We are in it too.',
+                                )}
+                            </p>
+                        </div>
+
+                        <Button asChild variant="outline">
+                            <a href={links.discord} target="_blank" rel="noreferrer">
+                                {t('Join the Discord')}
+                            </a>
+                        </Button>
+                    </div>
+
+                    {releases.length > 0 && (
+                        <div className="space-y-8">
+                            <h2 className="text-lg font-semibold tracking-tight">{t("What's new")}</h2>
+
+                            {releases.map((release) => (
+                                <ReleaseNotes key={release.version} release={release} />
+                            ))}
+                        </div>
+                    )}
+
+                    <div className="flex justify-center">
+                        <Button asChild>
+                            <Link href={route('dashboard')}>
+                                {t('Continue to the dashboard')}
+                                <ArrowRight className="size-4" />
+                            </Link>
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </AppLayout>
+    );
+}
+
+function ReleaseNotes({ release }: { release: Release }) {
+    return (
+        <section className="space-y-4">
+            <div className="flex items-baseline gap-3 border-b pb-2">
+                <h3 className="font-semibold">{release.version}</h3>
+                {release.date !== '' && <span className="text-muted-foreground text-sm">{release.date}</span>}
+            </div>
+
+            {release.intro.map((paragraph, index) => (
+                <p key={index} className="text-muted-foreground text-sm">
+                    {paragraph}
+                </p>
+            ))}
+
+            {release.groups.map((group, index) => (
+                <div key={index} className="space-y-3">
+                    {group.heading !== '' && <h4 className="text-sm font-medium">{group.heading}</h4>}
+
+                    <ul className="space-y-3">
+                        {group.items.map((item, itemIndex) => (
+                            <li key={itemIndex} className="text-sm">
+                                {item.title !== '' && <span className="font-medium">{item.title}. </span>}
+                                <span className="text-muted-foreground">{item.body}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            ))}
+        </section>
+    );
+}

--- a/resources/js/pages/system/whats-new.tsx
+++ b/resources/js/pages/system/whats-new.tsx
@@ -65,20 +65,31 @@ export default function WhatsNew({ version, previousVersion, justUpdated, releas
                     </div>
 
                     {/* The invitation, above the notes on purpose: it is the
-                        part with a person on the other end of it. */}
-                    <div className="bg-muted/40 flex flex-col items-center gap-4 rounded-lg border p-6 text-center">
-                        <MessagesSquare className="text-muted-foreground size-8" strokeWidth={1.5} />
+                        part with a person on the other end of it.
+
+                        Carried on `accent` rather than `muted` so it reads as
+                        the featured thing on the page. That token is the
+                        brand colour at surface strength and already has a
+                        dark-mode counterpart, so this stays legible in both
+                        without a single hardcoded purple — and follows the
+                        palette on an installation whose branding replaces
+                        ours. */}
+                    <div className="bg-accent border-primary/20 flex flex-col items-center gap-4 rounded-lg border p-6 text-center">
+                        <MessagesSquare className="text-primary size-8" strokeWidth={1.5} />
 
                         <div className="space-y-1">
-                            <p className="font-medium">{t('Come and say hello')}</p>
-                            <p className="text-muted-foreground text-sm">
+                            <p className="text-accent-foreground font-medium">{t('Come and say hello')}</p>
+                            <p className="text-accent-foreground/80 text-sm">
                                 {t(
                                     'ProjectSend has a Discord: release news, help when something is not behaving, and other people running the same software. We are in it too.',
                                 )}
                             </p>
                         </div>
 
-                        <Button asChild variant="outline">
+                        {/* Solid rather than outline: an outline button's
+                            hover state is this very background colour, so on
+                            this card it would disappear under the cursor. */}
+                        <Button asChild>
                             <a href={links.discord} target="_blank" rel="noreferrer">
                                 {t('Join the Discord')}
                             </a>
@@ -95,8 +106,11 @@ export default function WhatsNew({ version, previousVersion, justUpdated, releas
                         </div>
                     )}
 
+                    {/* Outline, so the invitation above is the one filled
+                        button on the page. Leaving is not the thing being
+                        encouraged here. */}
                     <div className="flex justify-center">
-                        <Button asChild>
+                        <Button asChild variant="outline">
                             <Link href={route('dashboard')}>
                                 {t('Continue to the dashboard')}
                                 <ArrowRight className="size-4" />

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -75,6 +75,7 @@ export interface SharedData {
         website: string;
         source: string;
         open_collective: string;
+        discord: string;
     };
     /**
      * Whether this installation names ProjectSend to its clients and

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -25,6 +25,7 @@ use App\Modules\Platform\Http\Controllers\PublicListingSettingsController;
 use App\Modules\Platform\Http\Controllers\SchedulerMonitoringController;
 use App\Modules\Platform\Http\Controllers\SystemSettingsController;
 use App\Modules\Platform\Http\Controllers\ThemingSettingsController;
+use App\Modules\Platform\Http\Controllers\WhatsNewController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth')->group(function () {
@@ -109,6 +110,14 @@ Route::middleware('auth')->group(function () {
     // footer links every staff member here regardless of what they may
     // edit.
     Route::middleware('staff')->get('system/about', AboutController::class)->name('system.about');
+
+    // Where an administrator is sent after an update, and a page anyone
+    // who may read About's environment block can revisit afterwards. The
+    // capability keeps it off managed installations, where nobody signed
+    // in here performed the update it thanks them for.
+    Route::middleware(['staff', 'capability:system.updates', 'can:view_system_info'])
+        ->get('system/whats-new', WhatsNewController::class)
+        ->name('system.whats-new');
 
     // System-wide configuration — deliberately outside the account
     // settings section; it lives under its own sidebar entry, one route

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\RedirectToWhatsNew;
 use App\Modules\Api\Http\Controllers\ApiDashboardController;
 use App\Modules\Api\Http\Controllers\ApiDocsController;
 use App\Modules\Audit\Http\Controllers\ActivityLogController;
@@ -73,7 +74,11 @@ Route::get('s/{token}', [PublicShareController::class, 'show'])->middleware('thr
 Route::get('s/{token}/download', [PublicShareController::class, 'download'])->middleware('throttle:30,1,share-link')->name('share.download');
 
 Route::middleware(['auth'])->group(function () {
-    Route::get('dashboard', DashboardController::class)->name('dashboard');
+    // The welcome middleware sits here and nowhere else — see the class
+    // for why the dashboard is the right and only place to intercept.
+    Route::get('dashboard', DashboardController::class)
+        ->middleware(RedirectToWhatsNew::class)
+        ->name('dashboard');
     Route::put('dashboard/widgets', [DashboardWidgetPreferencesController::class, 'update'])->name('dashboard.widgets.update');
 
     // Every account (staff or client) has their own notifications —

--- a/tests/Feature/Platform/ReleaseNotesTest.php
+++ b/tests/Feature/Platform/ReleaseNotesTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Modules\Platform\Updates\ReleaseNotes;
+
+/**
+ * The changelog is written for people, by hand, and this reads it. Every
+ * shape asserted here is one that exists in CHANGELOG.md today — the
+ * parser is not general-purpose Markdown, and does not need to be.
+ */
+function changelog(): string
+{
+    return <<<'MARKDOWN'
+        # Changelog
+
+        What changed in each release, written for the people running it.
+
+        ## Unreleased
+
+        Collected as it lands.
+
+        ## 2.2.0 — 2026-09-01
+
+        A short release.
+
+        ### Fixed
+
+        - **Downloads no longer stall.** The part that hung is gone, and the retry
+          is now bounded.
+
+        ## 2.1.0 — 2026-08-20
+
+        ### Added
+
+        - **A REST API.** Files and clients, with [scoped tokens](https://example.com) and `php artisan` docs.
+        - **Clients sign in with their email address**, not their username.
+
+        ### Upgrade notes
+
+        - Run the migrations before starting the workers.
+
+        ## 2.0.0 — 2026-08-14
+
+        The rewrite.
+        MARKDOWN;
+}
+
+it('reads a release into its heading, date and items', function (): void {
+    $releases = (new ReleaseNotes)->all(changelog());
+
+    expect($releases)->toHaveCount(3)
+        ->and($releases[0]['version'])->toBe('2.2.0')
+        ->and($releases[0]['date'])->toBe('2026-09-01')
+        ->and($releases[0]['intro'])->toBe(['A short release.'])
+        ->and($releases[0]['groups'][0]['heading'])->toBe('Fixed')
+        ->and($releases[0]['groups'][0]['items'][0]['title'])->toBe('Downloads no longer stall');
+});
+
+// "Unreleased" carries no version number, so it never matches the heading
+// pattern — which is the whole reason the pattern requires one.
+it('skips the unreleased section', function (): void {
+    $versions = array_column((new ReleaseNotes)->all(changelog()), 'version');
+
+    expect($versions)->toBe(['2.2.0', '2.1.0', '2.0.0']);
+});
+
+// Bullets wrap at 100 columns in the file; a reader wants the sentence.
+it('joins a bullet that wraps across lines', function (): void {
+    $item = (new ReleaseNotes)->all(changelog())[0]['groups'][0]['items'][0];
+
+    expect($item['body'])->toBe('The part that hung is gone, and the retry is now bounded.');
+});
+
+it('keeps link text and drops the markup around it', function (): void {
+    $item = (new ReleaseNotes)->all(changelog())[1]['groups'][0]['items'][0];
+
+    expect($item['title'])->toBe('A REST API')
+        ->and($item['body'])->toBe('Files and clients, with scoped tokens and php artisan docs.');
+});
+
+// A bold fragment the sentence continues through is not a lead-in.
+// Promoting it produced "Clients sign in with their email address. , not
+// their username" on the page.
+it('leaves a bullet whose bold opening is not a sentence intact', function (): void {
+    $item = (new ReleaseNotes)->all(changelog())[1]['groups'][0]['items'][1];
+
+    expect($item['title'])->toBe('')
+        ->and($item['body'])->toBe('Clients sign in with their email address, not their username.');
+});
+
+it('keeps a bullet with no bold at all', function (): void {
+    $group = (new ReleaseNotes)->all(changelog())[1]['groups'][1];
+
+    expect($group['heading'])->toBe('Upgrade notes')
+        ->and($group['items'][0])->toBe(['title' => '', 'body' => 'Run the migrations before starting the workers.']);
+});
+
+// The point of recording both versions: somebody who updates twice a year
+// crosses several releases at once, and all of them are news to them.
+it('returns every release in the gap, newest first', function (): void {
+    $versions = array_column((new ReleaseNotes)->between('2.0.0', '2.2.0', changelog()), 'version');
+
+    expect($versions)->toBe(['2.2.0', '2.1.0']);
+});
+
+it('excludes the version being updated from, and anything newer than the one reached', function (): void {
+    $versions = array_column((new ReleaseNotes)->between('2.1.0', '2.1.0', changelog()), 'version');
+
+    expect($versions)->toBe([]);
+});
+
+// The first update of an installation older than this feature has no
+// recorded previous version. One release is better than the entire history.
+it('shows only the version reached when the previous one is unknown', function (): void {
+    $versions = array_column((new ReleaseNotes)->between('', '2.1.0', changelog()), 'version');
+
+    expect($versions)->toBe(['2.1.0']);
+});
+
+// A release whose notes were never written up: the page drops the section
+// rather than inventing one.
+it('returns nothing for a version the changelog does not mention', function (): void {
+    expect((new ReleaseNotes)->between('2.2.0', '2.3.0', changelog()))->toBe([]);
+});
+
+// The real file, so a change to how the changelog is written shows up
+// here rather than on an administrator's screen.
+it('reads the changelog this release actually ships', function (): void {
+    $releases = (new ReleaseNotes)->between('', (string) config('projectsend.version'));
+
+    expect($releases)->not->toBeEmpty()
+        ->and($releases[0]['version'])->toBe(config('projectsend.version'))
+        ->and($releases[0]['groups'])->not->toBeEmpty();
+});

--- a/tests/Feature/Platform/UpdateCommandTest.php
+++ b/tests/Feature/Platform/UpdateCommandTest.php
@@ -242,3 +242,47 @@ test('a fresh installation logs no update', function () {
     expect(ActivityLog::query()->where('action', Action::ApplicationUpdated)->count())->toBe(0)
         ->and(app(Settings::class)->get(Setting::AppliedVersion))->toBe(config('projectsend.version'));
 });
+
+// The marker the administrator's welcome page consumes. It carries both
+// versions so that page can name every release in the gap, which matters
+// for anybody who updates twice a year rather than every release.
+test('it raises the welcome marker, naming the ground the update covered', function () {
+    app(Settings::class)->set(Setting::AppliedVersion, '2.0.0');
+    config()->set('projectsend.version', '2.1.0');
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect(app(Settings::class)->get(Setting::UpdateWelcomeFrom))->toBe('2.0.0')
+        ->and(app(Settings::class)->get(Setting::UpdateWelcomeTo))->toBe('2.1.0');
+});
+
+// Same reasoning as the activity log above: every container boot runs this
+// command, and greeting somebody for a restart would train them to dismiss
+// the page without reading it.
+test('re-running on the same version raises no welcome', function () {
+    app(Settings::class)->set(Setting::AppliedVersion, config('projectsend.version'));
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect(app(Settings::class)->get(Setting::UpdateWelcomeTo))->toBe('');
+});
+
+test('a fresh installation raises no welcome', function () {
+    $fake = recordingUpdate();
+    $fake->existingInstall = false;
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect(app(Settings::class)->get(Setting::UpdateWelcomeTo))->toBe('');
+});
+
+// Restoring an older release is a version change and is logged as one, but
+// the person doing it is dealing with a problem, not celebrating.
+test('a rollback raises no welcome', function () {
+    app(Settings::class)->set(Setting::AppliedVersion, '99.0.0');
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect(app(Settings::class)->get(Setting::UpdateWelcomeTo))->toBe('')
+        ->and(ActivityLog::query()->where('action', Action::ApplicationUpdated)->count())->toBe(1);
+});

--- a/tests/Feature/Platform/UpdateWelcomeTest.php
+++ b/tests/Feature/Platform/UpdateWelcomeTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Identity\Permissions\SystemRole;
+use App\Modules\Platform\Capabilities\Edition;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+use Inertia\Testing\AssertableInertia;
+
+/**
+ * An update finished; the person who administers this installation should
+ * hear about it once, and nobody else should be interrupted at all.
+ */
+beforeEach(function () {
+    // The oldest active administrator — created first, so it is the main
+    // one no matter what the tests below add afterwards.
+    $this->admin = User::factory()->create();
+
+    // Settings survive RefreshDatabase's rollback in the cache, so every
+    // test states the marker it wants rather than assuming a default.
+    app(Settings::class)->set(Setting::UpdateWelcomeFrom, '');
+    app(Settings::class)->set(Setting::UpdateWelcomeTo, '');
+});
+
+function anUpdateJustLanded(string $from = '2.0.0', ?string $to = null): void
+{
+    app(Settings::class)->set(Setting::UpdateWelcomeFrom, $from);
+    app(Settings::class)->set(Setting::UpdateWelcomeTo, $to ?? (string) config('projectsend.version'));
+}
+
+test('the main administrator lands on the welcome page after an update', function () {
+    anUpdateJustLanded();
+
+    $this->actingAs($this->admin)->get('/dashboard')->assertRedirect('/system/whats-new');
+});
+
+test('the page names the release and what it brought', function () {
+    anUpdateJustLanded();
+
+    $this->actingAs($this->admin)->get('/system/whats-new')->assertInertia(
+        fn (AssertableInertia $page) => $page
+            ->component('system/whats-new')
+            ->where('version', config('projectsend.version'))
+            ->where('previousVersion', '2.0.0')
+            ->where('justUpdated', true)
+            ->has('releases'),
+    );
+});
+
+// Once. The second visit to the dashboard is somebody trying to get on
+// with their day.
+test('the redirect happens exactly once', function () {
+    anUpdateJustLanded();
+
+    $this->actingAs($this->admin)->get('/dashboard')->assertRedirect('/system/whats-new');
+    $this->actingAs($this->admin)->get('/system/whats-new')->assertOk();
+
+    $this->actingAs($this->admin)->get('/dashboard')->assertOk();
+});
+
+// Closing it by accident should not be unrecoverable: the address keeps
+// working and keeps describing the release, it just stops interrupting.
+test('the page still reads after it has been dismissed', function () {
+    anUpdateJustLanded();
+
+    $this->actingAs($this->admin)->get('/system/whats-new')->assertOk();
+
+    $this->actingAs($this->admin)->get('/system/whats-new')->assertInertia(
+        fn (AssertableInertia $page) => $page
+            ->where('justUpdated', false)
+            ->where('version', config('projectsend.version')),
+    );
+});
+
+// The update happened to the installation, not to five people. Every
+// administrator being stopped and made to dismiss the same page would turn
+// a pleasant moment into a support question.
+test('another administrator is not interrupted', function () {
+    anUpdateJustLanded();
+
+    $second = User::factory()->create();
+
+    $this->actingAs($second)->get('/dashboard')->assertOk();
+});
+
+// …and reading it does not consume a greeting addressed to somebody else.
+test('another administrator reading the page leaves it waiting', function () {
+    anUpdateJustLanded();
+
+    $this->actingAs(User::factory()->create())->get('/system/whats-new')->assertOk();
+
+    $this->actingAs($this->admin)->get('/dashboard')->assertRedirect('/system/whats-new');
+});
+
+// The founder who left: their account is deactivated, and the greeting
+// moves to whoever administers the installation now rather than sitting
+// unread forever.
+test('a deactivated main administrator hands the greeting to the next one', function () {
+    anUpdateJustLanded();
+
+    $second = User::factory()->create();
+    $this->admin->update(['active' => false]);
+
+    $this->actingAs($second)->get('/dashboard')->assertRedirect('/system/whats-new');
+});
+
+test('staff who may not read system information are not interrupted', function () {
+    anUpdateJustLanded();
+
+    $uploader = User::factory()->role(SystemRole::Uploader)->create();
+
+    $this->actingAs($uploader)->get('/dashboard')->assertOk();
+    $this->actingAs($uploader)->get('/system/whats-new')->assertForbidden();
+});
+
+test('clients see nothing of it', function () {
+    anUpdateJustLanded();
+
+    $client = User::factory()->client()->create();
+
+    // EnsureStaff redirects a client away from a staff GET rather than
+    // answering 403 — see its docblock.
+    $this->actingAs($client)->get('/system/whats-new')->assertRedirect();
+});
+
+// Nobody signed in to a managed installation performed the update, so
+// "thank you for keeping it current" would be addressed to the wrong
+// person. Same gate as About's environment block and the dashboard's
+// System card.
+test('a managed installation never shows it', function () {
+    config()->set('projectsend.edition', Edition::Cloud);
+    anUpdateJustLanded();
+
+    $this->actingAs($this->admin)->get('/dashboard')->assertOk();
+    $this->actingAs($this->admin)->get('/system/whats-new')->assertNotFound();
+});
+
+test('with no update waiting the dashboard is the dashboard', function () {
+    $this->actingAs($this->admin)->get('/dashboard')->assertOk();
+});
+
+// A redirect swallows a request body, and nothing that writes should ever
+// be answered with a greeting.
+test('it never intercepts anything but a GET', function () {
+    anUpdateJustLanded();
+
+    $this->actingAs($this->admin)
+        ->from('/dashboard')
+        ->put('/dashboard/widgets', [
+            'columns' => 2,
+            'widgets' => [['widget_key' => 'counters', 'enabled' => true, 'column_index' => 0, 'position' => 0]],
+        ])
+        ->assertRedirect('/dashboard');
+});


### PR DESCRIPTION
An update finished and nothing said so. The dashboard looked identical to yesterday's, and whatever the release brought was in a file nobody opens.

The first time the installation's administrator opens ProjectSend after an update they now land on a page that names the version they are on, invites them to the Discord — the same invitation `update.sh` prints, made again where they are actually looking — and then lays out what the release brought.

## The decisions worth arguing with

**The notes come from `CHANGELOG.md` inside the release, not from GitHub.** The one moment this page exists for is the moment after an update, possibly on a server with no outbound access, describing code already sitting on disk. `verify-release.sh` already refuses a zip without the changelog, so it is there in every install and in the image built from it. Parsed rather than rendered — the page gets titles and sentences and does its own formatting, so nothing in a changelog written years from now can become HTML.

**Once, and to one person.** The update happened to the *installation*. Greeting five staff members, each of whom then dismisses a page they did not ask for, turns a pleasant moment into a support question. It goes to the **oldest active administrator**, which on any installation that went through setup is whoever set it up. No owner flag was invented: administrators are equal in authority here, and changing the permission model for a greeting is not a trade worth making. Deactivate that account and the greeting moves to the next administrator rather than sitting unread forever.

**Only forwards, and only for a real update.** A fresh install has nothing to catch up on; a container reboot has not updated anything; somebody restoring an older release is dealing with a problem, not celebrating. The activity log still records all three, because that is a record — this is a greeting.

**Managed installations never see it.** Nobody signed in there performed the update it thanks them for. Same gate About's environment block and the dashboard's System card already carry (`view_system_info` + `SystemUpdates`).

**The redirect is attached to the dashboard alone**, not the web group. That catches a login *and* the already-signed-in administrator who ran `update.sh` in another window and clicked the logo — without ever interrupting a download to congratulate somebody. Reading the page clears the marker; the address keeps working afterwards, because closing it by accident should not be unrecoverable, and About now links to it.

**Skipped releases all show.** Both versions are recorded, so somebody who updates twice a year gets every release in the gap rather than only the newest.

## Testing

- 1660 Pest tests, PHPStan, `tsc`, ESLint — all green. `scramble:export` produces no diff: no API surface moved.
- The parser is tested against a fixture *and* against the real `CHANGELOG.md`, so a change in how releases are written up shows up here rather than on an administrator's screen.
- **Driven in a real browser over CDP**, not just asserted: dashboard → `/system/whats-new` with "ProjectSend is now on 2.0.0"; reload → the dismissed wording; dashboard → stays on the dashboard; page still readable afterwards; marker cleared. Light and dark both render.

One live-suite interaction worth noting: `StaleCodeNoticeTest` went red on the first run, because its rollback scenario is a version change and the dashboard it asserts against started redirecting. That is what surfaced the forwards-only rule — the test is unchanged.

## Follow-up

The new strings are English only, per the sibling rule in `docs/api-checklist.md`. They want a `/update-translations` pass before the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)