### PR TITLE
Give the official Docker image a way to migrate

### DIFF
--- a/MIGRATING-FROM-V1.md
+++ b/MIGRATING-FROM-V1.md
@@ -100,17 +100,16 @@ The tool reports each of these before it starts and names every affected row. It
 
 ## Step 1 — Install the tool
 
-On the **new** install:
+Everything here happens on the **new** install. How the tool gets there — and whether you get its
+screen — depends on how ProjectSend itself got onto the machine, so find yours below and use that
+section on its own.
+
+### If you installed from a release zip
 
 ```sh
 composer require projectsend/v1-migration-tool
 php artisan migrate    # creates the tool's two tables
 ```
-
-What comes after that depends on how ProjectSend got onto the machine, and so does whether you get
-the tool's screen.
-
-### If you installed from a release zip
 
 That is the whole installation — there is no `npm run build` to run. The zip ships its assets
 already compiled and deliberately without the toolchain that compiled them, so there is no
@@ -124,16 +123,44 @@ Nothing is missing from the migration itself. Every step below lists the command
 commands do everything the screen does, and on a zip install they are the interface rather than a
 fallback. Start with [Step 2](#step-2--pick-your-route) and follow the commands.
 
-### If you are running from a git checkout
+### If you are running the official Docker image
 
-Including the Docker stack in this repository. Build the frontend so the screen appears:
+The image carries no Composer. It ships the application already built and has no use for one, so
+fetch it for the length of the migration and use it in place:
 
 ```sh
-npm run build
+docker compose exec -u www-data app \
+    php -r 'copy("https://getcomposer.org/composer.phar", "/tmp/composer.phar");'
+docker compose exec -u www-data app \
+    php /tmp/composer.phar require projectsend/v1-migration-tool --update-no-dev
+docker compose exec -u www-data app php artisan migrate
 ```
 
-In Docker, prefix the two commands above with `docker compose exec app`; `npm run build` runs on
-the host, where the toolchain is.
+`-u www-data` is not decoration: `exec` lands as root, and a root-owned `vendor/` is a problem the
+application runs into later rather than now. `--update-no-dev` keeps the test tooling that the lock
+file knows about out of a production install.
+
+That install lives in the container's writable layer, so it lasts until the container is replaced —
+a `docker compose pull`, or any change to your compose file, takes it with it. For a migration you
+finish in one sitting that is fine, and if it does go, install it again: the run's progress and its
+id map are in the database, not in the package.
+
+There is no `/system/migrate` screen here either, for the same reason as a zip install. The commands
+are the interface — start with [Step 2](#step-2--pick-your-route).
+
+### If you are running from a git checkout
+
+Including the Docker stack in this repository, which builds the application from source rather than
+pulling the published image.
+
+```sh
+composer require projectsend/v1-migration-tool
+php artisan migrate    # creates the tool's two tables
+npm run build          # so the tool's screen enters the frontend bundle
+```
+
+In Docker, prefix the first two with `docker compose exec app`; `npm run build` runs on the host,
+where the toolchain is.
 
 Then open **`/system/migrate`**, signed in as a staff user with the *Edit settings* permission.
 There is no sidebar link — a one-time tool does not earn a permanent slot in the navigation of an
@@ -188,6 +215,13 @@ over. Take it from the package, which is where it lives on every install:
 
 ```sh
 vendor/projectsend/v1-migration-tool/bin/projectsend-v1-export.php
+```
+
+In Docker, copy it out of the container first:
+
+```sh
+docker compose cp \
+    app:/var/www/html/vendor/projectsend/v1-migration-tool/bin/projectsend-v1-export.php .
 ```
 
 If you have the screen, `/system/migrate` offers it as a download instead.


### PR DESCRIPTION
The guide had no working answer for the install method we recommend most. The published image carries **no Composer** — it ships the application already built and has no use for one — so `composer require`, the first command in Step 1, is not something a Docker reader can run at all. The guide's Docker line assumed the stack in *this* repository, which builds from source and does have one.

Follows #1651, which fixed the same class of problem for zip installs.

### The way through

Composer is a PHP file, and PHP is what the image is. Fetch it into `/tmp` for the length of the migration:

```sh
docker compose exec -u www-data app \
    php -r 'copy("https://getcomposer.org/composer.phar", "/tmp/composer.phar");'
docker compose exec -u www-data app \
    php /tmp/composer.phar require projectsend/v1-migration-tool --update-no-dev
docker compose exec -u www-data app php artisan migrate
```

Two details there are load-bearing rather than decorative, and the section says why:

- **`-u www-data`** — `exec` lands as root, and a root-owned `vendor/` is a problem the application meets later rather than now.
- **`--update-no-dev`** — the shipped lock file knows about pest and phpstan, and a production install should not grow a test suite on the way past. (This also answers the dev-dependency bloat I flagged on #1650.)

### Verified, not plausible

Everything above was run against the **real production image**, built locally from the release zip — the Docker Hub repository is still private, so pulling it wasn't an option:

- Image inventory: no `composer`, no `npm`, no `node`, no `git`, no `package.json`, no `packages/`. `unzip` and PHP 8.4.24 present.
- The tool installs cleanly as `www-data` and lands at `vendor/projectsend/v1-migration-tool`.
- **All four `projectsend:migrate:*` commands register** with no `package:discover` run by hand — the post-install scripts handle it.
- The Bundle route's export script is present at the path the guide now gives.
- `--update-no-dev` confirmed: no `vendor/pestphp`.

### Honest about the limit

The install lives in the container's writable layer and does **not** survive the container being replaced — a `docker compose pull` or a compose-file change takes it with it. The section says so, and says why that is acceptable: the run's progress and its id map are in the database, so losing the package costs an install, not a migration.

### Shape

Step 1 is now three self-contained sections — zip, official Docker image, git checkout — rather than one set of commands with exceptions bolted on. That previous shape is precisely what let a reader follow instructions that could not work on their install.

Also adds the `docker compose cp` line for getting the export script out of the container, which the Bundle route needs.

### Worth deciding separately

Whether the image should simply **carry Composer**. It would make this three lines shorter and make any package installable, at the cost of image size and surface area. Not assumed either way here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)