### PR TITLE
Finish the update story before 2.1.0

### DIFF
--- a/app/Modules/Notifications/Console/PurgeNotificationsCommand.php
+++ b/app/Modules/Notifications/Console/PurgeNotificationsCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Notifications\Console;
+
+use App\Modules\Notifications\InAppNotification;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+use Illuminate\Console\Command;
+
+/**
+ * Delete read notifications past the retention window.
+ *
+ * One row per recipient per event, and until now nothing ever removed
+ * one. On an installation where every share notifies a handful of people
+ * this is the fastest-growing table in the database, and the growth buys
+ * nothing: nobody scrolls a year back through a notification list.
+ *
+ * **Unread notifications are never deleted, at any age.** A notification
+ * nobody has looked at is the one thing in this table still doing its
+ * job, and an installation whose owner was away for four months should
+ * come back to their news rather than to a clean slate. The history is
+ * not an audit trail either way — the activity log is, and it is never
+ * pruned.
+ */
+class PurgeNotificationsCommand extends Command
+{
+    protected $signature = 'projectsend:purge-notifications';
+
+    protected $description = 'Delete read notifications older than the configured retention window (runs daily)';
+
+    public function handle(Settings $settings): int
+    {
+        $days = (int) $settings->get(Setting::NotificationRetentionDays);
+
+        if ($days <= 0) {
+            $this->info('Notification retention is disabled; nothing pruned.');
+
+            return self::SUCCESS;
+        }
+
+        // Chunked for the same reason the API request log is: this is a
+        // high-volume table, and a single unbounded DELETE on a busy
+        // installation holds locks for as long as it takes.
+        $cutoff = now()->subDays($days);
+        $deleted = 0;
+
+        do {
+            $batch = InAppNotification::query()
+                ->whereNotNull('read_at')
+                ->where('created_at', '<', $cutoff)
+                ->limit(5000)
+                ->delete();
+            $deleted += $batch;
+        } while ($batch > 0);
+
+        $this->info("Pruned {$deleted} read notifications older than {$days} days.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Modules/Notifications/NotificationsServiceProvider.php
+++ b/app/Modules/Notifications/NotificationsServiceProvider.php
@@ -18,6 +18,12 @@ class NotificationsServiceProvider extends ServiceProvider
         $this->app->singleton(NotificationTypeRegistry::class);
         $this->app->singleton(Notifier::class);
         $this->app->singleton(NotificationPreferences::class);
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                Console\PurgeNotificationsCommand::class,
+            ]);
+        }
     }
 
     public function boot(): void

--- a/app/Modules/Platform/Http/Controllers/AboutController.php
+++ b/app/Modules/Platform/Http/Controllers/AboutController.php
@@ -7,6 +7,8 @@ namespace App\Modules\Platform\Http\Controllers;
 use App\Http\Controllers\Controller;
 use App\Modules\Platform\Capabilities\Capability;
 use App\Modules\Platform\Capabilities\CapabilityRegistry;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
 use App\Modules\Platform\System\SystemEnvironment;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -32,6 +34,7 @@ class AboutController extends Controller
     public function __construct(
         private readonly CapabilityRegistry $capabilities,
         private readonly SystemEnvironment $environment,
+        private readonly Settings $settings,
     ) {}
 
     public function __invoke(Request $request): Response
@@ -45,6 +48,35 @@ class AboutController extends Controller
         return Inertia::render('system/about', [
             'license' => 'GNU General Public License v2',
             'environment' => $canSeeEnvironment ? $this->environment->toArray() : null,
+            'updated' => $canSeeEnvironment ? $this->lastUpdate() : null,
         ]);
+    }
+
+    /**
+     * When `projectsend:update` last brought this installation to a new
+     * version.
+     *
+     * Both values are written by that command alone, and RunningCodeState
+     * has until now been their only reader — which means the fact was
+     * recorded and then only ever mentioned when something was *wrong*.
+     * On a healthy installation nothing said when it was last updated,
+     * which is the ordinary question of the two.
+     *
+     * Null on anything that has never been updated through the command: a
+     * fresh install, or one older than the command itself. There is no
+     * honest date to show there, and "unknown" is noise.
+     *
+     * @return array{version: string, at: string}|null
+     */
+    private function lastUpdate(): ?array
+    {
+        $version = $this->settings->get(Setting::AppliedVersion);
+        $at = $this->settings->get(Setting::AppliedVersionAt);
+
+        if (! is_string($version) || $version === '' || ! is_string($at) || $at === '') {
+            return null;
+        }
+
+        return ['version' => $version, 'at' => $at];
     }
 }

--- a/app/Modules/Platform/Http/Controllers/SchedulerMonitoringController.php
+++ b/app/Modules/Platform/Http/Controllers/SchedulerMonitoringController.php
@@ -6,6 +6,9 @@ namespace App\Modules\Platform\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use App\Modules\Platform\Scheduling\ScheduledTaskRun;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+use App\Modules\Platform\Updates\LatestReleaseInfo;
 use App\Support\Pagination;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -48,13 +51,16 @@ class SchedulerMonitoringController extends Controller
 
     public function __construct(
         private readonly FailedJobProviderInterface $failer,
+        private readonly LatestReleaseInfo $latestRelease,
+        private readonly Settings $settings,
     ) {}
 
     public function index(Request $request): Response|RedirectResponse
     {
         $runs = ScheduledTaskRun::query()->get()->keyBy('command');
+        $details = $this->details();
 
-        $tasks = collect(self::KNOWN_COMMANDS)->map(function (string $label, string $command) use ($runs): array {
+        $tasks = collect(self::KNOWN_COMMANDS)->map(function (string $label, string $command) use ($runs, $details): array {
             $run = $runs->get($command);
 
             return [
@@ -62,6 +68,7 @@ class SchedulerMonitoringController extends Controller
                 'label' => $label,
                 'status' => $run?->status->value,
                 'message' => $run?->message,
+                'detail' => $details[$command] ?? null,
                 'duration_ms' => $run?->duration_ms,
                 'ran_at' => $run?->ran_at?->toIso8601String(),
             ];
@@ -136,5 +143,33 @@ class SchedulerMonitoringController extends Controller
         $this->failer->flush();
 
         return back()->with('success', __('All failed jobs deleted.'));
+    }
+
+    /**
+     * What a task actually found, for the tasks that find something.
+     *
+     * The run rows answer "did it work"; they cannot answer "and what did
+     * it say", because Laravel's ScheduledTaskFinished event fires after
+     * the command returns and carries no output — which is why a
+     * successful check for updates has always shown an empty Message.
+     * Joined here at render time instead, from what the command itself
+     * wrote to the settings, so the line stays true whether the daily job
+     * or somebody pressing the button did the work.
+     *
+     * @return array<string, string>
+     */
+    private function details(): array
+    {
+        $release = $this->latestRelease->current();
+        $checkedAt = $this->settings->get(Setting::LatestVersionCheckedAt);
+        $everChecked = is_string($checkedAt) && $checkedAt !== '';
+
+        $updates = match (true) {
+            $release !== null => (string) __(':version is available', ['version' => $release['version']]),
+            $everChecked => (string) __('Up to date'),
+            default => null,
+        };
+
+        return array_filter(['projectsend:check-for-updates' => $updates]);
     }
 }

--- a/app/Modules/Platform/Http/Controllers/SchedulerMonitoringController.php
+++ b/app/Modules/Platform/Http/Controllers/SchedulerMonitoringController.php
@@ -45,6 +45,9 @@ class SchedulerMonitoringController extends Controller
         'projectsend:fetch-news' => 'Fetch dashboard news',
         'projectsend:purge-expired-files' => 'Purge expired files',
         'projectsend:purge-orphan-files' => 'Purge orphan files',
+        'projectsend:purge-api-request-logs' => 'Purge API request logs',
+        'projectsend:purge-failed-jobs' => 'Purge failed jobs',
+        'projectsend:purge-notifications' => 'Purge read notifications',
     ];
 
     private const FAILED_PER_PAGE = 20;
@@ -117,7 +120,34 @@ class SchedulerMonitoringController extends Controller
             'failed_pagination' => Pagination::meta($paginator),
             'failed_total' => $failed->count(),
             'pending_jobs_count' => DB::table('jobs')->count(),
+            'retention' => [
+                'failed_jobs' => (int) $this->settings->get(Setting::FailedJobRetentionDays),
+                'notifications' => (int) $this->settings->get(Setting::NotificationRetentionDays),
+            ],
         ]);
+    }
+
+    /**
+     * How long the two tables that grow on their own are kept.
+     *
+     * They live on this screen because this is where their purges are
+     * listed: the window and the job that honours it are one idea, and an
+     * administrator who has just seen "Purge failed jobs · never run" is
+     * the person asking how long anything is kept.
+     */
+    public function updateRetention(Request $request): RedirectResponse
+    {
+        // Ten years is not a policy, it is a guard against a typo becoming
+        // a number nobody notices. 0 is the real "keep everything".
+        $validated = $request->validate([
+            'failed_jobs' => ['required', 'integer', 'min:0', 'max:3650'],
+            'notifications' => ['required', 'integer', 'min:0', 'max:3650'],
+        ]);
+
+        $this->settings->set(Setting::FailedJobRetentionDays, $validated['failed_jobs']);
+        $this->settings->set(Setting::NotificationRetentionDays, $validated['notifications']);
+
+        return back()->with('success', __('Retention updated.'));
     }
 
     public function retryFailedJob(string $uuid): RedirectResponse

--- a/app/Modules/Platform/Http/Controllers/SystemSettingsController.php
+++ b/app/Modules/Platform/Http/Controllers/SystemSettingsController.php
@@ -12,6 +12,8 @@ use App\Modules\Platform\Capabilities\CapabilityRegistry;
 use App\Modules\Platform\Localization\TimezoneRegistry;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
+use App\Modules\Platform\Updates\CheckForUpdates;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
@@ -25,6 +27,13 @@ use Inertia\Response;
  */
 class SystemSettingsController extends Controller
 {
+    /**
+     * How long an answer from the release feed is treated as still true.
+     * Short enough that "check now" means now, long enough that a room
+     * full of administrators cannot spend the server's whole allowance.
+     */
+    private const CHECK_COOLDOWN_MINUTES = 5;
+
     public function __construct(
         private readonly Settings $settings,
         private readonly ActivityLogger $activity,
@@ -53,7 +62,61 @@ class SystemSettingsController extends Controller
             'viewer_timezone' => $request->user()?->timezone,
             'can_manage_updates' => $canManageUpdates,
             'check_for_updates' => $canManageUpdates ? $this->settings->get(Setting::CheckForUpdates) : null,
+            'last_checked_at' => $canManageUpdates ? $this->lastCheckedAt()?->toIso8601String() : null,
+            'check_result' => $request->session()->get('update_check_result'),
         ]);
+    }
+
+    /**
+     * Ask the release feed now, rather than waiting for tonight's run.
+     *
+     * Deliberately not gated on Setting::CheckForUpdates: that switches
+     * off the unattended daily call, which is not the same as refusing to
+     * answer a question somebody has just asked out loud.
+     */
+    public function checkForUpdates(Request $request, CheckForUpdates $check): RedirectResponse
+    {
+        $canManageUpdates = $this->capabilities->has(Capability::SystemUpdates)
+            && $request->user()?->can('manage_updates') === true;
+
+        abort_unless($canManageUpdates, 403);
+
+        // A second throttle, and not a redundant one. The route's bucket is
+        // per user; GitHub's unauthenticated rate limit is per server
+        // address, so two administrators each within their own allowance
+        // can still exhaust the installation's. This one is the whole
+        // installation's, and it costs no new setting — the timestamp it
+        // reads is the one every check already writes.
+        $lastCheckedAt = $this->lastCheckedAt();
+
+        if ($lastCheckedAt !== null && $lastCheckedAt->gt(now()->subMinutes(self::CHECK_COOLDOWN_MINUTES))) {
+            return back()->with('update_check_result', [
+                'ok' => true,
+                'message' => __('Checked a moment ago, so this is the answer from then.'),
+            ]);
+        }
+
+        $result = $check->run();
+
+        return back()->with('update_check_result', [
+            'ok' => $result['ok'],
+            'message' => $result['message'],
+        ]);
+    }
+
+    private function lastCheckedAt(): ?CarbonImmutable
+    {
+        $value = $this->settings->get(Setting::LatestVersionCheckedAt);
+
+        if (! is_string($value) || $value === '') {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse($value);
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     public function update(Request $request): RedirectResponse

--- a/app/Modules/Platform/Onboarding/QuickStart.php
+++ b/app/Modules/Platform/Onboarding/QuickStart.php
@@ -11,6 +11,7 @@ use App\Modules\Identity\Permissions\PermissionChecker;
 use App\Modules\Identity\UserType;
 use App\Modules\Platform\Capabilities\Capability;
 use App\Modules\Platform\Capabilities\CapabilityRegistry;
+use App\Modules\Platform\Scheduling\ScheduledTaskRun;
 
 /**
  * The short list of things worth doing on a brand-new installation, in
@@ -33,11 +34,12 @@ use App\Modules\Platform\Capabilities\CapabilityRegistry;
  * It is a fact about the task rather than about the layout, which is why
  * it is decided here and not in the page.
  *
- * The two tasks that can be answered from the database are answered:
- * "add your first client" and "upload a file" tick themselves. Nothing
- * else is checkable without guessing — a theme that was never changed is
- * indistinguishable from one that was chosen deliberately — and a tick
- * that means "we assume so" is worse than no tick at all.
+ * The tasks that can be answered from the database are answered: "add
+ * your first client", "upload a file" and "check the scheduler" tick
+ * themselves. Nothing else is checkable without guessing — a theme that
+ * was never changed is indistinguishable from one that was chosen
+ * deliberately — and a tick that means "we assume so" is worse than no
+ * tick at all.
  *
  * Descriptions are one short line each. This is a list to be scanned on
  * the first day, by somebody who wants to get on with it; the screen at
@@ -148,7 +150,7 @@ class QuickStart
                 'description' => __('Expiring files and queued email need it.'),
                 'href' => route('system-settings.scheduler.index', absolute: false),
                 'essential' => true,
-                'done' => false,
+                'done' => $this->schedulerHasRun(),
             ];
         }
 
@@ -163,5 +165,21 @@ class QuickStart
     private function hasAFile(): bool
     {
         return File::query()->exists();
+    }
+
+    /**
+     * The scheduler step is the one essential task nobody could ever
+     * complete: it was hardcoded unticked even though the screen it links
+     * to already answers the question from these rows.
+     *
+     * A row exists once the scheduler has run here at all — which is
+     * precisely what the step asks. Its status does not come into it: a
+     * task that ran and failed still proves cron reaches this
+     * installation, and the Scheduler screen is where that failure is
+     * read.
+     */
+    private function schedulerHasRun(): bool
+    {
+        return ScheduledTaskRun::query()->exists();
     }
 }

--- a/app/Modules/Platform/PlatformServiceProvider.php
+++ b/app/Modules/Platform/PlatformServiceProvider.php
@@ -22,6 +22,7 @@ use App\Modules\Platform\Settings\Settings;
 use App\Modules\Platform\Theming\Console\GenerateThemePreviewDataCommand;
 use App\Modules\Platform\Theming\EmailThemeRegistry;
 use App\Modules\Platform\Theming\PublicThemeRegistry;
+use App\Modules\Platform\Scheduling\Console\PurgeFailedJobsCommand;
 use App\Modules\Platform\Updates\Console\CheckForUpdatesCommand;
 use App\Modules\Platform\Updates\Console\UpdateCommand;
 use Illuminate\Console\Events\ScheduledTaskFailed;
@@ -76,6 +77,7 @@ class PlatformServiceProvider extends ServiceProvider
                 FetchNewsCommand::class,
                 DisableCaptchaCommand::class,
                 TestCaptchaCommand::class,
+                PurgeFailedJobsCommand::class,
             ]);
         }
     }

--- a/app/Modules/Platform/Scheduling/Console/PurgeFailedJobsCommand.php
+++ b/app/Modules/Platform/Scheduling/Console/PurgeFailedJobsCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Scheduling\Console;
+
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+use Illuminate\Console\Command;
+use Illuminate\Queue\Failed\FailedJobProviderInterface;
+use Illuminate\Queue\Failed\PrunableFailedJobProvider;
+
+/**
+ * Delete permanently failed queue jobs past the retention window.
+ *
+ * The Scheduler screen lists them and offers a "Delete all failed"
+ * button, which is the right tool for a backlog somebody is looking at —
+ * but it is the *only* thing that ever shrank this table. A mail server
+ * down overnight can leave thousands of rows, each carrying a serialized
+ * payload and an exception trace, on an installation whose administrator
+ * has no reason to open that screen for months.
+ *
+ * Deliberately its own `projectsend:` command rather than a scheduled
+ * `queue:prune-failed`, for two reasons: RecordsScheduledTaskRuns only
+ * tracks our own signatures, so anything else runs invisibly; and the
+ * retention window belongs in the settings with the rest of them rather
+ * than in a number written into routes/console.php.
+ */
+class PurgeFailedJobsCommand extends Command
+{
+    protected $signature = 'projectsend:purge-failed-jobs';
+
+    protected $description = 'Delete failed queue jobs older than the configured retention window (runs daily)';
+
+    public function handle(Settings $settings, FailedJobProviderInterface $failer): int
+    {
+        $days = (int) $settings->get(Setting::FailedJobRetentionDays);
+
+        // 0 means keep indefinitely — an explicit choice for somebody who
+        // treats a failed job as evidence rather than as debris.
+        if ($days <= 0) {
+            $this->info('Failed job retention is disabled; nothing pruned.');
+
+            return self::SUCCESS;
+        }
+
+        // Both providers this application can be configured with implement
+        // it; the guard is here because the interface it is declared
+        // against does not require it, and a queue driver that cannot
+        // prune should say so rather than fail obscurely.
+        if (! $failer instanceof PrunableFailedJobProvider) {
+            $this->warn('This queue failure store cannot be pruned; nothing done.');
+
+            return self::SUCCESS;
+        }
+
+        $deleted = $failer->prune(now()->subDays($days));
+
+        $this->info("Pruned {$deleted} failed jobs older than {$days} days.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Modules/Platform/Settings/Setting.php
+++ b/app/Modules/Platform/Settings/Setting.php
@@ -110,6 +110,18 @@ enum Setting: string
     // the api_request_logs migration for why the two are separate.
     case ApiRequestLogRetentionDays = 'api_request_log_retention_days';
 
+    // How long a permanently failed queue job is kept, and how long a
+    // notification somebody has already read is kept. Both tables grow
+    // with use and neither ever shrank on its own: the failed-jobs list
+    // waited for somebody to press "Delete all failed", and nothing at
+    // all pruned notifications. An installation nobody tends should not
+    // pay for that with its database.
+    //
+    // 0 means keep indefinitely in both cases, the same explicit choice
+    // ApiRequestLogRetentionDays offers.
+    case FailedJobRetentionDays = 'failed_job_retention_days';
+    case NotificationRetentionDays = 'notification_retention_days';
+
     // How many days a self-deleted account is retained (soft-deleted)
     // before PurgeErasuresCommand permanently erases it. Consumed by
     // ProfileController.
@@ -350,6 +362,8 @@ enum Setting: string
             self::AccountErasureGraceDays,
             self::AccountErasureReassignTo,
             self::ApiRequestLogRetentionDays,
+            self::FailedJobRetentionDays,
+            self::NotificationRetentionDays,
             self::ExpiredFilesDeleteAfterDays,
             self::CommentsEditWindowMinutes,
             self::OrphanFilesDeleteAfterDays,
@@ -411,6 +425,8 @@ enum Setting: string
             self::AccountErasureGraceDays => 30,
             self::AccountErasureReassignTo => 0,
             self::ApiRequestLogRetentionDays => 30,
+            self::FailedJobRetentionDays => 30,
+            self::NotificationRetentionDays => 90,
             self::ExpiredFilesDeleteAfterDays => 30,
             self::OrphanFilesDeleteAfterDays => 30,
             self::CommentsEditWindowMinutes => 15,

--- a/app/Modules/Platform/Updates/CheckForUpdates.php
+++ b/app/Modules/Platform/Updates/CheckForUpdates.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Platform\Updates;
+
+use App\Models\User;
+use App\Modules\Identity\Permissions\Permission;
+use App\Modules\Identity\Permissions\PermissionChecker;
+use App\Modules\Identity\UserType;
+use App\Modules\Notifications\Notifier;
+use App\Modules\Platform\Capabilities\Capability;
+use App\Modules\Platform\Capabilities\CapabilityRegistry;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Ask the public repository what the newest release is, and remember the
+ * answer.
+ *
+ * There is no in-app self-updater and this is not one: it reads a feed
+ * and writes settings. Applying an update is always somebody running
+ * `update.sh` or pulling a new image.
+ *
+ * This lives in a class rather than in the command because there are two
+ * callers now — the daily scheduled run and the button in the settings —
+ * and the part that must not drift between them is the part with
+ * consequences: which staff get notified, and the guard that stops them
+ * being notified twice for the same release. A second copy of that in a
+ * controller would be found wrong six months later, by a staff member
+ * receiving the same notification every time somebody pressed a button.
+ */
+class CheckForUpdates
+{
+    public function __construct(
+        private readonly CapabilityRegistry $capabilities,
+        private readonly Settings $settings,
+        private readonly PermissionChecker $permissions,
+        private readonly Notifier $notifier,
+    ) {}
+
+    /**
+     * @return array{ok: bool, outcome: 'unavailable'|'unreachable'|'unrecognised'|'checked', message: string, latest_version: string, update_available: bool}
+     */
+    public function run(): array
+    {
+        if (! $this->capabilities->has(Capability::SystemUpdates)) {
+            return $this->result(true, 'unavailable', __('Update checks are not available on this edition.'));
+        }
+
+        $response = Http::withHeaders(['User-Agent' => 'ProjectSend'])
+            ->timeout(10)
+            ->get('https://api.github.com/repos/projectsend/projectsend/releases/latest');
+
+        if (! $response->successful()) {
+            return $this->result(false, 'unreachable', __('Could not reach the update feed.'));
+        }
+
+        $tag = (string) ($response->json('tag_name') ?? '');
+        $latestVersion = ltrim($tag, 'v');
+
+        // The public repo's tags are still v1's r-number scheme (r2029,
+        // not SemVer) until a real Community v2 release ships there —
+        // skip rather than misreport an "update" against a tag we can't
+        // meaningfully compare.
+        if (! preg_match('/^\d+\.\d+\.\d+/', $latestVersion)) {
+            return $this->result(true, 'unrecognised', __('The latest release (:tag) is not a version this can compare.', ['tag' => $tag]));
+        }
+
+        $currentVersion = (string) config('projectsend.version');
+        $previouslyKnownVersion = $this->settings->get(Setting::LatestKnownVersion);
+
+        $this->settings->set(Setting::LatestKnownVersion, $latestVersion);
+        $this->settings->set(Setting::LatestVersionCheckedAt, now()->toIso8601String());
+        $this->settings->set(Setting::LatestReleaseTitle, (string) ($response->json('name') ?? $tag));
+        $this->settings->set(Setting::LatestReleaseNotes, (string) ($response->json('body') ?? ''));
+        $this->settings->set(Setting::LatestReleaseUrl, (string) ($response->json('html_url') ?? ''));
+        $this->settings->set(Setting::LatestReleasePublishedAt, (string) ($response->json('published_at') ?? ''));
+
+        $updateAvailable = version_compare($latestVersion, $currentVersion, '>');
+        $alreadyKnown = $previouslyKnownVersion === $latestVersion;
+
+        // Only the first time a genuinely newer release is seen. This is
+        // what keeps the settings button from notifying every staff member
+        // again on every press, and it belongs here rather than in either
+        // caller for exactly that reason.
+        if ($updateAvailable && ! $alreadyKnown) {
+            $recipients = array_values(User::query()->where('type', UserType::Staff)->get()
+                ->filter(fn (User $staff): bool => $this->permissions->allows($staff, Permission::ManageUpdates))
+                ->all());
+
+            $this->notifier->send('update_available', $recipients, data: [
+                'latestVersion' => $latestVersion,
+                'currentVersion' => $currentVersion,
+            ]);
+        }
+
+        return $this->result(
+            true,
+            'checked',
+            $updateAvailable
+                ? __('Version :version is available. You are running :current.', ['version' => $latestVersion, 'current' => $currentVersion])
+                : __('You are up to date, running version :current.', ['current' => $currentVersion]),
+            $latestVersion,
+            $updateAvailable,
+        );
+    }
+
+    /**
+     * @param  'unavailable'|'unreachable'|'unrecognised'|'checked'  $outcome
+     * @return array{ok: bool, outcome: 'unavailable'|'unreachable'|'unrecognised'|'checked', message: string, latest_version: string, update_available: bool}
+     */
+    private function result(bool $ok, string $outcome, string $message, string $latestVersion = '', bool $updateAvailable = false): array
+    {
+        return [
+            'ok' => $ok,
+            'outcome' => $outcome,
+            'message' => $message,
+            'latest_version' => $latestVersion,
+            'update_available' => $updateAvailable,
+        ];
+    }
+}

--- a/app/Modules/Platform/Updates/Console/CheckForUpdatesCommand.php
+++ b/app/Modules/Platform/Updates/Console/CheckForUpdatesCommand.php
@@ -4,26 +4,24 @@ declare(strict_types=1);
 
 namespace App\Modules\Platform\Updates\Console;
 
-use App\Models\User;
-use App\Modules\Identity\Permissions\Permission;
-use App\Modules\Identity\Permissions\PermissionChecker;
-use App\Modules\Identity\UserType;
-use App\Modules\Notifications\Notifier;
-use App\Modules\Platform\Capabilities\Capability;
-use App\Modules\Platform\Capabilities\CapabilityRegistry;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
+use App\Modules\Platform\Updates\CheckForUpdates;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Http;
 
 /**
- * Community edition only. There is no in-app self-updater — v1's
- * download-a-zip-and-extract-it-over-the-live-install approach doesn't
- * make sense once the app runs from a Docker image (see
- * docs/... — the rewrite brief explicitly rejects porting it). This
- * command only ever checks the public repo's latest GitHub release and
- * caches the result; upgrading is always an admin running
- * `docker compose pull && docker compose up -d` themselves.
+ * Community edition only, once a day. The work itself lives in
+ * CheckForUpdates, which the settings screen's "check now" button calls
+ * too; this is the scheduled half, and the only thing it adds is the
+ * setting that switches the schedule off.
+ *
+ * That setting governs *this* command and not the service on purpose: an
+ * administrator who does not want a daily outbound call should still be
+ * able to ask the question themselves.
+ *
+ * There is still no in-app self-updater — nothing here downloads or
+ * applies anything. Applying an update is `update.sh` on a server
+ * install, or a new image on a container one.
  */
 class CheckForUpdatesCommand extends Command
 {
@@ -32,76 +30,29 @@ class CheckForUpdatesCommand extends Command
     protected $description = 'Check for a newer ProjectSend release and notify admins (Community edition, runs daily)';
 
     public function __construct(
-        private readonly CapabilityRegistry $capabilities,
         private readonly Settings $settings,
-        private readonly PermissionChecker $permissions,
-        private readonly Notifier $notifier,
+        private readonly CheckForUpdates $check,
     ) {
         parent::__construct();
     }
 
     public function handle(): int
     {
-        if (! $this->capabilities->has(Capability::SystemUpdates)) {
-            $this->info('Update checks are not available on this edition.');
-
-            return self::SUCCESS;
-        }
-
         if ($this->settings->get(Setting::CheckForUpdates) !== true) {
             $this->info('Update checks are disabled.');
 
             return self::SUCCESS;
         }
 
-        $response = Http::withHeaders(['User-Agent' => 'ProjectSend'])
-            ->timeout(10)
-            ->get('https://api.github.com/repos/projectsend/projectsend/releases/latest');
+        $result = $this->check->run();
 
-        if (! $response->successful()) {
-            $this->warn('Could not reach the update feed.');
+        if (! $result['ok']) {
+            $this->warn($result['message']);
 
             return self::FAILURE;
         }
 
-        $tag = (string) ($response->json('tag_name') ?? '');
-        $latestVersion = ltrim($tag, 'v');
-
-        // The public repo's tags are still v1's r-number scheme (r2029,
-        // not SemVer) until a real Community v2 release ships there —
-        // skip rather than misreport an "update" against a tag we can't
-        // meaningfully compare.
-        if (! preg_match('/^\d+\.\d+\.\d+/', $latestVersion)) {
-            $this->info("Latest release tag ({$tag}) is not a recognized version — skipping.");
-
-            return self::SUCCESS;
-        }
-
-        $currentVersion = (string) config('projectsend.version');
-        $previouslyKnownVersion = $this->settings->get(Setting::LatestKnownVersion);
-
-        $this->settings->set(Setting::LatestKnownVersion, $latestVersion);
-        $this->settings->set(Setting::LatestVersionCheckedAt, now()->toIso8601String());
-        $this->settings->set(Setting::LatestReleaseTitle, (string) ($response->json('name') ?? $tag));
-        $this->settings->set(Setting::LatestReleaseNotes, (string) ($response->json('body') ?? ''));
-        $this->settings->set(Setting::LatestReleaseUrl, (string) ($response->json('html_url') ?? ''));
-        $this->settings->set(Setting::LatestReleasePublishedAt, (string) ($response->json('published_at') ?? ''));
-
-        $updateAvailable = version_compare($latestVersion, $currentVersion, '>');
-        $alreadyKnown = $previouslyKnownVersion === $latestVersion;
-
-        if ($updateAvailable && ! $alreadyKnown) {
-            $recipients = array_values(User::query()->where('type', UserType::Staff)->get()
-                ->filter(fn (User $staff): bool => $this->permissions->allows($staff, Permission::ManageUpdates))
-                ->all());
-
-            $this->notifier->send('update_available', $recipients, data: [
-                'latestVersion' => $latestVersion,
-                'currentVersion' => $currentVersion,
-            ]);
-        }
-
-        $this->info("Latest version: {$latestVersion} (current: {$currentVersion}).");
+        $this->info($result['message']);
 
         return self::SUCCESS;
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4056,12 +4056,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/projectsend/community-modules.git",
-                "reference": "26d9ca875f7bc3e1e2deefce884822005301f020"
+                "reference": "311883a7bdca91671ab84891443400e8c397e1df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/projectsend/community-modules/zipball/26d9ca875f7bc3e1e2deefce884822005301f020",
-                "reference": "26d9ca875f7bc3e1e2deefce884822005301f020",
+                "url": "https://api.github.com/repos/projectsend/community-modules/zipball/311883a7bdca91671ab84891443400e8c397e1df",
+                "reference": "311883a7bdca91671ab84891443400e8c397e1df",
                 "shasum": ""
             },
             "require": {
@@ -4101,7 +4101,7 @@
                 "source": "https://github.com/projectsend/community-modules/tree/main",
                 "issues": "https://github.com/projectsend/community-modules/issues"
             },
-            "time": "2026-08-14T04:49:40+00:00"
+            "time": "2026-08-16T18:45:51+00:00"
         },
         {
             "name": "psr/clock",

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -39,10 +39,14 @@ return [
             'throw' => false,
         ],
 
+        // Laravel's stock private disk. Nothing in this application writes
+        // to it, and `serve` is off because the framework's /storage route
+        // would otherwise hand out whatever ended up there — a door with
+        // nothing behind it today is still a door.
         'local' => [
             'driver' => 'local',
             'root' => storage_path('app/private'),
-            'serve' => true,
+            'serve' => false,
             'throw' => false,
         ],
 

--- a/docker/production/nginx.conf
+++ b/docker/production/nginx.conf
@@ -50,7 +50,10 @@ server {
     # cannot touch this app's origin or the viewer's session. Images loaded
     # as subresources are unaffected: a CSP on a subresource response never
     # creates a browsing context, so thumbnails and previews still render.
-    location /protected-files/ {
+    # `^~` so this prefix beats the `\.php$` regex below: without it a
+    # protected path ending in .php would be handed to the PHP handler
+    # instead of streaming under the sandbox headers this block sets.
+    location ^~ /protected-files/ {
         internal;
         alias /var/www/html/storage/app/files/;
 

--- a/docker/web/nginx.conf
+++ b/docker/web/nginx.conf
@@ -32,7 +32,10 @@ server {
     # cannot touch this app's origin or the viewer's session. Images loaded
     # as subresources are unaffected: a CSP on a subresource response never
     # creates a browsing context, so thumbnails and previews still render.
-    location /protected-files/ {
+    # `^~` so this prefix beats the `\.php$` regex below: without it a
+    # protected path ending in .php would be handed to the PHP handler
+    # instead of streaming under the sandbox headers this block sets.
+    location ^~ /protected-files/ {
         internal;
         alias /var/www/html/storage/app/files/;
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,7 +41,10 @@ export default [
         // Maintainer tooling scripts (*.cjs) are plain Node, not app
         // source — they don't run in the browser and use Node globals
         // (require, process, __dirname) the app's ruleset forbids.
-        ignores: ['vendor', 'node_modules', 'public', 'bootstrap/ssr', 'tailwind.config.js', '.claude', 'packages'],
+        // `.release-build` is where build-release.sh assembles a zip: a full
+        // copy of the app plus vendored, minified JS. It is gitignored, so
+        // linting it only ever means `--fix` rewriting artifacts nobody reads.
+        ignores: ['vendor', 'node_modules', 'public', 'bootstrap/ssr', 'tailwind.config.js', '.claude', 'packages', '.release-build'],
     },
     prettier, // Turn off all rules that might conflict with Prettier
 ];

--- a/resources/js/components/update-instructions.tsx
+++ b/resources/js/components/update-instructions.tsx
@@ -1,3 +1,4 @@
+import { UpdateOptionsDialog } from '@/components/update-options-dialog';
 import { useTranslation } from '@/hooks/use-translation';
 import { cn } from '@/lib/utils';
 
@@ -45,9 +46,10 @@ export function UpdateInstructions({
 
     if (compact) {
         return (
-            <p className="text-muted-foreground">
-                {t('To update, run sudo ./update.sh in the install directory — it asks before it downloads or changes anything.')}
-            </p>
+            <div className="text-muted-foreground space-y-1">
+                <p>{t('To update, run sudo ./update.sh in the install directory — it asks before it downloads or changes anything.')}</p>
+                <UpdateOptionsDialog />
+            </div>
         );
     }
 
@@ -65,6 +67,9 @@ export function UpdateInstructions({
                     'It asks before checking for a release, before downloading one, and before touching your installation — and verifies the checksum of what it downloads. UPDATE.md has the full procedure.',
                 )}
             </p>
+            <div className="mt-1">
+                <UpdateOptionsDialog />
+            </div>
         </>
     );
 }

--- a/resources/js/components/update-options-dialog.tsx
+++ b/resources/js/components/update-options-dialog.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { useTranslation } from '@/hooks/use-translation';
+
+/**
+ * The handful of update.sh options worth knowing about, behind a link
+ * rather than printed on the page.
+ *
+ * The screen that tells somebody how to update has one job: the one
+ * command. Listing every flag beside it would bury that command under
+ * options most people never need — but two of them are the ones an
+ * administrator most wants at exactly that moment ("can it back up for
+ * me?", "can I just look?"), and finding them meant opening UPDATE.md on
+ * a machine they are probably not sitting at.
+ *
+ * So: nothing on screen until asked for, and then four lines. The script
+ * documents the rest with --help, and UPDATE.md documents the procedure.
+ *
+ * It opens from inside the update dialog as well as from the dashboard
+ * card. A dialog on top of a dialog is unusual, and correct here — the
+ * reader asked for a footnote to what they are already reading, and
+ * Escape returns them to it.
+ */
+export function UpdateOptionsDialog() {
+    const { t } = useTranslation();
+    const [open, setOpen] = useState(false);
+
+    const options: { flag: string; description: string }[] = [
+        { flag: '--backup', description: t('Dump the database before touching anything, and stop if the dump fails.') },
+        { flag: '--check', description: t('Report which version is installed and which is available, and change nothing.') },
+        { flag: '--i-have-a-backup', description: t('Skip the question about backups, for a run you are not sitting in front of.') },
+        { flag: '--no-restart', description: t('Leave PHP and the worker alone, for when you restart them yourself.') },
+    ];
+
+    return (
+        <>
+            <button type="button" onClick={() => setOpen(true)} className="text-muted-foreground text-xs underline hover:no-underline">
+                {t('Other options')}
+            </button>
+
+            <Dialog open={open} onOpenChange={setOpen}>
+                <DialogContent className="max-w-lg">
+                    <DialogHeader>
+                        <DialogTitle>{t('Update options')}</DialogTitle>
+                    </DialogHeader>
+
+                    <div className="space-y-3 text-sm">
+                        <p className="text-muted-foreground">
+                            {t('Run the script with no options and it asks about each of these as it goes. These are for the runs where you already know the answer.')}
+                        </p>
+
+                        <dl className="divide-y">
+                            {options.map((option) => (
+                                <div key={option.flag} className="grid gap-1 py-2 sm:grid-cols-[10rem_1fr] sm:gap-3">
+                                    <dt>
+                                        <code className="bg-muted rounded px-1.5 py-0.5 text-xs">{option.flag}</code>
+                                    </dt>
+                                    <dd className="text-muted-foreground">{option.description}</dd>
+                                </div>
+                            ))}
+                        </dl>
+
+                        <p className="text-muted-foreground text-xs">
+                            {t('sudo ./update.sh --help lists every option, and UPDATE.md walks through the whole procedure, including doing it by hand.')}
+                        </p>
+                    </div>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}

--- a/resources/js/pages/system/about.tsx
+++ b/resources/js/pages/system/about.tsx
@@ -3,6 +3,7 @@ import { Head, Link, usePage } from '@inertiajs/react';
 
 import Heading from '@/components/heading';
 import ProjectSendLogo from '@/components/projectsend-logo';
+import { useFormatDate } from '@/hooks/use-format-date';
 import { useTranslation } from '@/hooks/use-translation';
 import AppLayout from '@/layouts/app-layout';
 
@@ -14,10 +15,17 @@ interface Environment {
     database: string;
 }
 
+interface LastUpdate {
+    version: string;
+    at: string;
+}
+
 interface AboutProps {
     license: string;
     /** Null for anyone the dashboard's System widget would also hide it from. */
     environment: Environment | null;
+    /** Null on an installation that has never been updated through the command. */
+    updated: LastUpdate | null;
 }
 
 function Row({ label, value }: { label: string; value: string }) {
@@ -29,8 +37,9 @@ function Row({ label, value }: { label: string; value: string }) {
     );
 }
 
-export default function About({ license, environment }: AboutProps) {
+export default function About({ license, environment, updated }: AboutProps) {
     const { t } = useTranslation();
+    const { dateTime } = useFormatDate();
     const { version, edition, links } = usePage<SharedData>().props;
 
     const breadcrumbs: BreadcrumbItem[] = [{ title: t('About'), href: '/system/about' }];
@@ -98,6 +107,10 @@ export default function About({ license, environment }: AboutProps) {
                             </p>
                             <dl className="divide-y text-sm">
                                 <Row label={t('Version')} value={environment.version} />
+                                {/* Absent until this installation has been
+                                    updated at least once through the command —
+                                    a fresh install has no update to date. */}
+                                {updated && <Row label={t('Updated')} value={t(':version on :date', { version: updated.version, date: dateTime(updated.at) })} />}
                                 <Row label={t('Edition')} value={environment.edition} />
                                 <Row label="PHP" value={environment.php} />
                                 <Row label="Laravel" value={environment.laravel} />

--- a/resources/js/pages/system/settings/general.tsx
+++ b/resources/js/pages/system/settings/general.tsx
@@ -1,14 +1,17 @@
 import { type BreadcrumbItem, type SharedData } from '@/types';
-import { Head, Link, useForm, usePage } from '@inertiajs/react';
-import { FormEventHandler } from 'react';
+import { Head, Link, router, useForm, usePage } from '@inertiajs/react';
+import { FormEventHandler, useState } from 'react';
 
 import Heading from '@/components/heading';
 import InputError from '@/components/input-error';
 import { SaveButton } from '@/components/save-button';
+import { TestResultAlert } from '@/components/test-result-alert';
 import { TimezonePicker, type TimezoneOption } from '@/components/timezone-picker';
+import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { useFormatDate } from '@/hooks/use-format-date';
 import { useTranslation } from '@/hooks/use-translation';
 import AppLayout from '@/layouts/app-layout';
 
@@ -20,6 +23,10 @@ interface SystemSettingsProps {
     viewer_timezone: string | null;
     can_manage_updates: boolean;
     check_for_updates: boolean | null;
+    /** When the release feed was last asked, by anybody. Null until it has been. */
+    last_checked_at: string | null;
+    /** The answer to a "check now" press, for the one render after it. */
+    check_result: { ok: boolean; message: string } | null;
 }
 
 export default function SystemSettings({
@@ -29,9 +36,25 @@ export default function SystemSettings({
     viewer_timezone,
     can_manage_updates,
     check_for_updates,
+    last_checked_at,
+    check_result,
 }: SystemSettingsProps) {
     const { t } = useTranslation();
+    const { dateTime } = useFormatDate();
     const { version, links } = usePage<SharedData>().props;
+    const [checking, setChecking] = useState(false);
+
+    const checkNow = () => {
+        router.post(
+            route('system-settings.check-for-updates'),
+            {},
+            {
+                preserveScroll: true,
+                onStart: () => setChecking(true),
+                onFinish: () => setChecking(false),
+            },
+        );
+    };
 
     // Matched against the offered list so the note names the zone the way
     // the picker does, rather than printing a raw identifier.
@@ -124,6 +147,23 @@ export default function SystemSettings({
                                     "Periodically checks projectsend.org's public repository for a newer release and shows a notice on the dashboard. Nothing is ever downloaded or applied automatically — updating is always something you run, and the update script asks before each step.",
                                 )}
                             </p>
+
+                            {/* Outside the form on purpose: this asks a
+                                question rather than saving anything, and
+                                pressing it should not depend on — or
+                                discard — unsaved edits above it. */}
+                            <div className="mt-1 flex flex-wrap items-center gap-3">
+                                <Button type="button" variant="outline" onClick={checkNow} disabled={checking}>
+                                    {checking ? t('Checking…') : t('Check now')}
+                                </Button>
+                                {last_checked_at && (
+                                    <span className="text-muted-foreground text-sm">
+                                        {t('Last checked :date', { date: dateTime(last_checked_at) })}
+                                    </span>
+                                )}
+                            </div>
+
+                            {check_result && <TestResultAlert ok={check_result.ok}>{check_result.message}</TestResultAlert>}
                         </div>
                     )}
 

--- a/resources/js/pages/system/settings/scheduler.tsx
+++ b/resources/js/pages/system/settings/scheduler.tsx
@@ -1,12 +1,17 @@
 import { type BreadcrumbItem } from '@/types';
-import { Head, Link, router } from '@inertiajs/react';
+import { Head, Link, router, useForm } from '@inertiajs/react';
+import { type FormEventHandler } from 'react';
 
 import { ConfirmDialog } from '@/components/confirm-dialog';
 import Heading from '@/components/heading';
 import HeadingSmall from '@/components/heading-small';
+import InputError from '@/components/input-error';
 import { Pagination, type PaginationMeta } from '@/components/pagination';
+import { SaveButton } from '@/components/save-button';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { useFormatDate } from '@/hooks/use-format-date';
 import { useTranslation } from '@/hooks/use-translation';
 import AppLayout from '@/layouts/app-layout';
@@ -39,6 +44,8 @@ interface SchedulerSettingsProps {
     failed_pagination: PaginationMeta;
     failed_total: number;
     pending_jobs_count: number;
+    /** Days each self-growing table is kept for. 0 means indefinitely. */
+    retention: { failed_jobs: number; notifications: number };
 }
 
 export default function SchedulerSettings({
@@ -48,9 +55,22 @@ export default function SchedulerSettings({
     failed_pagination,
     failed_total,
     pending_jobs_count,
+    retention,
 }: SchedulerSettingsProps) {
     const { t } = useTranslation();
     const { dateTime } = useFormatDate();
+
+    // Strings rather than numbers: an emptied number input is '', and
+    // coercing that to 0 mid-typing would silently mean "keep everything".
+    const { data, setData, patch, processing, errors, recentlySuccessful } = useForm({
+        failed_jobs: String(retention.failed_jobs),
+        notifications: String(retention.notifications),
+    });
+
+    const saveRetention: FormEventHandler = (event) => {
+        event.preventDefault();
+        patch(route('system-settings.scheduler.retention'), { preserveScroll: true });
+    };
 
     const breadcrumbs: BreadcrumbItem[] = [
         { title: t('Settings'), href: '/system/settings' },
@@ -141,6 +161,57 @@ export default function SchedulerSettings({
                             </tbody>
                         </table>
                     </div>
+                )}
+
+                {tab === 'tasks' && (
+                    <form onSubmit={saveRetention} className="max-w-xl space-y-4">
+                        <HeadingSmall
+                            title={t('Housekeeping')}
+                            description={t('Two things pile up on their own. These are the windows the daily purges above work to.')}
+                        />
+
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            <div className="grid gap-1.5">
+                                <Label htmlFor="failed_jobs_retention">{t('Keep failed jobs for')}</Label>
+                                <div className="flex items-center gap-2">
+                                    <Input
+                                        id="failed_jobs_retention"
+                                        type="number"
+                                        min={0}
+                                        max={3650}
+                                        value={data.failed_jobs}
+                                        onChange={(event) => setData('failed_jobs', event.target.value)}
+                                        className="w-28"
+                                    />
+                                    <span className="text-muted-foreground text-sm">{t('days')}</span>
+                                </div>
+                                <InputError message={errors.failed_jobs} />
+                            </div>
+
+                            <div className="grid gap-1.5">
+                                <Label htmlFor="notifications_retention">{t('Keep read notifications for')}</Label>
+                                <div className="flex items-center gap-2">
+                                    <Input
+                                        id="notifications_retention"
+                                        type="number"
+                                        min={0}
+                                        max={3650}
+                                        value={data.notifications}
+                                        onChange={(event) => setData('notifications', event.target.value)}
+                                        className="w-28"
+                                    />
+                                    <span className="text-muted-foreground text-sm">{t('days')}</span>
+                                </div>
+                                <InputError message={errors.notifications} />
+                            </div>
+                        </div>
+
+                        <p className="text-muted-foreground text-sm">
+                            {t('0 keeps everything. Unread notifications are never deleted, however old they are.')}
+                        </p>
+
+                        <SaveButton processing={processing} recentlySuccessful={recentlySuccessful} />
+                    </form>
                 )}
 
                 {tab === 'failed' && (

--- a/resources/js/pages/system/settings/scheduler.tsx
+++ b/resources/js/pages/system/settings/scheduler.tsx
@@ -16,6 +16,8 @@ interface ScheduledTask {
     label: string;
     status: 'success' | 'failed' | null;
     message: string | null;
+    /** What the task found, for the tasks that find something. Never set on a failure. */
+    detail: string | null;
     duration_ms: number | null;
     ran_at: string | null;
 }
@@ -130,7 +132,10 @@ export default function SchedulerSettings({
                                         <td className="text-muted-foreground px-4 py-2.5 whitespace-nowrap">
                                             {task.duration_ms !== null ? `${task.duration_ms} ms` : '—'}
                                         </td>
-                                        <td className="text-muted-foreground max-w-xs px-4 py-2.5 break-words">{task.message ?? '—'}</td>
+                                        {/* A failure's own message wins: what the
+                                            last successful run found is not the
+                                            answer to why this one broke. */}
+                                        <td className="text-muted-foreground max-w-xs px-4 py-2.5 break-words">{task.message ?? task.detail ?? '—'}</td>
                                     </tr>
                                 ))}
                             </tbody>

--- a/routes/console.php
+++ b/routes/console.php
@@ -16,3 +16,5 @@ Schedule::command('projectsend:fetch-news')->daily();
 Schedule::command('projectsend:purge-expired-files')->daily();
 Schedule::command('projectsend:purge-orphan-files')->daily();
 Schedule::command('projectsend:purge-api-request-logs')->daily();
+Schedule::command('projectsend:purge-failed-jobs')->daily();
+Schedule::command('projectsend:purge-notifications')->daily();

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -203,6 +203,7 @@ Route::middleware('auth')->group(function () {
             Route::post('system/settings/scheduler/failed-jobs/{uuid}/retry', [SchedulerMonitoringController::class, 'retryFailedJob'])->name('system-settings.scheduler.retry');
             Route::delete('system/settings/scheduler/failed-jobs/{uuid}', [SchedulerMonitoringController::class, 'destroyFailedJob'])->name('system-settings.scheduler.destroy');
             Route::delete('system/settings/scheduler/failed-jobs', [SchedulerMonitoringController::class, 'destroyAllFailedJobs'])->name('system-settings.scheduler.destroy-all');
+            Route::patch('system/settings/scheduler/retention', [SchedulerMonitoringController::class, 'updateRetention'])->name('system-settings.scheduler.retention');
         });
     });
 

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -135,6 +135,14 @@ Route::middleware('auth')->group(function () {
         Route::redirect('system/settings', '/system/settings/general');
         Route::get('system/settings/general', [SystemSettingsController::class, 'edit'])->name('system-settings.edit');
         Route::patch('system/settings/general', [SystemSettingsController::class, 'update'])->name('system-settings.update');
+        // Its own throttle bucket, like every other action route here: a
+        // bare `throttle:5,1` is keyed on the domain and the address, so
+        // it would share one allowance with everything else that omits a
+        // name. The controller enforces manage_updates and the edition,
+        // and applies an installation-wide cooldown of its own.
+        Route::post('system/settings/check-for-updates', [SystemSettingsController::class, 'checkForUpdates'])
+            ->middleware('throttle:5,1,check-for-updates-now')
+            ->name('system-settings.check-for-updates');
         Route::get('system/settings/security', [SecuritySettingsController::class, 'edit'])->name('system-settings.security.edit');
         Route::patch('system/settings/security', [SecuritySettingsController::class, 'update'])->name('system-settings.security.update');
         Route::get('system/settings/clients', [ClientSettingsController::class, 'edit'])->name('system-settings.clients.edit');

--- a/tests/Feature/Platform/AboutPageTest.php
+++ b/tests/Feature/Platform/AboutPageTest.php
@@ -6,6 +6,8 @@ use App\Models\User;
 use App\Modules\Platform\Attribution\Attribution;
 use App\Modules\Platform\Attribution\Events\ResolvingAttribution;
 use App\Modules\Platform\Capabilities\Edition;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
 use Illuminate\Support\Facades\Event;
 use Inertia\Testing\AssertableInertia;
 
@@ -90,4 +92,39 @@ test('the generator meta names ProjectSend without its version', function () {
     // The version is deliberately absent: this tag is served to anyone
     // who asks, and it would tell a scanner which advisories apply.
     $response->assertDontSee('content="ProjectSend '.config('projectsend.version').'"', false);
+});
+
+test('about names the version this installation was last updated to, and when', function () {
+    config()->set('projectsend.edition', Edition::Community);
+    $settings = app(Settings::class);
+    $settings->set(Setting::AppliedVersion, '2.1.0');
+    $settings->set(Setting::AppliedVersionAt, '2026-08-17T10:00:00+00:00');
+
+    $this->actingAs($this->admin)->get('/system/about')->assertInertia(
+        fn (AssertableInertia $page) => $page
+            ->where('updated.version', '2.1.0')
+            ->where('updated.at', '2026-08-17T10:00:00+00:00'),
+    );
+});
+
+test('an installation that has never been updated says nothing rather than guessing', function () {
+    config()->set('projectsend.edition', Edition::Community);
+    $settings = app(Settings::class);
+    $settings->set(Setting::AppliedVersion, '');
+    $settings->set(Setting::AppliedVersionAt, '');
+
+    $this->actingAs($this->admin)->get('/system/about')->assertInertia(
+        fn (AssertableInertia $page) => $page->where('updated', null),
+    );
+});
+
+test('the last-update line is hidden from anyone the environment block is hidden from', function () {
+    config()->set('projectsend.edition', Edition::Cloud);
+    $settings = app(Settings::class);
+    $settings->set(Setting::AppliedVersion, '2.1.0');
+    $settings->set(Setting::AppliedVersionAt, '2026-08-17T10:00:00+00:00');
+
+    $this->actingAs($this->admin)->get('/system/about')->assertInertia(
+        fn (AssertableInertia $page) => $page->where('environment', null)->where('updated', null),
+    );
 });

--- a/tests/Feature/Platform/CheckForUpdatesNowTest.php
+++ b/tests/Feature/Platform/CheckForUpdatesNowTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Identity\Models\Role;
+use App\Modules\Identity\Models\RolePermission;
+use App\Modules\Platform\Capabilities\Edition;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+use Illuminate\Support\Facades\Http;
+use Inertia\Testing\AssertableInertia;
+
+/**
+ * The "check now" button in the general settings. The check itself is
+ * covered by CheckForUpdatesCommandTest; what is tested here is who may
+ * press it, and that pressing it repeatedly cannot spend the
+ * installation's whole allowance with the release feed.
+ *
+ * @param  array<string, mixed>  $extra
+ */
+function fakeReleaseFeed(string $tagName, array $extra = []): void
+{
+    Http::fake([
+        'api.github.com/repos/projectsend/projectsend/releases/latest' => Http::response([
+            'tag_name' => $tagName,
+            'name' => $extra['name'] ?? "Release {$tagName}",
+            'body' => $extra['body'] ?? 'Some release notes.',
+            'html_url' => $extra['html_url'] ?? "https://github.com/projectsend/projectsend/releases/tag/{$tagName}",
+            'published_at' => $extra['published_at'] ?? '2026-08-02T00:00:00Z',
+        ], 200),
+    ]);
+}
+
+beforeEach(function () {
+    config()->set('projectsend.version', '2.0.0');
+    config()->set('projectsend.edition', Edition::Community);
+
+    // Both are cached beyond the per-test rollback, so every test states
+    // what it needs rather than inheriting whatever ran before it.
+    $settings = app(Settings::class);
+    $settings->set(Setting::CheckForUpdates, true);
+    $settings->set(Setting::LatestVersionCheckedAt, '');
+    $settings->set(Setting::LatestKnownVersion, '');
+});
+
+test('an administrator can ask the feed on demand and is told what it said', function () {
+    $this->actingAs(User::factory()->create());
+    fakeReleaseFeed('v2.5.0');
+
+    $this->post('/system/settings/check-for-updates')
+        ->assertRedirect()
+        ->assertSessionHas('update_check_result', fn (array $result): bool => $result['ok'] === true
+            && str_contains($result['message'], '2.5.0'));
+
+    expect(app(Settings::class)->get(Setting::LatestKnownVersion))->toBe('2.5.0');
+});
+
+test('the answer reaches the page that asked for it', function () {
+    $this->actingAs(User::factory()->create());
+    fakeReleaseFeed('v2.5.0');
+
+    $this->post('/system/settings/check-for-updates');
+
+    $this->get('/system/settings/general')->assertInertia(
+        fn (AssertableInertia $page) => $page
+            ->component('system/settings/general')
+            ->where('check_result.ok', true)
+            ->has('last_checked_at'),
+    );
+});
+
+test('a second press within the cooldown re-reads the answer instead of the feed', function () {
+    $this->actingAs(User::factory()->create());
+    fakeReleaseFeed('v2.5.0');
+
+    $this->post('/system/settings/check-for-updates');
+    $this->post('/system/settings/check-for-updates')->assertRedirect();
+
+    Http::assertSentCount(1);
+});
+
+test('the daily check being switched off does not refuse a question somebody asked out loud', function () {
+    app(Settings::class)->set(Setting::CheckForUpdates, false);
+    $this->actingAs(User::factory()->create());
+    fakeReleaseFeed('v2.5.0');
+
+    $this->post('/system/settings/check-for-updates');
+
+    Http::assertSentCount(1);
+    expect(app(Settings::class)->get(Setting::LatestKnownVersion))->toBe('2.5.0');
+});
+
+test('an unreachable feed says so and leaves every cached answer alone', function () {
+    app(Settings::class)->set(Setting::LatestKnownVersion, '2.4.0');
+    $this->actingAs(User::factory()->create());
+    Http::fake(['api.github.com/*' => Http::response(null, 500)]);
+
+    $this->post('/system/settings/check-for-updates')
+        ->assertSessionHas('update_check_result', fn (array $result): bool => $result['ok'] === false);
+
+    expect(app(Settings::class)->get(Setting::LatestKnownVersion))->toBe('2.4.0');
+});
+
+test('a staff member without manage_updates cannot press it', function () {
+    $role = Role::query()->create(['name' => 'Settings Only', 'is_administrator' => false, 'is_system' => false]);
+    RolePermission::query()->insert(['role_id' => $role->id, 'permission' => 'edit_settings']);
+    $this->actingAs(User::factory()->create(['role_id' => $role->id]));
+    fakeReleaseFeed('v2.5.0');
+
+    $this->post('/system/settings/check-for-updates')->assertForbidden();
+
+    Http::assertNothingSent();
+});
+
+test('the cloud edition has nothing to check', function () {
+    config()->set('projectsend.edition', Edition::Cloud);
+    $this->actingAs(User::factory()->create());
+    fakeReleaseFeed('v2.5.0');
+
+    $this->post('/system/settings/check-for-updates')->assertForbidden();
+
+    Http::assertNothingSent();
+});

--- a/tests/Feature/Platform/GettingStartedTest.php
+++ b/tests/Feature/Platform/GettingStartedTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use App\Models\User;
 use App\Modules\Identity\Permissions\SystemRole;
 use App\Modules\Platform\Capabilities\Edition;
+use App\Modules\Platform\Scheduling\ScheduledTaskRun;
+use App\Modules\Platform\Scheduling\TaskRunStatus;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
 use Inertia\Testing\AssertableInertia;
@@ -220,4 +222,51 @@ test('the email theme step deep-links to its own tab', function () {
     $emailTheme = collect($items)->firstWhere('key', 'email-theme');
 
     expect($emailTheme['href'])->toContain('tab=email');
+});
+
+// The one essential step that could never be completed: it was hardcoded
+// unticked, while the screen it links to was already answering the
+// question from these very rows.
+test('the scheduler step ticks itself once the scheduler has run here', function () {
+    $items = [];
+
+    $this->actingAs($this->admin)->get('/system/getting-started')->assertInertia(function (AssertableInertia $page) use (&$items) {
+        $items = collect($page->toArray()['props']['items'])->keyBy('key');
+    });
+
+    expect($items['scheduler']['done'])->toBeFalse();
+
+    ScheduledTaskRun::query()->create([
+        'command' => 'projectsend:purge-expired-files',
+        'status' => TaskRunStatus::Success,
+        'message' => null,
+        'duration_ms' => 12,
+        'ran_at' => now(),
+    ]);
+
+    $this->actingAs($this->admin)->get('/system/getting-started')->assertInertia(function (AssertableInertia $page) use (&$items) {
+        $items = collect($page->toArray()['props']['items'])->keyBy('key');
+    });
+
+    expect($items['scheduler']['done'])->toBeTrue();
+});
+
+// A run that failed still proves cron reaches this installation, which is
+// what the step asks. Why it failed is the Scheduler screen's job.
+test('a failed run still counts as the scheduler running', function () {
+    ScheduledTaskRun::query()->create([
+        'command' => 'projectsend:fetch-news',
+        'status' => TaskRunStatus::Failed,
+        'message' => 'Scheduled command failed with exit code [1].',
+        'duration_ms' => null,
+        'ran_at' => now(),
+    ]);
+
+    $items = [];
+
+    $this->actingAs($this->admin)->get('/system/getting-started')->assertInertia(function (AssertableInertia $page) use (&$items) {
+        $items = collect($page->toArray()['props']['items'])->keyBy('key');
+    });
+
+    expect($items['scheduler']['done'])->toBeTrue();
 });

--- a/tests/Feature/Platform/RetentionPurgesTest.php
+++ b/tests/Feature/Platform/RetentionPurgesTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Notifications\InAppNotification;
+use App\Modules\Platform\Capabilities\Edition;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia;
+
+/**
+ * The two tables that grow on their own — failed queue jobs and read
+ * notifications — and the daily purges that now keep them from growing
+ * forever on an installation nobody tends.
+ */
+beforeEach(function () {
+    config()->set('projectsend.edition', Edition::Community);
+    $this->admin = User::factory()->create();
+
+    // Settings outlive the per-test rollback in the cache, so both
+    // windows are stated rather than assumed.
+    $settings = app(Settings::class);
+    $settings->set(Setting::FailedJobRetentionDays, 30);
+    $settings->set(Setting::NotificationRetentionDays, 90);
+});
+
+function insertFailedJob(string $failedAt): string
+{
+    $uuid = (string) Str::uuid();
+
+    DB::table('failed_jobs')->insert([
+        'uuid' => $uuid,
+        'connection' => 'redis',
+        'queue' => 'default',
+        'payload' => '{}',
+        'exception' => 'Something went wrong.',
+        'failed_at' => $failedAt,
+    ]);
+
+    return $uuid;
+}
+
+test('it deletes failed jobs past the window and keeps the recent ones', function () {
+    $old = insertFailedJob(now()->subDays(45)->toDateTimeString());
+    $recent = insertFailedJob(now()->subDays(3)->toDateTimeString());
+
+    $this->artisan('projectsend:purge-failed-jobs')->assertSuccessful();
+
+    expect(DB::table('failed_jobs')->where('uuid', $old)->exists())->toBeFalse()
+        ->and(DB::table('failed_jobs')->where('uuid', $recent)->exists())->toBeTrue();
+});
+
+test('a retention of zero keeps every failed job, however old', function () {
+    app(Settings::class)->set(Setting::FailedJobRetentionDays, 0);
+    $old = insertFailedJob(now()->subYears(3)->toDateTimeString());
+
+    $this->artisan('projectsend:purge-failed-jobs')->assertSuccessful();
+
+    expect(DB::table('failed_jobs')->where('uuid', $old)->exists())->toBeTrue();
+});
+
+test('it deletes read notifications past the window', function () {
+    $old = InAppNotification::query()->create([
+        'user_id' => $this->admin->id,
+        'type' => 'file_shared',
+        'read_at' => now()->subDays(100),
+        'created_at' => now()->subDays(100),
+    ]);
+    $recent = InAppNotification::query()->create([
+        'user_id' => $this->admin->id,
+        'type' => 'file_shared',
+        'read_at' => now()->subDay(),
+        'created_at' => now()->subDay(),
+    ]);
+
+    $this->artisan('projectsend:purge-notifications')->assertSuccessful();
+
+    expect(InAppNotification::query()->whereKey($old->id)->exists())->toBeFalse()
+        ->and(InAppNotification::query()->whereKey($recent->id)->exists())->toBeTrue();
+});
+
+test('an unread notification survives at any age', function () {
+    $ancient = InAppNotification::query()->create([
+        'user_id' => $this->admin->id,
+        'type' => 'file_shared',
+        'read_at' => null,
+        'created_at' => now()->subYears(2),
+    ]);
+
+    $this->artisan('projectsend:purge-notifications')->assertSuccessful();
+
+    expect(InAppNotification::query()->whereKey($ancient->id)->exists())->toBeTrue();
+});
+
+test('a retention of zero keeps read notifications too', function () {
+    app(Settings::class)->set(Setting::NotificationRetentionDays, 0);
+    $old = InAppNotification::query()->create([
+        'user_id' => $this->admin->id,
+        'type' => 'file_shared',
+        'read_at' => now()->subYears(2),
+        'created_at' => now()->subYears(2),
+    ]);
+
+    $this->artisan('projectsend:purge-notifications')->assertSuccessful();
+
+    expect(InAppNotification::query()->whereKey($old->id)->exists())->toBeTrue();
+});
+
+test('both windows are set from the scheduler screen', function () {
+    $this->actingAs($this->admin)->get('/system/settings/scheduler')->assertInertia(
+        fn (AssertableInertia $page) => $page
+            ->where('retention.failed_jobs', 30)
+            ->where('retention.notifications', 90),
+    );
+
+    $this->actingAs($this->admin)
+        ->patch('/system/settings/scheduler/retention', ['failed_jobs' => 7, 'notifications' => 0])
+        ->assertRedirect();
+
+    $settings = app(Settings::class);
+    expect($settings->get(Setting::FailedJobRetentionDays))->toBe(7)
+        ->and($settings->get(Setting::NotificationRetentionDays))->toBe(0);
+});
+
+test('a negative window is refused rather than stored', function () {
+    $this->actingAs($this->admin)
+        ->patch('/system/settings/scheduler/retention', ['failed_jobs' => -1, 'notifications' => 90])
+        ->assertSessionHasErrors('failed_jobs');
+
+    expect(app(Settings::class)->get(Setting::FailedJobRetentionDays))->toBe(30);
+});
+
+test('the cloud edition has no scheduler screen to set them on', function () {
+    config()->set('projectsend.edition', Edition::Cloud);
+
+    $this->actingAs($this->admin)
+        ->patch('/system/settings/scheduler/retention', ['failed_jobs' => 7, 'notifications' => 7])
+        ->assertNotFound();
+});

--- a/tests/Feature/Platform/SchedulerMonitoringTest.php
+++ b/tests/Feature/Platform/SchedulerMonitoringTest.php
@@ -9,6 +9,7 @@ use App\Modules\Platform\Scheduling\ScheduledTaskRun;
 use App\Modules\Platform\Scheduling\TaskRunStatus;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
@@ -44,7 +45,7 @@ test('the scheduler page lists every known command, flagging ones that have neve
     ]);
 
     $response = $this->actingAs($this->admin)->get('/system/settings/scheduler');
-    $response->assertInertia(fn (AssertableInertia $page) => $page->component('system/settings/scheduler')->has('tasks', 7));
+    $response->assertInertia(fn (AssertableInertia $page) => $page->component('system/settings/scheduler')->has('tasks', 10));
 
     $tasks = collect(schedulerPageProps($response)['tasks'])->keyBy('command');
     expect($tasks->get('projectsend:purge-expired-files')['status'])->toBe('success')
@@ -203,4 +204,21 @@ test('a check that has never run has nothing to report', function () {
     $tasks = collect(schedulerPageProps($response)['tasks'])->keyBy('command');
 
     expect($tasks->get('projectsend:check-for-updates')['detail'])->toBeNull();
+});
+
+// The list on the screen and the schedule are two hand-maintained lists of
+// the same thing, and they had already drifted once: the API request log
+// purge ran nightly without ever appearing here, so a failure of it was
+// invisible on the screen built to make failures visible.
+test('every scheduled command appears on the screen', function () {
+    $scheduled = collect(app(Schedule::class)->events())
+        ->map(fn ($event): string => (string) Str::of((string) $event->command)->match('/projectsend:[\w-]+/'))
+        ->filter()
+        ->sort()
+        ->values();
+
+    $response = $this->actingAs($this->admin)->get('/system/settings/scheduler');
+    $listed = collect(schedulerPageProps($response)['tasks'])->pluck('command')->sort()->values();
+
+    expect($listed->all())->toBe($scheduled->all());
 });

--- a/tests/Feature/Platform/SchedulerMonitoringTest.php
+++ b/tests/Feature/Platform/SchedulerMonitoringTest.php
@@ -7,6 +7,8 @@ use App\Modules\Identity\Models\Role;
 use App\Modules\Platform\Capabilities\Edition;
 use App\Modules\Platform\Scheduling\ScheduledTaskRun;
 use App\Modules\Platform\Scheduling\TaskRunStatus;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
@@ -166,4 +168,39 @@ test('staff without edit_settings cannot access the scheduler page', function ()
     $staffer = User::factory()->create(['role_id' => $role->id]);
 
     $this->actingAs($staffer)->get('/system/settings/scheduler')->assertForbidden();
+});
+
+test('the update check reports what it found, not just that it ran', function () {
+    config()->set('projectsend.version', '2.0.0');
+    $settings = app(Settings::class);
+    $settings->set(Setting::LatestVersionCheckedAt, now()->toIso8601String());
+    $settings->set(Setting::LatestKnownVersion, '2.5.0');
+
+    $response = $this->actingAs($this->admin)->get('/system/settings/scheduler');
+    $tasks = collect(schedulerPageProps($response)['tasks'])->keyBy('command');
+
+    expect($tasks->get('projectsend:check-for-updates')['detail'])->toContain('2.5.0');
+});
+
+test('a check that found nothing newer says so', function () {
+    config()->set('projectsend.version', '2.0.0');
+    $settings = app(Settings::class);
+    $settings->set(Setting::LatestVersionCheckedAt, now()->toIso8601String());
+    $settings->set(Setting::LatestKnownVersion, '2.0.0');
+
+    $response = $this->actingAs($this->admin)->get('/system/settings/scheduler');
+    $tasks = collect(schedulerPageProps($response)['tasks'])->keyBy('command');
+
+    expect($tasks->get('projectsend:check-for-updates')['detail'])->toBe('Up to date');
+});
+
+test('a check that has never run has nothing to report', function () {
+    $settings = app(Settings::class);
+    $settings->set(Setting::LatestVersionCheckedAt, '');
+    $settings->set(Setting::LatestKnownVersion, '');
+
+    $response = $this->actingAs($this->admin)->get('/system/settings/scheduler');
+    $tasks = collect(schedulerPageProps($response)['tasks'])->keyBy('command');
+
+    expect($tasks->get('projectsend:check-for-updates')['detail'])->toBeNull();
 });


### PR DESCRIPTION
Six small additions that close the gaps the update and onboarding work left, plus the hygiene a 2.1.0 build would otherwise ship wrong.

### Added
- **Check for updates now.** The daily job was the only thing that refreshed the notice; an administrator who wanted to know *now* had to reach a terminal. The command's logic moved into a shared `CheckForUpdates` service so the notify-once guard cannot drift between the two callers. Throttled twice — a per-user route bucket, and an installation-wide cooldown, because GitHub's limit is per server address.
- **About says when this installation was last updated.** `AppliedVersion`/`AppliedVersionAt` have been recorded since the update command shipped and were read by exactly one thing: the notice that appears when something is wrong.
- **The Scheduler screen says what the update check found**, not just that it ran. Joined at render time — the scheduler's finished event fires after the command returns and would overwrite anything the command wrote, which is why that column was always empty.
- **The getting-started scheduler step ticks itself.** It was marked essential and hardcoded unticked, so the list could never be completed.
- **The update script's useful options, one click away.** `--backup`, `--check` and two more behind an "Other options" dialog, so the page in its resting state still shows one command.
- **Retention for the two tables that grow on their own.** Failed queue jobs and read notifications now have a window (30 and 90 days, 0 keeps everything), set together under Housekeeping on the Scheduler screen, with a nightly purge each. Unread notifications are never deleted, at any age.

### Fixed in passing
- `composer.lock` was pinned before the community package started shipping its own sixteen catalogues, so the translation plumbing merged last week had nothing to carry.
- The API request-log purge had run nightly since it shipped without ever appearing on the Scheduler screen — a failure of it was invisible on the screen built to make failures visible. There is now a test asserting the screen's list and the schedule are the same list.
- `serve => false` on the unused stock `local` disk, `^~` on the nginx protected-files block, `.release-build` in eslint's ignores.

### Verification
pest (1710 passed, 1 skipped), phpstan, tsc and eslint all clean. Every touched screen was loaded in a real browser and screenshotted: the button and its last-checked line, the About row, the "Up to date" cell, the ticked step, and the options dialog. No migrations, no new permission or capability keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)