### PR TITLE
Let the setup screen be what the quickstart actually shows

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ docker compose -f compose.example.yaml up -d
 ```
 
 Open `APP_URL` and the first thing you see is a setup screen that creates your administrator
-account — or set `ADMIN_EMAIL` and `ADMIN_PASSWORD` in the file first and it is created for you.
+account — or uncomment `ADMIN_EMAIL` and `ADMIN_PASSWORD` in the file first, with a password of
+your own, and it is created for you.
 
 Before you put real files in it, read **[DOCKER.md](DOCKER.md)** — where your database and uploads
 actually live, how to move them onto paths you chose, and how to back them up so an upgrade can't

--- a/docker/production/compose.example.yaml
+++ b/docker/production/compose.example.yaml
@@ -2,8 +2,7 @@
 #
 #   1. Edit the passwords and APP_URL below.
 #   2. docker compose -f compose.example.yaml up -d
-#   3. Open APP_URL. If you set ADMIN_EMAIL/ADMIN_PASSWORD the first
-#      administrator already exists; otherwise the setup screen prompts.
+#   3. Open APP_URL — the setup screen creates your administrator account.
 #
 # This is the file the Docker Hub description points at, so it is written
 # for someone who has never seen the project before.
@@ -58,11 +57,13 @@ services:
       # download log records the proxy's address.
       TRUSTED_PROXIES: "*"
 
-      # Optional: creates the first administrator so you skip the setup
-      # screen. Ignored once any user exists.
-      ADMIN_NAME: Administrator
-      ADMIN_EMAIL: admin@example.com
-      ADMIN_PASSWORD: change-me-admin
+      # Optional: uncomment these — with a password of your own — to create
+      # the first administrator unattended and skip the setup screen. Left
+      # commented, the setup screen creates it instead. Ignored once any
+      # user exists.
+      # ADMIN_NAME: Administrator
+      # ADMIN_EMAIL: admin@example.com
+      # ADMIN_PASSWORD: change-me-admin
     volumes:
       # Every uploaded file lives here, along with the generated APP_KEY.
       # This is the volume to back up; losing it loses the data.

--- a/docker/production/dockerhub-overview.md
+++ b/docker/production/dockerhub-overview.md
@@ -60,11 +60,13 @@ services:
       # container — including the reverse proxy you should be running.
       TRUSTED_PROXIES: "*"
 
-      # Optional: creates the first administrator so you skip the setup
-      # screen. Ignored once any user exists.
-      ADMIN_NAME: Administrator
-      ADMIN_EMAIL: admin@example.com
-      ADMIN_PASSWORD: change-me-admin
+      # Optional: uncomment these — with a password of your own — to create
+      # the first administrator unattended and skip the setup screen. Left
+      # commented, the setup screen creates it instead. Ignored once any
+      # user exists.
+      # ADMIN_NAME: Administrator
+      # ADMIN_EMAIL: admin@example.com
+      # ADMIN_PASSWORD: change-me-admin
     volumes:
       # Every uploaded file lives here, along with the generated APP_KEY.
       - storage:/var/www/html/storage
@@ -100,8 +102,9 @@ volumes:
   redis-data:
 ```
 
-Then open `APP_URL`. If you set `ADMIN_EMAIL` and `ADMIN_PASSWORD` the first administrator already
-exists; otherwise the setup screen creates one.
+Then open `APP_URL` — the setup screen creates your administrator account. Uncomment
+`ADMIN_EMAIL` and `ADMIN_PASSWORD` above, with a password of your own, to create it unattended
+instead.
 
 The first start is slower than later ones: the container waits for MySQL to accept connections
 before it migrates the database. That wait is normal, not a failure.


### PR DESCRIPTION
The website, the README and the Docker Hub page all promise the same thing: run the quickstart, open `APP_URL`, and a setup screen creates your administrator account.

That is not what happened. `docker/production/compose.example.yaml` shipped with `ADMIN_NAME` / `ADMIN_EMAIL` / `ADMIN_PASSWORD` filled in, so `entrypoint.sh` ran `projectsend:admin --if-none` on first boot and the user landed on the login screen instead. Worse, anyone who followed the instructions literally — "edit `APP_URL` and the passwords" — got a publicly reachable administrator on `admin@example.com` with a password published in a file on `main`.

This comments the three variables out. Unattended provisioning is unchanged and still documented in the env-var table; it is just opt-in now.

- `docker/production/compose.example.yaml` — variables commented, header step 3 corrected
- `docker/production/dockerhub-overview.md` — same block in the embedded snippet, plus the paragraph below it
- `README.md` — "set" → "uncomment", which is now the actual step

## Verification

Ran the quickstart for real off the edited file (port remapped to 8099):

- `docker compose config` parses; the app service has no `ADMIN*` keys in its environment
- `http://localhost:8099/` → 302 to `/setup`, Inertia component `setup`
- `User::count()` in the container: `0` — no stray `admin@example.com`

No application code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)