### PR TITLE
Say the right things to a hosted customer

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -17,6 +17,7 @@ use App\Modules\Platform\Captcha\Captcha;
 use App\Modules\Platform\Installation\Installation;
 use App\Modules\Platform\Localization\LocaleRegistry;
 use App\Modules\Platform\Localization\TimezoneRegistry;
+use App\Modules\Platform\OfficialLinks;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
 use App\Modules\Platform\Updates\LatestReleaseInfo;
@@ -72,7 +73,10 @@ class HandleInertiaRequests extends Middleware
             'edition' => $capabilities->edition()->value,
             'noindex' => app(Settings::class)->get(Setting::DiscourageSearchIndexing),
             'version' => config('projectsend.version'),
-            'links' => config('projectsend.links'),
+            // Resolved rather than handed over raw: each edition has its
+            // own front door, and a managed installation offers no
+            // donation link at all. See OfficialLinks.
+            'links' => app(OfficialLinks::class)->toArray(),
             // Whether the client- and visitor-facing surfaces name
             // ProjectSend. True everywhere unless a package answers
             // otherwise — see ResolvingAttribution. Staff surfaces

--- a/app/Modules/Platform/OfficialLinks.php
+++ b/app/Modules/Platform/OfficialLinks.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform;
+
+use App\Modules\Platform\Capabilities\CapabilityRegistry;
+use App\Modules\Platform\Capabilities\Edition;
+
+/**
+ * Where "ProjectSend" points, which is not the same address for both
+ * editions.
+ *
+ * Each edition has its own front door — projectsend.org for the software
+ * you run yourself, projectsend.cloud for the hosted service — and the
+ * link belongs to whichever one the reader is actually using. It matters
+ * beyond the About screen: the "Powered by ProjectSend" line at the foot
+ * of every outgoing email and on every client-facing page is the one
+ * place a recipient meets the product for the first time, and sending a
+ * hosted customer's recipients to the self-hosting instructions is the
+ * wrong door.
+ *
+ * The donation link is dropped on a managed installation for a simpler
+ * reason: those customers are already paying for this. Asking again, on
+ * the screen that thanks them for choosing it, reads as not having
+ * noticed.
+ *
+ * Resolved here rather than in the config file so both readers get the
+ * same answer — the Inertia shared props and the two mail footers, which
+ * read `config('projectsend.links.website')` straight out of Blade.
+ */
+class OfficialLinks
+{
+    public function __construct(private readonly CapabilityRegistry $capabilities) {}
+
+    /**
+     * @return array{website: string, source: string, discord: string, open_collective?: string}
+     */
+    public function toArray(): array
+    {
+        /** @var array<string, string> $links */
+        $links = config('projectsend.links');
+
+        $resolved = [
+            'website' => $this->website(),
+            'source' => $links['source'] ?? '',
+            'discord' => $links['discord'] ?? '',
+        ];
+
+        // Omitted rather than hidden by the page, so a surface added later
+        // cannot ask a paying customer for a donation by forgetting to
+        // check.
+        if (! $this->managed()) {
+            $resolved['open_collective'] = $links['open_collective'] ?? '';
+        }
+
+        return $resolved;
+    }
+
+    public function website(): string
+    {
+        /** @var array<string, string> $links */
+        $links = config('projectsend.links');
+
+        return $this->managed()
+            ? ($links['website_cloud'] ?? $links['website'])
+            : $links['website'];
+    }
+
+    private function managed(): bool
+    {
+        return $this->capabilities->edition() === Edition::Cloud;
+    }
+}

--- a/config/projectsend.php
+++ b/config/projectsend.php
@@ -80,8 +80,15 @@ return [
     |--------------------------------------------------------------------------
     */
 
+    // Read through App\Modules\Platform\OfficialLinks rather than
+    // directly: which of the two front doors "website" means, and whether
+    // the donation link is offered at all, both depend on the edition.
     'links' => [
         'website' => 'https://www.projectsend.org/',
+        // The hosted service's own front door. A managed installation
+        // links here instead — including from the "Powered by" line on
+        // client-facing pages and outgoing email.
+        'website_cloud' => 'https://www.projectsend.cloud/',
         // Where this code lives, and the same repository
         // CheckForUpdatesCommand asks for the latest release. v1 remains
         // available at github.com/projectsend/legacy.

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "La versió curta del que cal fer en una instal·lació nova. Res d'això caduca.",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Ara estàs a la :version i tot ha tornat a funcionar. Gràcies per continuar confiant en el ProjectSend per compartir els teus fitxers.",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Ara estàs a la :version, des de la :previous, i tot ha tornat a funcionar. Gràcies per continuar confiant en el ProjectSend per compartir els teus fitxers.",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Estàs fent servir la versió :version, i és teva. Això és el que convé fer primer."
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Estàs fent servir la versió :version, i és teva. Això és el que convé fer primer.",
+    "Thank you for choosing ProjectSend": "Gràcies per triar el ProjectSend",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "El teu lloc està a punt, i mantenir-lo en marxa és feina nostra. Això és el que convé fer primer."
 }

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "Krátká verze toho, co udělat na nové instalaci. Nic z toho nevyprší.",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Nyní máte :version a vše je zase v provozu. Děkujeme, že své soubory nadále svěřujete ProjectSendu.",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Nyní máte :version, z :previous, a vše je zase v provozu. Děkujeme, že své soubory nadále svěřujete ProjectSendu.",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Používáte verzi :version a je vaše. Tohle se vyplatí udělat jako první."
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Používáte verzi :version a je vaše. Tohle se vyplatí udělat jako první.",
+    "Thank you for choosing ProjectSend": "Děkujeme, že jste si vybrali ProjectSend",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "Váš web je připravený a jeho provoz je na nás. Tohle se vyplatí udělat jako první."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "Die Kurzfassung dessen, was auf einer neuen Installation zu tun ist. Nichts davon läuft ab.",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Sie sind jetzt auf :version, und alles läuft wieder. Danke, dass Sie ProjectSend weiterhin Ihre Dateien anvertrauen.",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Sie sind jetzt auf :version, zuvor :previous, und alles läuft wieder. Danke, dass Sie ProjectSend weiterhin Ihre Dateien anvertrauen.",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Sie nutzen Version :version, und sie gehört Ihnen. Das hier lohnt sich zuerst."
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Sie nutzen Version :version, und sie gehört Ihnen. Das hier lohnt sich zuerst.",
+    "Thank you for choosing ProjectSend": "Danke, dass Sie sich für ProjectSend entschieden haben",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "Ihre Website ist bereit, und der Betrieb ist unsere Sache. Das hier lohnt sich zuerst."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "La versión corta de qué hacer en una instalación nueva. Nada de esto caduca.",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Ahora estás en la :version y todo volvió a funcionar. Gracias por seguir confiando en ProjectSend para compartir tus archivos.",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Ahora estás en la :version, desde la :previous, y todo volvió a funcionar. Gracias por seguir confiando en ProjectSend para compartir tus archivos.",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Estás usando la versión :version, y es tuya. Esto es lo que conviene hacer primero."
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Estás usando la versión :version, y es tuya. Esto es lo que conviene hacer primero.",
+    "Thank you for choosing ProjectSend": "Gracias por elegir ProjectSend",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "Tu sitio está listo, y mantenerlo funcionando es cosa nuestra. Esto es lo que conviene hacer primero."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "La version courte de ce qu'il faut faire sur une nouvelle installation. Rien de tout cela n'expire.",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Vous êtes maintenant en :version, et tout est reparti. Merci de continuer à confier vos fichiers à ProjectSend.",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Vous êtes maintenant en :version, contre :previous auparavant, et tout est reparti. Merci de continuer à confier vos fichiers à ProjectSend.",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Vous utilisez la version :version, et elle est à vous. Voici ce qui vaut la peine d'être fait en premier."
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Vous utilisez la version :version, et elle est à vous. Voici ce qui vaut la peine d'être fait en premier.",
+    "Thank you for choosing ProjectSend": "Merci d'avoir choisi ProjectSend",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "Votre site est prêt, et le faire tourner, c'est notre travail. Voici ce qui vaut la peine d'être fait en premier."
 }

--- a/lang/id.json
+++ b/lang/id.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "Versi singkat dari apa yang perlu dilakukan pada instalasi baru. Tidak ada yang kedaluwarsa di sini.",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Anda kini di :version dan semuanya kembali berjalan. Terima kasih telah terus mempercayakan berbagi berkas Anda pada ProjectSend.",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Anda kini di :version, dari :previous, dan semuanya kembali berjalan. Terima kasih telah terus mempercayakan berbagi berkas Anda pada ProjectSend.",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Anda menjalankan versi :version, dan ini milik Anda. Inilah yang sebaiknya dilakukan lebih dulu."
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Anda menjalankan versi :version, dan ini milik Anda. Inilah yang sebaiknya dilakukan lebih dulu.",
+    "Thank you for choosing ProjectSend": "Terima kasih telah memilih ProjectSend",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "Situs Anda sudah siap, dan menjaganya tetap berjalan adalah tugas kami. Inilah yang sebaiknya dilakukan lebih dulu."
 }

--- a/lang/it.json
+++ b/lang/it.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "La versione breve di cosa fare su una nuova installazione. Niente di tutto questo scade.",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Ora sei alla :version e tutto è tornato attivo. Grazie per continuare ad affidare i tuoi file a ProjectSend.",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Ora sei alla :version, dalla :previous, e tutto è tornato attivo. Grazie per continuare ad affidare i tuoi file a ProjectSend.",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Stai usando la versione :version, ed è tua. Ecco cosa conviene fare per primo."
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Stai usando la versione :version, ed è tua. Ecco cosa conviene fare per primo.",
+    "Thank you for choosing ProjectSend": "Grazie per aver scelto ProjectSend",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "Il tuo sito è pronto, e tenerlo in funzione è compito nostro. Ecco cosa conviene fare per primo."
 }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "新しいインストールでやることの要点です。期限はありません。",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "現在 :version です。すべて元どおり動作しています。これからも ProjectSend にファイル共有をお任せいただきありがとうございます。",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": ":previous から :version になりました。すべて元どおり動作しています。これからも ProjectSend にファイル共有をお任せいただきありがとうございます。",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "バージョン :version を使っています。まず何をするとよいかをまとめました。"
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "バージョン :version を使っています。まず何をするとよいかをまとめました。",
+    "Thank you for choosing ProjectSend": "ProjectSend をお選びいただきありがとうございます",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "サイトの準備が整いました。運用は私たちにお任せください。まず何をするとよいかをまとめました。"
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "De korte versie van wat je op een nieuwe installatie doet. Niets hiervan verloopt.",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Je draait nu op :version en alles draait weer. Bedankt dat je je bestandsdeling aan ProjectSend blijft toevertrouwen.",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Je draait nu op :version, vanaf :previous, en alles draait weer. Bedankt dat je je bestandsdeling aan ProjectSend blijft toevertrouwen.",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Je draait versie :version, en die is van jou. Dit is wat je het eerst wilt doen."
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Je draait versie :version, en die is van jou. Dit is wat je het eerst wilt doen.",
+    "Thank you for choosing ProjectSend": "Bedankt dat je voor ProjectSend hebt gekozen",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "Je site is klaar, en hem draaiende houden is onze taak. Dit is wat je het eerst wilt doen."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "Krótka wersja tego, co zrobić na nowej instalacji. Nic z tego nie wygasa.",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Masz teraz :version i wszystko znów działa. Dziękujemy, że nadal powierzasz swoje pliki ProjectSend.",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Masz teraz :version, z :previous, i wszystko znów działa. Dziękujemy, że nadal powierzasz swoje pliki ProjectSend.",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Używasz wersji :version i jest twoja. Oto, co warto zrobić najpierw."
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Używasz wersji :version i jest twoja. Oto, co warto zrobić najpierw.",
+    "Thank you for choosing ProjectSend": "Dziękujemy za wybór ProjectSend",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "Twoja witryna jest gotowa, a utrzymanie jej to nasza sprawa. Oto, co warto zrobić najpierw."
 }

--- a/lang/pt_BR.json
+++ b/lang/pt_BR.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "A versão curta do que fazer em uma instalação nova. Nada disso expira.",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Você está na :version agora e tudo voltou a funcionar. Obrigado por continuar confiando seus arquivos ao ProjectSend.",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Você está na :version agora, vindo da :previous, e tudo voltou a funcionar. Obrigado por continuar confiando seus arquivos ao ProjectSend.",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Você está usando a versão :version, e ela é sua. Veja o que vale a pena fazer primeiro."
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Você está usando a versão :version, e ela é sua. Veja o que vale a pena fazer primeiro.",
+    "Thank you for choosing ProjectSend": "Obrigado por escolher o ProjectSend",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "Seu site está pronto, e mantê-lo funcionando é trabalho nosso. Veja o que vale a pena fazer primeiro."
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "Коротко о том, что стоит сделать на новой установке. Ничего из этого не устаревает.",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Теперь у вас :version, и всё снова работает. Спасибо, что продолжаете доверять обмен файлами ProjectSend.",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Теперь у вас :version вместо :previous, и всё снова работает. Спасибо, что продолжаете доверять обмен файлами ProjectSend.",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Вы используете версию :version, и она ваша. Вот что стоит сделать в первую очередь."
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Вы используете версию :version, и она ваша. Вот что стоит сделать в первую очередь.",
+    "Thank you for choosing ProjectSend": "Спасибо, что выбрали ProjectSend",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "Ваш сайт готов, а поддерживать его работу — наша забота. Вот что стоит сделать в первую очередь."
 }

--- a/lang/sw.json
+++ b/lang/sw.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "Muhtasari wa cha kufanya kwenye usakinishaji mpya. Hakuna kinachoisha muda hapa.",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Sasa uko kwenye :version na kila kitu kimerudi kufanya kazi. Asante kwa kuendelea kuamini ProjectSend kwa kushiriki mafaili yako.",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Sasa uko kwenye :version, kutoka :previous, na kila kitu kimerudi kufanya kazi. Asante kwa kuendelea kuamini ProjectSend kwa kushiriki mafaili yako.",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Unatumia toleo :version, na ni lako. Haya ndiyo yanayofaa kufanywa kwanza."
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Unatumia toleo :version, na ni lako. Haya ndiyo yanayofaa kufanywa kwanza.",
+    "Thank you for choosing ProjectSend": "Asante kwa kuchagua ProjectSend",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "Tovuti yako iko tayari, na kuiendesha ni kazi yetu. Haya ndiyo yanayofaa kufanywa kwanza."
 }

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "Yeni bir kurulumda yapılacakların kısa hâli. Bunların hiçbiri zaman aşımına uğramaz.",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Artık :version sürümündesiniz ve her şey yeniden çalışıyor. Dosya paylaşımınız için ProjectSend'e güvenmeye devam ettiğiniz için teşekkürler.",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Artık :version sürümündesiniz, :previous sürümünden geldiniz ve her şey yeniden çalışıyor. Dosya paylaşımınız için ProjectSend'e güvenmeye devam ettiğiniz için teşekkürler.",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": ":version sürümünü kullanıyorsunuz ve o sizin. İlk yapmaya değecek şeyler burada."
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": ":version sürümünü kullanıyorsunuz ve o sizin. İlk yapmaya değecek şeyler burada.",
+    "Thank you for choosing ProjectSend": "ProjectSend'i seçtiğiniz için teşekkürler",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "Siteniz hazır, çalışır durumda tutmak da bizim işimiz. İlk yapmaya değecek şeyler burada."
 }

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "Bản tóm tắt những việc nên làm trên một bản cài đặt mới. Không có gì ở đây hết hạn.",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Bạn đang dùng :version và mọi thứ đã hoạt động trở lại. Cảm ơn bạn đã tiếp tục tin tưởng ProjectSend cho việc chia sẻ tệp.",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "Bạn đang dùng :version, lên từ :previous, và mọi thứ đã hoạt động trở lại. Cảm ơn bạn đã tiếp tục tin tưởng ProjectSend cho việc chia sẻ tệp.",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Bạn đang chạy phiên bản :version, và nó là của bạn. Đây là những việc nên làm trước tiên."
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "Bạn đang chạy phiên bản :version, và nó là của bạn. Đây là những việc nên làm trước tiên.",
+    "Thank you for choosing ProjectSend": "Cảm ơn bạn đã chọn ProjectSend",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "Trang của bạn đã sẵn sàng, và việc duy trì nó là của chúng tôi. Đây là những việc nên làm trước tiên."
 }

--- a/lang/zh_CN.json
+++ b/lang/zh_CN.json
@@ -1822,5 +1822,7 @@
     "The short version of what to do on a new installation. Nothing here expires.": "新安装该做什么的精简版。这些都不会过期。",
     "You are now on :version, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "你现在使用的是 :version，一切都已恢复正常。感谢你继续把文件分享交给 ProjectSend。",
     "You are now on :version, up from :previous, and everything came back up. Thank you for continuing to trust ProjectSend with your file sharing.": "你现在使用的是 :version，从 :previous 升级而来，一切都已恢复正常。感谢你继续把文件分享交给 ProjectSend。",
-    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "你正在使用版本 :version，它属于你。以下是值得先做的事。"
+    "You are running version :version, and it is yours to keep. Here is what is worth doing first.": "你正在使用版本 :version，它属于你。以下是值得先做的事。",
+    "Thank you for choosing ProjectSend": "感谢你选择 ProjectSend",
+    "Your site is ready, and keeping it running is our job. Here is what is worth doing first.": "你的站点已就绪，运行维护交给我们。以下是值得先做的事。"
 }

--- a/resources/js/pages/system/about.tsx
+++ b/resources/js/pages/system/about.tsx
@@ -67,9 +67,13 @@ export default function About({ license, environment }: AboutProps) {
                         <a href={links.source} target="_blank" rel="noreferrer" className="underline hover:no-underline">
                             {t('Source code')}
                         </a>
-                        <a href={links.open_collective} target="_blank" rel="noreferrer" className="underline hover:no-underline">
-                            {t('Support the project')}
-                        </a>
+                        {/* Absent on a managed installation, where the reader
+                            is already paying for this — see OfficialLinks. */}
+                        {links.open_collective && (
+                            <a href={links.open_collective} target="_blank" rel="noreferrer" className="underline hover:no-underline">
+                                {t('Support the project')}
+                            </a>
+                        )}
                         <a href={links.discord} target="_blank" rel="noreferrer" className="underline hover:no-underline">
                             {t('Discord')}
                         </a>

--- a/resources/js/pages/system/getting-started.tsx
+++ b/resources/js/pages/system/getting-started.tsx
@@ -44,7 +44,14 @@ const ICONS: Record<string, LucideIcon> = {
 
 export default function GettingStarted({ items, justInstalled }: GettingStartedProps) {
     const { t } = useTranslation();
-    const { version } = usePage<SharedData>().props;
+    const { version, edition } = usePage<SharedData>().props;
+
+    // Nobody on a managed installation installed anything, and the version
+    // they are running is not theirs to keep or to change — it is looked
+    // after for them. Thanking them for installing it would be thanking
+    // them for somebody else's work, on the one screen whose whole job is
+    // to sound like a person wrote it.
+    const managed = edition === 'cloud';
 
     const breadcrumbs: BreadcrumbItem[] = [{ title: t('Getting started'), href: '/system/getting-started' }];
 
@@ -56,14 +63,20 @@ export default function GettingStarted({ items, justInstalled }: GettingStartedP
                 <div className="mx-auto max-w-3xl space-y-8">
                     <div className="space-y-2 text-center">
                         <h1 className="text-2xl font-semibold tracking-tight">
-                            {justInstalled ? t('Thank you for installing ProjectSend') : t('Getting started')}
+                            {justInstalled
+                                ? managed
+                                    ? t('Thank you for choosing ProjectSend')
+                                    : t('Thank you for installing ProjectSend')
+                                : t('Getting started')}
                         </h1>
 
                         <p className="text-muted-foreground text-sm">
                             {justInstalled
-                                ? t('You are running version :version, and it is yours to keep. Here is what is worth doing first.', {
-                                      version,
-                                  })
+                                ? managed
+                                    ? t('Your site is ready, and keeping it running is our job. Here is what is worth doing first.')
+                                    : t('You are running version :version, and it is yours to keep. Here is what is worth doing first.', {
+                                          version,
+                                      })
                                 : t('The short version of what to do on a new installation. Nothing here expires.')}
                         </p>
                     </div>

--- a/resources/js/pages/system/settings/general.tsx
+++ b/resources/js/pages/system/settings/general.tsx
@@ -132,13 +132,26 @@ export default function SystemSettings({
 
                 <p className="text-muted-foreground/70 mt-10 text-xs">
                     ProjectSend {version} ·{' '}
+                    {/* The host, not a hardcoded "projectsend.org": each
+                        edition has its own front door and this line used to
+                        name the wrong one on the hosted service. */}
                     <a href={links.website} target="_blank" rel="noreferrer" className="hover:text-muted-foreground underline">
-                        projectsend.org
-                    </a>{' '}
-                    ·{' '}
-                    <a href={links.open_collective} target="_blank" rel="noreferrer" className="hover:text-muted-foreground underline">
-                        {t('Support the project')}
+                        {new URL(links.website).host.replace(/^www\./, '')}
                     </a>
+                    {links.open_collective && (
+                        <>
+                            {' '}
+                            ·{' '}
+                            <a
+                                href={links.open_collective}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="hover:text-muted-foreground underline"
+                            >
+                                {t('Support the project')}
+                            </a>
+                        </>
+                    )}
                 </p>
             </div>
         </AppLayout>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -72,10 +72,12 @@ export interface SharedData {
     edition: Edition;
     version: string;
     links: {
+        /** projectsend.org, or projectsend.cloud on a managed installation. */
         website: string;
         source: string;
-        open_collective: string;
         discord: string;
+        /** Absent on a managed installation — those customers already pay. */
+        open_collective?: string;
     };
     /**
      * Whether this installation names ProjectSend to its clients and

--- a/resources/views/vendor/mail/html/footer.blade.php
+++ b/resources/views/vendor/mail/html/footer.blade.php
@@ -19,7 +19,8 @@
 <td class="content-cell" align="center">
 {{ Illuminate\Mail\Markdown::parse($slot) }}
 @if ($mail_attribution ?? true)
-<p><a href="{{ config('projectsend.links.website') }}">{{ __('Powered by ProjectSend') }}</a></p>
+{{-- Each edition has its own front door, so this is resolved rather than read straight out of config — see OfficialLinks. --}}
+<p><a href="{{ app(App\Modules\Platform\OfficialLinks::class)->website() }}">{{ __('Powered by ProjectSend') }}</a></p>
 @endif
 </td>
 </tr>

--- a/resources/views/vendor/mail/text/footer.blade.php
+++ b/resources/views/vendor/mail/text/footer.blade.php
@@ -5,5 +5,5 @@
 {{ $slot }}
 @if ($mail_attribution ?? true)
 
-{{ __('Powered by ProjectSend') }}: {{ config('projectsend.links.website') }}
+{{ __('Powered by ProjectSend') }}: {{ app(App\Modules\Platform\OfficialLinks::class)->website() }}
 @endif

--- a/tests/Feature/Platform/OfficialLinksTest.php
+++ b/tests/Feature/Platform/OfficialLinksTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Platform\Capabilities\Edition;
+use App\Modules\Platform\OfficialLinks;
+use Inertia\Testing\AssertableInertia;
+
+/**
+ * Each edition has its own front door, and only one of them asks for
+ * donations.
+ */
+beforeEach(function () {
+    $this->admin = User::factory()->create();
+});
+
+function officialLinks(Edition $edition): array
+{
+    config()->set('projectsend.edition', $edition);
+    app()->forgetInstance(App\Modules\Platform\Capabilities\CapabilityRegistry::class);
+
+    return app(OfficialLinks::class)->toArray();
+}
+
+test('a self-hosted installation points at projectsend.org', function () {
+    $links = officialLinks(Edition::Community);
+
+    expect($links['website'])->toBe('https://www.projectsend.org/');
+});
+
+test('a managed installation points at projectsend.cloud', function () {
+    $links = officialLinks(Edition::Cloud);
+
+    expect($links['website'])->toBe('https://www.projectsend.cloud/');
+});
+
+// Omitted rather than hidden by the page: a surface added later cannot
+// ask a paying customer for a donation by forgetting to check.
+test('a managed installation offers no donation link at all', function () {
+    expect(officialLinks(Edition::Cloud))->not->toHaveKey('open_collective')
+        ->and(officialLinks(Edition::Community))->toHaveKey('open_collective');
+});
+
+test('the source and the community are the same for both', function () {
+    $community = officialLinks(Edition::Community);
+    $cloud = officialLinks(Edition::Cloud);
+
+    expect($cloud['source'])->toBe($community['source'])
+        ->and($cloud['discord'])->toBe($community['discord']);
+});
+
+test('the resolved links are what every page is handed', function () {
+    config()->set('projectsend.edition', Edition::Cloud);
+    app()->forgetInstance(App\Modules\Platform\Capabilities\CapabilityRegistry::class);
+
+    $this->actingAs($this->admin)->get('/system/about')->assertInertia(
+        fn (AssertableInertia $page) => $page
+            ->where('links.website', 'https://www.projectsend.cloud/')
+            ->missing('links.open_collective'),
+    );
+});
+
+// The "Powered by ProjectSend" line at the foot of every outgoing message
+// is where a recipient meets the product for the first time. Sending a
+// hosted customer's recipients to the self-hosting instructions is the
+// wrong door, and that footer reads the link straight out of Blade.
+test('the mail footers resolve the link rather than reading the config', function () {
+    foreach (['html', 'text'] as $format) {
+        $footer = file_get_contents(resource_path("views/vendor/mail/{$format}/footer.blade.php"));
+
+        expect($footer)->toContain('OfficialLinks')
+            ->and($footer)->not->toContain("config('projectsend.links.website')");
+    }
+});


### PR DESCRIPTION
Three things written when there was only one edition, all of them addressed to somebody who did not install this and is already paying for it.

## The greeting

| | Community | Cloud |
|---|---|---|
| Heading | Thank you for **installing** ProjectSend | Thank you for **choosing** ProjectSend |
| Lead | You are running version 2.0.0, and it is yours to keep. Here is what is worth doing first. | Your site is ready, and keeping it running is our job. Here is what is worth doing first. |

The version comes out of the sentence on Cloud. It is true, and it is none of their concern — which is what makes it noise there, while on self-hosted it is the first thing you want to know.

Branched on the shared `edition` prop, not a capability: `SystemUpdates` happens to line up today, but it is about who may *update*, not who *installed*.

## The front door

`projectsend.org` is the way in for the software you run yourself; `projectsend.cloud` is the way in for the hosted service. `links.website` now resolves to whichever one the reader is actually using, through a new `OfficialLinks`.

**This deliberately reaches past the About screen.** The "Powered by ProjectSend" line at the foot of every outgoing email and on every client-facing page is where a recipient meets this product for the first time — sending a hosted customer's recipients to self-hosting instructions is the wrong door. Both mail footers read the resolved link now instead of the raw config value, and a test asserts they keep doing so.

## The donation link

Hidden on Cloud, where the reader is already paying — and asking again on the screen that thanks them for choosing it reads as not having noticed.

It is **omitted from the shared props** rather than hidden by the page, so a surface added later cannot ask a paying customer for money by forgetting to check. `open_collective` is optional in the TypeScript type, so the compiler enforces the same thing.

Also fixed on the way past: `system/settings/general` hardcoded the text "projectsend.org" next to that link, so on the hosted service it *named* a site it did not *link to*. It reads the host off the resolved URL now.

## Testing

- 1682 Pest tests, PHPStan, `tsc`, ESLint green. Scan: **0 missing** in all sixteen locales; orphans unchanged at 277.
- Six new tests: both editions' website, the donation link present/absent, the shared props a page actually receives, and the two mail footers.
- **Driven in a real browser against both editions**, flipping `PROJECTSEND_EDITION` and reading every outbound link off the rendered page:

```
cloud     /system/about            -> projectsend.cloud | Source code | Discord
cloud     /system/settings/general -> projectsend.cloud
community /system/about            -> projectsend.org | Source code | Support the project | Discord
community /system/settings/general -> projectsend.org | Support the project
```

Both new greeting strings ship translated into all sixteen catalogues in the same commit — two strings, and splitting it would leave every hosted customer's greeting English-only until the next pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)