### PR TITLE
Show the dashboard on the Docker Hub page

### DIFF
--- a/docker/production/dockerhub-overview.md
+++ b/docker/production/dockerhub-overview.md
@@ -20,6 +20,11 @@ per-seat pricing. It runs on your server, and the files stay there.
 
 This is the official image for the Community edition — free software under the GPL v2 or later.
 
+![The dashboard: counters for files, clients and groups, the clients using the most storage against their quotas, a month of uploads and downloads as a line chart, and recent activity](https://raw.githubusercontent.com/projectsend/projectsend/main/.github/screenshots/dashboard.png)
+
+*The dashboard — what is in the installation, and what has been happening in it. More screenshots
+are in the [README](https://github.com/projectsend/projectsend#screenshots).*
+
 ---
 
 ## Quick start


### PR DESCRIPTION
The page described the application in three paragraphs and then went straight to a compose file. Somebody deciding whether to pull it had no idea what it looks like — and for a thing whose whole job is a screen your clients use, that is the question they are actually asking.

Follows #1656, which added the masthead.

### Placement

After the paragraphs that say what this is, before **Quick start** — the point where a reader has decided they are interested and has not yet decided to spend ten minutes on a compose file. Same spot `owncloud/server` uses.

### Choices

- **The same image and the same alt text as the README.** The alt was written to describe the screen — counters, storage against quotas, a month of uploads and downloads, recent activity — rather than to name the file, so it carries its weight for anyone reading with a screen reader.
- **One screenshot, not three.** The README has the library and the client portal too, and the caption links there. A registry description that scrolls past its own install instructions has stopped being an install page.
- **Absolute `raw.githubusercontent.com` URL**, because a repository-relative path resolves to nothing on hub.docker.com — the same reason the badges point there.

`.github/` is stripped from the release artifact, which does not matter here: this file is pasted into a description, not shipped inside the zip.

### Verified

- The image URL returns `200 image/png` (412 KB, 2720×1700 — a retina capture, so it fills the description column rather than looking soft).
- `dashboard-dark.png` is also present and serving, if a dark variant is ever wanted instead.
- The caption's `README#screenshots` anchor exists (`README.md:52`) and resolves 200.

As with #1656: merging does not publish this. It reaches Docker Hub when the file is pasted into the repository description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)