### PR TITLE
Give the Docker Hub page a masthead

### DIFF
--- a/docker/production/dockerhub-overview.md
+++ b/docker/production/dockerhub-overview.md
@@ -1,3 +1,12 @@
+[![ProjectSend](https://raw.githubusercontent.com/projectsend/projectsend/main/public/apple-touch-icon.png)](https://github.com/projectsend/projectsend)
+
+[![Release](https://img.shields.io/github/v/release/projectsend/projectsend?color=3b5bdb&label=release)](https://github.com/projectsend/projectsend/releases "what is in each release, and the downloadable zip")
+[![Docker pulls](https://img.shields.io/docker/pulls/projectsend/projectsend?color=0b7285)](https://hub.docker.com/r/projectsend/projectsend/tags "every published tag")
+[![Image size](https://img.shields.io/docker/image-size/projectsend/projectsend/latest?color=0b7285&label=image)](https://hub.docker.com/r/projectsend/projectsend/tags "compressed size of the latest tag")
+[![GitHub stars](https://img.shields.io/github/stars/projectsend/projectsend?color=3b5bdb)](https://github.com/projectsend/projectsend "source, issues and full documentation")
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/VT9n6cyvXT "release news, and help when something is not behaving")
+[![License](https://img.shields.io/badge/license-GPLv2%2B-3b5bdb)](https://github.com/projectsend/projectsend/blob/main/LICENSE "free software, and commercial licences for those who need them")
+
 # ProjectSend
 
 **Share files with your clients, from your own server.**


### PR DESCRIPTION
The Docker Hub description opened on a bare `# ProjectSend`, which on a registry listing reads as an unfinished description rather than a product. Every well-kept image beside ours leads with a mark and a row of badges — and there the badges are not decoration: version, size and where to get help are exactly the questions somebody has *before* they decide to pull.

Six, each answering one:

| Badge | Links to |
|---|---|
| Release — reads **v2.1.0** live | Releases |
| Docker pulls — reads **168** live | Tags |
| Image size — reads **78.4 MiB** live | Tags |
| GitHub stars — reads **2k** live | The repository |
| Discord | The invite |
| License GPLv2+ | `LICENSE` |

Four are live values, so the page stops being something anyone has to remember to update.

### Three decisions worth recording

**Pure markdown, no HTML.** Docker Hub sanitises HTML out of descriptions, so the `<p align="center">` layouts people write for GitHub silently collapse there. I checked what actually renders by reading the source of a page known to work — `linuxserver/docker-projectsend`'s README — and it is consecutive markdown links with title attributes. That is what this uses.

**The mark is `apple-touch-icon.png`, not the wordmark or the favicon.** `favicon.svg` has a `viewBox` and *no width or height*, so it has no intrinsic size and renders at whatever width the container offers — enormous, on a wide column. The PNG is 180×180 and renders as a mark. This also matches `README.md`, which puts a small icon above the title rather than a banner.

**The colours are ours, not the page this was modelled after.** `3b5bdb` for project facts and `0b7285` for Docker facts, both from `README.md`, plus Discord's own brand colour where the badge is a Discord badge. The two front doors should look like the same project rather than like a copy of somebody else's.

### Verified

All twelve URLs return 200 — six badge endpoints, six link targets, the raw logo included. And because shields.io answers 200 even when it renders the word "invalid", I read the text out of each dynamic badge to confirm it shows a real value.

Remember this file is not published by merging: it is pasted into the repository description on Docker Hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)