### PR TITLE
Let Packagist answer for the migration tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,11 @@ a version is cut.
   to release it from any screen. Deleting now hands the name back. Names already held by things you
   deleted earlier are released when you update. ([#1645](https://github.com/projectsend/projectsend/issues/1645))
 - **The Legacy migration tool installs with the command the guide gives you.** `composer require
-  projectsend/v1-migration-tool` failed with *Could not find a matching version of package* on a
-  fresh installation, because the tool is not published on Packagist and nothing told Composer
-  where to find it. ProjectSend now ships that pointer, so the documented command works as
-  written. If you are upgrading rather than installing fresh and still see the error, add the
-  entry shown in the first step of [MIGRATING-FROM-V1.md](MIGRATING-FROM-V1.md) to your
-  `composer.json` and run the command again.
+  projectsend/v1-migration-tool` failed with *Could not find a matching version of package*,
+  because nothing told Composer where to find the tool. It is now published, so the documented
+  command works as written on any installation, new or existing, with nothing to add to your
+  `composer.json`. The tool also has real version numbers now instead of tracking its development
+  branch, so an installation can say which version of it ran.
 
 ## 2.0.0 — 2026-08-14
 

--- a/MIGRATING-FROM-V1.md
+++ b/MIGRATING-FROM-V1.md
@@ -111,19 +111,6 @@ npm run build          # so its screen enters the frontend bundle
 In Docker, prefix each with `docker compose exec app` (except `npm run build`, which runs on the
 host).
 
-> **If `composer require` answers `Could not find a matching version of package
-> projectsend/v1-migration-tool`,** your install predates the entry that tells Composer where the
-> tool lives. Add it to the `repositories` array in your `composer.json` — top level, alongside
-> `require`, not inside it — and run the command again:
->
-> ```json
-> "repositories": [
->     { "type": "vcs", "url": "https://github.com/projectsend/v1-migration-tool" }
-> ]
-> ```
->
-> The repository is public, so Composer needs no credentials or token for it.
-
 Then open **`/system/migrate`** on your new install, signed in as a staff user with the *Edit
 settings* permission. There is no sidebar link — a one-time tool does not earn a permanent slot in
 the navigation of an install that will use it once.
@@ -308,10 +295,6 @@ composer remove projectsend/v1-migration-tool
 `--drop` throws away the Legacy → ProjectSend id map. **Keep it** if you may ever want to redirect
 old `download.php?id=…` links, because it is the only thing that can resolve them. Removing the
 package without `--drop` leaves the two tables behind harmlessly.
-
-Leave the `repositories` entry in `composer.json` alone. It ships with ProjectSend, it costs
-nothing while nothing requires the package, and removing it is what makes a second attempt fail to
-find the tool.
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,6 @@
         {
             "type": "vcs",
             "url": "https://github.com/projectsend/community-modules"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/projectsend/v1-migration-tool"
         }
     ],
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "730d982155d0301ab2a3b5f59c4caebb",
+    "content-hash": "cfcaf0c1e3208e2f96b6879bb0eaf3a7",
     "packages": [
         {
             "name": "aws/aws-crt-php",


### PR DESCRIPTION
`projectsend/v1-migration-tool` is [published on Packagist](https://packagist.org/packages/projectsend/v1-migration-tool) now, and tagged [v1.0.0](https://github.com/projectsend/v1-migration-tool/releases/tag/v1.0.0). So `composer require projectsend/v1-migration-tool` resolves on its own — on any installation, new or existing, with nothing added to `composer.json`. That is what the guide always claimed, and what a customer's Debian install proved it was not.

Follows #1646, which shipped a `vcs` pointer as the stopgap. This replaces it.

### The entry has to go, not just stop being needed

Repositories declared in `composer.json` are **canonical and outrank packagist.org**. Leaving the `vcs` entry in would keep serving `dev-main` off the default branch and silently shadow every release ever tagged — no error, no warning, just the wrong code indefinitely. That is the failure mode you find months later, so it goes in the same change that made it redundant.

### What else goes with it

- The manual fallback blockquote in `MIGRATING-FROM-V1.md`. It described a state no reader is in any more.
- The teardown note telling people to *keep* the `repositories` entry, which would now be advice about an entry that does not exist.

Instructions for a state the reader is not in are exactly how the previous round went wrong: the note about the repository being private outlived the repository being private, so it read as inapplicable, got skipped, and was still mandatory. Not leaving a second one behind.

The changelog entry is rewritten rather than appended to — it described shipping a pointer, which was the fix that lasted a day. What actually landed is that the tool is published and versioned.

### Verification

- **A bare `{}` manifest** — no `repositories`, no `minimum-stability` — resolves `v1.0.0`. That is the whole point, checked rather than assumed.
- **This branch's `composer.json`** resolves `v1.0.0` and writes the constraint `^1.0`, where before it wrote `dev-main`.
- `composer install --no-dev` from the lock succeeds unchanged; `composer validate` reports no stale lock (the content-hash returns to its pre-#1646 value, since the manifest is byte-identical to before that stopgap).
- Packagist metadata confirmed serving `v1.0.0`.
- pest 1717 passed, 1 skipped. No PHP or TypeScript touched — manifest and prose.

### Still open, deliberately not here

The customer hit two further problems that this does not address, both from a release zip not being a git checkout: the shipped `composer.json` carries a `path` repository pointing at a `packages/*` directory the zip does not contain, and `npm run build` cannot run because no `package.json` ships. The second has a consequence worth knowing — `/system/migrate` is compiled into the bundle at release time, so on a zip install that screen does not exist and the `projectsend:migrate:*` commands are the whole interface. Those need their own change, and the artifact half needs a decision first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)