### PR TITLE
Tell Composer where the migration tool lives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Anything under **Upgrade notes** is something you have to do, not something we d
 This section collects changes as they land; the release process turns it into a numbered entry when
 a version is cut.
 
+### Fixed
+
+- **The Legacy migration tool installs with the command the guide gives you.** `composer require
+  projectsend/v1-migration-tool` failed with *Could not find a matching version of package* on a
+  fresh installation, because the tool is not published on Packagist and nothing told Composer
+  where to find it. ProjectSend now ships that pointer, so the documented command works as
+  written. If you are upgrading rather than installing fresh and still see the error, add the
+  entry shown in the first step of [MIGRATING-FROM-V1.md](MIGRATING-FROM-V1.md) to your
+  `composer.json` and run the command again.
+
 ## 2.0.0 — 2026-08-14
 
 ProjectSend, rebuilt from the ground up. This is a new application rather than an update to the one

--- a/MIGRATING-FROM-V1.md
+++ b/MIGRATING-FROM-V1.md
@@ -111,14 +111,18 @@ npm run build          # so its screen enters the frontend bundle
 In Docker, prefix each with `docker compose exec app` (except `npm run build`, which runs on the
 host).
 
-> While the repository is private, `composer require` needs to be told where to find it — add a
-> `vcs` entry to your `composer.json` `repositories` and give Composer credentials for the repo:
+> **If `composer require` answers `Could not find a matching version of package
+> projectsend/v1-migration-tool`,** your install predates the entry that tells Composer where the
+> tool lives. Add it to the `repositories` array in your `composer.json` — top level, alongside
+> `require`, not inside it — and run the command again:
 >
 > ```json
 > "repositories": [
 >     { "type": "vcs", "url": "https://github.com/projectsend/v1-migration-tool" }
 > ]
 > ```
+>
+> The repository is public, so Composer needs no credentials or token for it.
 
 Then open **`/system/migrate`** on your new install, signed in as a staff user with the *Edit
 settings* permission. There is no sidebar link — a one-time tool does not earn a permanent slot in
@@ -304,6 +308,10 @@ composer remove projectsend/v1-migration-tool
 `--drop` throws away the Legacy → ProjectSend id map. **Keep it** if you may ever want to redirect
 old `download.php?id=…` links, because it is the only thing that can resolve them. Removing the
 package without `--drop` leaves the two tables behind harmlessly.
+
+Leave the `repositories` entry in `composer.json` alone. It ships with ProjectSend, it costs
+nothing while nothing requires the package, and removing it is what makes a second attempt fail to
+find the tool.
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,10 @@
         {
             "type": "vcs",
             "url": "https://github.com/projectsend/community-modules"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/projectsend/v1-migration-tool"
         }
     ],
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cfcaf0c1e3208e2f96b6879bb0eaf3a7",
+    "content-hash": "730d982155d0301ab2a3b5f59c4caebb",
     "packages": [
         {
             "name": "aws/aws-crt-php",


### PR DESCRIPTION
The first command in the migration guide — `composer require projectsend/v1-migration-tool` — fails on a fresh installation with **"Could not find a matching version of package"**. Reported by a customer moving a Debian/Apache Legacy install onto v2.

The tool is not published on Packagist, and nothing in `composer.json` said where else to look. Public and published are different things: the repository went public, but Composer still had no pointer to it.

### Fixed
- **`composer.json` gains a `vcs` repository entry for the tool.** The manifest already had the answer four lines up — `community-modules` is also unpublished and resolves exactly this way. The documented command now works as documented, with nothing to hand-edit.
- **`MIGRATING-FROM-V1.md` no longer hides the manual fallback behind a stale condition.** It read *"While the repository is private…"*, which stopped being true when the repository went public — and a note that reads as inapplicable gets skipped, even though the step it described was still mandatory. It is now a fallback for installations predating this commit (which genuinely still need it), keyed on the error text rather than on a condition the reader has no way to check.
- **The teardown step is inverted.** It used to suggest removing the `repositories` entry once the migration was done, which would now break a second attempt. It says to leave it.
- `composer.lock` content-hash refreshed, since `repositories` is part of it. Without this every `composer install` would warn the lock was stale.

### Follow-up, not in this PR
The repository has **no tags and no releases**, so this installs `dev-main`. When the package is published to Packagist, **this `vcs` entry must be removed in the same change** — locally-defined repositories are canonical and take priority over packagist.org, so leaving it in would keep serving `dev-main` from the default branch and silently shadow every tagged release.

### Verification
- `composer require projectsend/v1-migration-tool` against a copy of this branch's manifest, with no hand-editing: resolves and installs `dev-main 9f4de25`.
- `composer install --no-dev` from the lock: succeeds, same package set, and never consults the new entry — no CI or Docker-build impact.
- `composer validate`: no stale-lock error; the one pre-existing warning (`community-modules` unbound `*`) is unchanged.
- The release build script only rewrites `path` repositories (`build-release.sh:295`), so the `vcs` entry passes through untouched into the shipped zip.
- No PHP or TypeScript changed, so pest/phpstan/tsc/eslint were not run — this is the composer manifest and prose. No `/api/v1` impact.

Pairs with projectsend/v1-migration-tool#6, which documents the entry from the tool's side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
