### PR TITLE
Depend on a version of community-modules, not a branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,6 @@
         "framework"
     ],
     "license": "GPL-2.0-or-later",
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/projectsend/community-modules"
-        }
-    ],
     "require": {
         "php": "^8.4",
         "bacon/bacon-qr-code": "^3.1",
@@ -27,7 +21,7 @@
         "laravel/tinker": "^2.10.1",
         "league/flysystem-aws-s3-v3": "^3.29",
         "pragmarx/google2fa": "^9.0",
-        "projectsend/community-modules": "*",
+        "projectsend/community-modules": "^1.0",
         "stevebauman/purify": "^6.3",
         "tightenco/ziggy": "^2.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cfcaf0c1e3208e2f96b6879bb0eaf3a7",
+    "content-hash": "8aeea042b113838ea5a2a2dcfb0965c5",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -4052,7 +4052,7 @@
         },
         {
             "name": "projectsend/community-modules",
-            "version": "dev-main",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/projectsend/community-modules.git",
@@ -4074,7 +4074,6 @@
                 "orchestra/testbench": "^10.0",
                 "pestphp/pest": "^3.8"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -4088,18 +4087,14 @@
                     "ProjectSend\\CommunityModules\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "ProjectSend\\CommunityModules\\Tests\\": "tests/"
-                }
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
             "description": "Community-exclusive feature modules for ProjectSend — free software, never part of the hosted Cloud edition.",
             "support": {
-                "source": "https://github.com/projectsend/community-modules/tree/main",
-                "issues": "https://github.com/projectsend/community-modules/issues"
+                "issues": "https://github.com/projectsend/community-modules/issues",
+                "source": "https://github.com/projectsend/community-modules/tree/v1.0.0"
             },
             "time": "2026-08-16T18:45:51+00:00"
         },


### PR DESCRIPTION
`projectsend/community-modules` is [published](https://packagist.org/packages/projectsend/community-modules) and tagged [v1.0.0](https://github.com/projectsend/community-modules/releases/tag/v1.0.0), so the dependency can finally name a version.

It could not before. With nothing to point at, `composer.json` carried `"*"` against a `vcs` entry, so every install resolved the default branch and got whatever had last been pushed to it. `composer validate` has been saying so on every run:

```
- require.projectsend/community-modules : unbound version constraints (*) should be avoided
```

That warning is now gone — `composer validate` is clean.

### Changed

- `"projectsend/community-modules": "*"` → `"^1.0"`.
- The `vcs` repositories entry removed, leaving no `repositories` key at all.
- Lock moves `dev-main 311883a` → `v1.0.0`, sourced from Packagist instead of a clone of a moving branch. Same code — the tag was cut from that commit — but now it is a code somebody can name.

The entry has to go rather than merely stop being needed: a repository declared in `composer.json` is canonical and outranks packagist.org, so leaving it would keep serving `dev-main` and silently shadow every release ever tagged. Same trap as #1649.

### Why it matters beyond tidiness

This is what makes the release artifact fixable. The build added a `path` repository so the edition's package could resolve from a staged clone, and that entry shipped — pointing at a `packages/*` directory the zip does not contain. It broke *every* `composer require` on a manual install, which is where the customer installing the migration tool onto a fresh 2.0.0 got stuck.

With the package on Packagist, a community build resolves it like any other dependency and ships no local path at all. That change is in `private-docs` (`build-release.sh`), since the release skill lives outside this repo.

### Verification

Built a real community zip with the new pipeline and inspected it:

- shipped `composer.json`: **no `repositories` key**, `community-modules` pinned at `v1.0.0`
- shipped `composer.lock`: normal `zip` dist, no path reference
- no `cloud-modules` anywhere in the artifact
- **unpacked the zip and ran the customer's exact command** — `composer require projectsend/v1-migration-tool` installs `v1.0.1` with no `packages/` directory and nothing added by hand

Plus: pest 1717 passed, 1 skipped; `composer validate` clean; `composer install --no-dev` from the lock resolves `v1.0.0` from Packagist with no `vcs` entry present.

### One thing I noticed and did not change

`composer require` inside the artifact also pulls the lock's dev dependencies (pest, phpstan) into `vendor/`. Pre-existing, unrelated to this change, and avoidable with `--update-no-dev`. Worth a follow-up on what the migration guide tells people to type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)