### PR TITLE
Survive open_basedir when probing for a container runtime

### DIFF
--- a/app/Modules/Platform/Installation/Installation.php
+++ b/app/Modules/Platform/Installation/Installation.php
@@ -42,7 +42,13 @@ class Installation
      */
     protected function inContainer(): bool
     {
-        // Docker writes the first; Podman writes the second.
-        return file_exists('/.dockerenv') || file_exists('/run/.containerenv');
+        // Docker writes the first; Podman writes the second. The probes are
+        // suppressed because under open_basedir (common on shared hosting)
+        // file_exists() on a path outside the allowed list raises a warning
+        // instead of returning false - and the framework escalates that
+        // warning into an exception. An unreadable answer means "not a
+        // container": a host restrictive enough for open_basedir is never
+        // the Docker install.
+        return @file_exists('/.dockerenv') || @file_exists('/run/.containerenv');
     }
 }


### PR DESCRIPTION
Fixes #<1663>

## What changes

`Installation::inContainer()` suppresses its two `file_exists()` probes.

## Why

Under `open_basedir` (common on shared hosting, often not editable by the
customer), probing `/.dockerenv` raises a warning instead of returning
false. Laravel escalates the warning into an ErrorException, which kills
every request that reaches the probe - in practice: the dashboard 500s on
an otherwise working installation.

## How I tested it

Reproduced on a Plesk shared host (PHP 8.4.24 FPM, open_basedir limited to
the webspace): dashboard 500s with the stack trace in the linked issue.
With this change applied on that host, the dashboard renders normally.
Behaviour on unrestricted hosts is unchanged - both probes still answer
true/false exactly as before.