### PR TITLE
Stop container detection from taking the dashboard down on shared hosting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ Anything under **Upgrade notes** is something you have to do, not something we d
 This section collects changes as they land; the release process turns it into a numbered entry when
 a version is cut.
 
+### Fixed
+
+- **The dashboard no longer fails on shared hosting.** To decide which update instructions to print,
+  ProjectSend asks whether it is running inside a container by looking for a file in the root of the
+  filesystem. On shared hosting PHP is usually confined to your own directory, and looking outside it
+  is treated as an error rather than as a "no" — so the one page that asks the question, the
+  dashboard, returned a 500 while every other page worked. It now takes the restriction as the answer
+  it always was: a server that keeps PHP inside a single directory is not our container image, and
+  gets the manual update instructions, which is correct for shared hosting anyway. Nothing to change
+  on your side, and no setting you would have been able to change if there were.
+  ([#1663](https://github.com/projectsend/projectsend/issues/1663))
+
 ## 2.1.0 — 18 August 2026
 
 Updating, mostly. ProjectSend now tells you when there is a new version, ends an update somewhere

--- a/app/Modules/Platform/Installation/Installation.php
+++ b/app/Modules/Platform/Installation/Installation.php
@@ -43,6 +43,15 @@ class Installation
     protected function inContainer(): bool
     {
         // Docker writes the first; Podman writes the second.
-        return file_exists('/.dockerenv') || file_exists('/run/.containerenv');
+        //
+        // Suppressed, and it has to stay that way. Shared hosting sets
+        // open_basedir to the webspace, and probing a path outside it is a
+        // warning rather than a false — which the framework's error handler
+        // turns into an exception, so the one call that asks which install
+        // this is took the whole dashboard down with it (#1663). Under `@`
+        // the warning is filtered and the probe answers false, which is the
+        // right answer anyway: a host that restricts PHP to a vhost
+        // directory is not the container image.
+        return @file_exists('/.dockerenv') || @file_exists('/run/.containerenv');
     }
 }


### PR DESCRIPTION
Fixes #1663.

Deciding which update instructions to print starts with asking whether we are running in a container, and that question is answered by looking for the file a container runtime leaves in the root of the filesystem. Shared hosting confines PHP to the webspace with `open_basedir`, where looking outside it raises a warning rather than returning false — and the framework's error handler turns warnings into exceptions, so the probe threw instead of answering. The dashboard is the one page that asks, so it returned a 500 while every other page worked.

Both probes are now suppressed. A host that keeps PHP inside a single directory is not our published image, so `false` is the correct answer as well as the surviving one, and it lands on the manual instructions that shared hosting wants anyway.

### Why `@` rather than checking `ini_get('open_basedir')`

The reporter offered both. Testing the ini setting gets a hardened container wrong in the other direction — it would hand the manual sequence to someone whose files are inside an image, which is the audience the class docblock says specifically must not get it.

### The dashboard was only the first symptom

Two other call sites reach `Installation::kind()` behind conditions the affected host had not met yet:

- `HandleInertiaRequests::updateNotice()` runs on **every Inertia response** for staff with `manage_updates`, but only once a newer release exists. The day 2.1.1 ships, that host loses every page rather than one.
- `RunningCodeState::current()` reaches it whenever the applied and running versions disagree — that is, mid-update.

So this was a latent full-site outage, not a single broken widget.

### Verification

The failure and the fix were reproduced directly, running the probe under `open_basedir` with the framework's own error-handler semantics:

```
bare        => THREW ErrorException: file_exists(): open_basedir restriction in effect. File(/.dockerenv) …
suppressed  => false
```

PHPStan clean, `tsc` clean, `eslint` clean. `InstallationKindTest`, `StorageDurabilityTest` and `DashboardTest` pass together.

Note that the existing test seam — `inContainer()` overridden in a subclass — cannot catch removal of the suppression, which is why the reason for it is written on the line itself.