### PR TITLE
Preview video, audio and PDF, not only images

### DIFF
--- a/app/Modules/Audit/Action.php
+++ b/app/Modules/Audit/Action.php
@@ -54,6 +54,7 @@ enum Action: string
     case ShareLinkRevoked = 'share_link.revoked';
     case ShareLinkDownloaded = 'share_link.downloaded';
     case PublicFileDownloaded = 'public_file.downloaded';
+    case PublicFilePreviewed = 'public_file.previewed';
     case FolderCreated = 'folder.created';
     case FolderRenamed = 'folder.renamed';
     case FolderMoved = 'folder.moved';
@@ -180,6 +181,7 @@ enum Action: string
             self::ShareLinkRevoked => 'Revoked a public link for the file ":subject"',
             self::ShareLinkDownloaded => 'Downloaded the file ":subject" via a public link',
             self::PublicFileDownloaded => 'Downloaded the file ":subject" via the public group listing',
+            self::PublicFilePreviewed => 'Previewed the file ":subject" via the public group listing',
             self::FolderCreated => 'Created the folder ":subject"',
             self::FolderRenamed => 'Renamed the folder ":subject"',
             self::FolderMoved => 'Moved the folder ":subject"',
@@ -278,6 +280,7 @@ enum Action: string
             self::ShareLinkRevoked => 'A public link was revoked',
             self::ShareLinkDownloaded => 'A file was downloaded via a public link',
             self::PublicFileDownloaded => 'A file was downloaded via the public group listing',
+            self::PublicFilePreviewed => 'A file was previewed via the public group listing',
             self::FolderCreated => 'A folder was created',
             self::FolderRenamed => 'A folder was renamed',
             self::FolderMoved => 'A folder was moved',

--- a/app/Modules/Audit/ActivityLogger.php
+++ b/app/Modules/Audit/ActivityLogger.php
@@ -93,7 +93,7 @@ class ActivityLogger
 
     private function shouldRecordIp(Action $action, ?User $actor): bool
     {
-        if (! in_array($action, [Action::FileDownloaded, Action::FilePreviewed, Action::ShareLinkDownloaded, Action::PublicFileDownloaded], true)) {
+        if (! in_array($action, [Action::FileDownloaded, Action::FilePreviewed, Action::ShareLinkDownloaded, Action::PublicFileDownloaded, Action::PublicFilePreviewed], true)) {
             return true;
         }
 

--- a/app/Modules/Clients/Http/Controllers/ClientSettingsController.php
+++ b/app/Modules/Clients/Http/Controllers/ClientSettingsController.php
@@ -32,6 +32,7 @@ class ClientSettingsController extends Controller
             'clients_can_select_group' => $this->settings->get(Setting::ClientsCanSelectGroup),
             'clients_membership_deny_cooldown_days' => $this->settings->get(Setting::ClientsMembershipDenyCooldownDays),
             'default_client_storage_quota_mb' => (int) $this->settings->get(Setting::DefaultClientStorageQuotaMb),
+            'clients_can_preview_files' => $this->settings->get(Setting::ClientsCanPreviewFiles),
             'groups' => Group::query()->orderBy('name')->get()
                 ->map(fn (Group $group): array => ['id' => $group->id, 'name' => $group->name])
                 ->all(),
@@ -47,6 +48,7 @@ class ClientSettingsController extends Controller
             'clients_can_select_group' => ['required', Rule::in(['none', 'public'])],
             'clients_membership_deny_cooldown_days' => ['required', 'integer', 'min:0', 'max:365'],
             'default_client_storage_quota_mb' => ['required', 'integer', 'min:0'],
+            'clients_can_preview_files' => ['required', 'boolean'],
         ]);
 
         $this->settings->set(Setting::ClientsCanRegister, $validated['clients_can_register']);
@@ -55,6 +57,7 @@ class ClientSettingsController extends Controller
         $this->settings->set(Setting::ClientsCanSelectGroup, $validated['clients_can_select_group']);
         $this->settings->set(Setting::ClientsMembershipDenyCooldownDays, (int) $validated['clients_membership_deny_cooldown_days']);
         $this->settings->set(Setting::DefaultClientStorageQuotaMb, (int) $validated['default_client_storage_quota_mb']);
+        $this->settings->set(Setting::ClientsCanPreviewFiles, $validated['clients_can_preview_files']);
 
         $this->activity->log(Action::SettingsUpdated, context: ['section' => 'clients']);
 

--- a/app/Modules/Files/Delivery/InlineFileResponse.php
+++ b/app/Modules/Files/Delivery/InlineFileResponse.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Files\Delivery;
+
+use App\Modules\Files\Models\File;
+use App\Support\ContentDisposition;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * A stored file's own bytes, served to be looked at rather than saved.
+ *
+ * The two preview endpoints — FileThumbnailController::preview for
+ * someone signed in, PublicGroupsController::preview for a visitor —
+ * reach this after they have each authorized in their own way. It
+ * authorizes nothing itself; it only knows how to put bytes on the wire
+ * for whichever disk the file lives on.
+ *
+ * Local disk: X-Accel-Redirect, so nginx streams the file and PHP never
+ * touches the bytes. That matters more here than it does for a download,
+ * because a <video> seeking through an hour of footage issues a long tail
+ * of Range requests; nginx's static handler answers those with 206s on
+ * its own, and drops the Content-Length below in favour of the range it
+ * actually served. Anything else — S3 and friends — gets a short-lived
+ * presigned URL carrying an inline disposition, which the object store
+ * ranges just as well.
+ *
+ * Callers must have established that the mime type is inline-safe first;
+ * PreviewKind is the allowlist, and the reason there is one.
+ */
+class InlineFileResponse
+{
+    public function make(File $file): Response|RedirectResponse
+    {
+        if ($file->disk !== 'files') {
+            $url = Storage::disk($file->disk)->temporaryUrl(
+                $file->path,
+                now()->addHour(),
+                ['ResponseContentDisposition' => ContentDisposition::inline($file->original_name)],
+            );
+
+            return redirect()->away($url);
+        }
+
+        return response('', 200, [
+            'X-Accel-Redirect' => '/protected-files/'.$file->path,
+            'Content-Type' => $file->mime_type,
+            'Content-Disposition' => ContentDisposition::inline($file->original_name),
+            'Content-Length' => (string) $file->size,
+        ]);
+    }
+}

--- a/app/Modules/Files/Http/Controllers/FileThumbnailController.php
+++ b/app/Modules/Files/Http/Controllers/FileThumbnailController.php
@@ -8,15 +8,20 @@ use App\Http\Controllers\Controller;
 use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLogger;
 use App\Modules\Files\Access\DownloadAllowance;
+use App\Modules\Files\Delivery\InlineFileResponse;
 use App\Modules\Files\Models\File;
+use App\Modules\Files\Preview\PreviewKind;
 use App\Modules\Files\Thumbnails\Events\ResolvingImageRendering;
 use App\Modules\Files\Thumbnails\ImageAudience;
 use App\Modules\Files\Thumbnails\ImageRendition;
 use App\Modules\Files\Thumbnails\ThumbnailGenerator;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
 use App\Support\ContentDisposition;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
@@ -32,17 +37,25 @@ use Illuminate\Support\Facades\Storage;
  * file's contents — a real, audit-worthy action, just not a "download."
  *
  * SECURITY: both methods serve bytes inline, from this app's own origin,
- * with the File's stored mime type — so both are restricted to
+ * with the File's stored mime type, so both are restricted to an
+ * allowlist — but not the same one, because they are asking different
+ * questions. `thumbnail()` is bounded by
  * ThumbnailGenerator::SUPPORTED_MIME_TYPES, the raster formats this app
- * renders itself. That list is the allowlist; nothing else is ever served
- * inline. Do NOT widen it to text/html, image/svg+xml, or anything else a
- * browser executes script from, and do not reach for the upload
- * allowed-extensions setting as a substitute: that setting matches on the
- * *extension*, while mime_type is detected from the *bytes*
- * (ChunkedUploadsController::complete), so a .txt holding HTML is stored
- * as text/html and would render as a page here. Serving a file inline as
- * a type the browser executes is same-origin script execution with the
- * viewer's session.
+ * decodes and re-encodes itself, since a thumbnail *is* a rendition.
+ * `preview()` is bounded by PreviewKind, which additionally admits the
+ * video, audio and PDF types a browser plays natively and this app never
+ * touches. PreviewKind's docblock carries the rule in full; the short
+ * version is that neither list may ever grow a type a browser executes
+ * script from, and neither may be derived from the upload
+ * allowed-extensions setting, which matches on the *extension* while
+ * mime_type is detected from the *bytes*
+ * (ChunkedUploadsController::complete).
+ *
+ * Serving media inline is also why `preview()` logs at most one
+ * Action::FilePreviewed per viewer per file per five minutes: a `<video>`
+ * seeking through a recording issues a long tail of Range requests
+ * against this same URL, and one row each would bury the log under a
+ * single deliberate act.
  *
  * Renditions always cache on the local "files" disk regardless of where
  * the source file lives — they're a derived artifact, not the original,
@@ -60,6 +73,8 @@ class FileThumbnailController extends Controller
         private readonly ThumbnailGenerator $thumbnails,
         private readonly ActivityLogger $activity,
         private readonly DownloadAllowance $allowance,
+        private readonly InlineFileResponse $inline,
+        private readonly Settings $settings,
     ) {}
 
     public function thumbnail(Request $request, File $file): Response
@@ -82,66 +97,92 @@ class FileThumbnailController extends Controller
     /**
      * A file opened to be looked at.
      *
-     * A preview is not the file — it is a rendered view of it, which is
-     * why it may be decorated at all. But rendering one is expensive
-     * (decoding and re-encoding a full-size photograph) where serving the
-     * stored bytes is nearly free, so core only pays that cost when a
-     * listener says this particular viewer must be served a rendering:
-     * ResolvingImageRendering asks, and defaults to no. On an
+     * For an image, a preview is not the file — it is a rendered view of
+     * it, which is why it may be decorated at all. But rendering one is
+     * expensive (decoding and re-encoding a full-size photograph) where
+     * serving the stored bytes is nearly free, so core only pays that
+     * cost when a listener says this particular viewer must be served a
+     * rendering: ResolvingImageRendering asks, and defaults to no. On an
      * installation that watermarks, a client gets a bounded, watermarked
      * render and staff get the original; on one that does not, everyone
      * gets exactly what this endpoint has always returned.
+     *
+     * For video, audio and PDF there is no rendering to resolve — this
+     * app cannot decode any of them, so it has no rendition to cache, no
+     * watermark to stamp, and nothing to ask about. Those go straight to
+     * the bytes.
      */
     public function preview(Request $request, File $file): Response|RedirectResponse
     {
         Gate::authorize('view', $file);
 
-        // Only types this app renders itself may be served inline; anything
-        // else is a download, not a preview. See the class docblock — the
-        // stored mime type is sniffed from the bytes, so an allowed
+        // The inline allowlist. See the class docblock and PreviewKind —
+        // the stored mime type is sniffed from the bytes, so an allowed
         // extension is not evidence of a safe-to-render payload.
-        abort_unless(ThumbnailGenerator::supports($file->mime_type), 404);
+        $kind = PreviewKind::forMime($file->mime_type);
+
+        abort_if($kind === null, 404);
+
+        // Staff are never gated: this switch exists so an installation can
+        // decide what its *clients* may do with a file short of taking it.
+        // 404 rather than 403 because with the setting off the endpoint is
+        // not a thing that exists for this viewer.
+        abort_if(
+            $request->user()?->isStaff() !== true && ! $this->settings->get(Setting::ClientsCanPreviewFiles),
+            404,
+        );
 
         // A preview is not counted as a download, but it is refused once
         // the download limit is spent — because unless a listener asks
-        // for a rendering (nothing does by default), the branches below
-        // serve the *original bytes* at full size. Without this a cap
-        // would be one URL away from meaningless for every image on the
-        // install. thumbnail() needs no such guard: a 300px rendition is
-        // not the file.
+        // for a rendering (nothing does by default, and nothing ever does
+        // for media), the branches below serve the *original bytes* at
+        // full size. Without this a cap would be one URL away from
+        // meaningless for every previewable file on the install.
+        // thumbnail() needs no such guard: a 300px rendition is not the
+        // file.
         abort_unless($this->allowance->allows($file, $request->user()), 403);
 
-        $this->activity->log(Action::FilePreviewed, subject: $file);
+        $this->logPreview($file, $request);
 
-        $audience = ImageAudience::forViewer($request->user());
+        if ($kind === PreviewKind::Image) {
+            $audience = ImageAudience::forViewer($request->user());
 
-        $decision = new ResolvingImageRendering($audience, ImageRendition::Preview, $file->mime_type);
-        Event::dispatch($decision);
+            $decision = new ResolvingImageRendering($audience, ImageRendition::Preview, $file->mime_type);
+            Event::dispatch($decision);
 
-        if ($decision->required) {
-            $path = $this->render($file, $audience, ImageRendition::Preview);
+            if ($decision->required) {
+                $path = $this->render($file, $audience, ImageRendition::Preview);
 
-            abort_if($path === null, 404);
+                abort_if($path === null, 404);
 
-            return $this->serve($file, $path);
+                return $this->serve($file, $path);
+            }
         }
 
-        if ($file->disk !== 'files') {
-            $url = Storage::disk($file->disk)->temporaryUrl(
-                $file->path,
-                now()->addHour(),
-                ['ResponseContentDisposition' => ContentDisposition::inline($file->original_name)],
-            );
+        return $this->inline->make($file);
+    }
 
-            return redirect()->away($url);
+    /**
+     * One log row per viewer per file per five minutes.
+     *
+     * Watching a video is a single deliberate act that the browser turns
+     * into dozens of Range requests against this route, and each one
+     * arrives here indistinguishable from someone clicking preview again.
+     * Cache::add is the whole mechanism: it writes only if the key is
+     * absent, so the first request through the window logs and the rest
+     * are silent, without a read-then-write race between two of them.
+     *
+     * Keyed by viewer, so one client's playback never suppresses another
+     * person's preview of the same file. Anonymous viewers do not reach
+     * this route at all — see PublicGroupsController::preview.
+     */
+    private function logPreview(File $file, Request $request): void
+    {
+        $key = 'file-preview-logged:'.$file->id.':'.($request->user()->id ?? 'guest');
+
+        if (Cache::add($key, true, now()->addMinutes(5))) {
+            $this->activity->log(Action::FilePreviewed, subject: $file);
         }
-
-        return response('', 200, [
-            'X-Accel-Redirect' => '/protected-files/'.$file->path,
-            'Content-Type' => $file->mime_type,
-            'Content-Disposition' => ContentDisposition::inline($file->original_name),
-            'Content-Length' => (string) $file->size,
-        ]);
     }
 
     /**

--- a/app/Modules/Files/Http/Controllers/MyFilesController.php
+++ b/app/Modules/Files/Http/Controllers/MyFilesController.php
@@ -260,6 +260,13 @@ class MyFilesController extends Controller
             'can_upload' => $client->can('upload'),
             'can_upload_here' => Folder::uploadableBy($client, $current),
             'can_create_folders' => $client->can('create_own_folders'),
+            // Whether a row is clickable to look at rather than only to
+            // take. Per page rather than per file: the mime type decides
+            // which files can be previewed and every theme already knows
+            // how to read one, so all this has to carry is whether the
+            // installation offers it here at all. See
+            // FileThumbnailController::preview, which re-checks it.
+            'preview_enabled' => $this->settings->get(Setting::ClientsCanPreviewFiles),
         ]);
     }
 

--- a/app/Modules/Files/Preview/PreviewKind.php
+++ b/app/Modules/Files/Preview/PreviewKind.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Files\Preview;
+
+use App\Modules\Files\Thumbnails\ThumbnailGenerator;
+
+/**
+ * What kind of inline view, if any, a stored file gets — the single
+ * answer to "may these bytes be served inline, and what element renders
+ * them?", shared by FileThumbnailController::preview (signed in) and
+ * PublicGroupsController::preview (anonymous).
+ *
+ * SECURITY: this is an allowlist, and it is the boundary. Preview serves
+ * a file's own bytes inline, from this app's origin, labelled with the
+ * mime type stored on the row — so anything a browser executes script
+ * from would be same-origin script execution with the viewer's session.
+ * Never add text/html, image/svg+xml, or any other document type, and
+ * never derive this list from Setting::AllowedUploadExtensions: that
+ * setting matches on the *extension* while mime_type is sniffed from the
+ * *bytes* (ChunkedUploadsController::complete), so a .txt holding HTML is
+ * stored as text/html and would arrive here looking allowed.
+ *
+ * Deliberately narrower than "files a browser might cope with": every
+ * type below is one every current browser decodes natively. Formats like
+ * video/quicktime, video/x-msvideo and video/x-matroska are left out
+ * because an embedded player for them shows a black rectangle. They
+ * upload and download exactly as before — only the inline view is
+ * withheld.
+ *
+ * Distinct from ThumbnailGenerator::SUPPORTED_MIME_TYPES, which answers a
+ * narrower question: which types this app can *decode and re-encode*
+ * itself, and therefore has renditions, a cache and a watermark hook for.
+ * Image delegates to it rather than restating it, so the two cannot drift.
+ */
+enum PreviewKind: string
+{
+    /** Rendered with <img>; the only kind with thumbnails and renditions. */
+    case Image = 'image';
+
+    /** Rendered with <video controls>. */
+    case Video = 'video';
+
+    /** Rendered with <audio controls>. */
+    case Audio = 'audio';
+
+    /** Rendered in a sandboxed <iframe>, by the browser's own viewer. */
+    case Pdf = 'pdf';
+
+    /** @var list<string> */
+    private const VIDEO_MIME_TYPES = [
+        'video/mp4',
+        'video/webm',
+        'video/ogg',
+    ];
+
+    /**
+     * More spellings than there are formats: the mime type is whatever
+     * finfo made of the bytes, and it is not consistent across systems —
+     * a .wav is audio/x-wav on one box and audio/vnd.wave on another, and
+     * an .m4a can come back as audio/mp4 or audio/x-m4a.
+     *
+     * @var list<string>
+     */
+    private const AUDIO_MIME_TYPES = [
+        'audio/mpeg',
+        'audio/wav',
+        'audio/x-wav',
+        'audio/vnd.wave',
+        'audio/ogg',
+        'audio/webm',
+        'audio/mp4',
+        'audio/x-m4a',
+        'audio/aac',
+        'audio/flac',
+        'audio/x-flac',
+    ];
+
+    public static function forMime(string $mimeType): ?self
+    {
+        if (ThumbnailGenerator::supports($mimeType)) {
+            return self::Image;
+        }
+
+        if (in_array($mimeType, self::VIDEO_MIME_TYPES, true)) {
+            return self::Video;
+        }
+
+        if (in_array($mimeType, self::AUDIO_MIME_TYPES, true)) {
+            return self::Audio;
+        }
+
+        if ($mimeType === 'application/pdf') {
+            return self::Pdf;
+        }
+
+        return null;
+    }
+
+    public static function supports(string $mimeType): bool
+    {
+        return self::forMime($mimeType) !== null;
+    }
+}

--- a/app/Modules/Groups/Http/Controllers/PublicGroupsController.php
+++ b/app/Modules/Groups/Http/Controllers/PublicGroupsController.php
@@ -9,9 +9,11 @@ use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLogger;
 use App\Modules\Comments\CommentingRules;
 use App\Modules\Files\Access\DownloadAllowance;
+use App\Modules\Files\Delivery\InlineFileResponse;
 use App\Modules\Files\Models\Category;
 use App\Modules\Files\Models\File;
 use App\Modules\Files\Models\Folder;
+use App\Modules\Files\Preview\PreviewKind;
 use App\Modules\Files\Thumbnails\ImageAudience;
 use App\Modules\Files\Thumbnails\ImageRendition;
 use App\Modules\Files\Thumbnails\ThumbnailGenerator;
@@ -79,6 +81,7 @@ class PublicGroupsController extends Controller
         private readonly PublicThemeRegistry $themes,
         private readonly CapabilityRegistry $capabilities,
         private readonly CommentingRules $commenting,
+        private readonly InlineFileResponse $inline,
     ) {}
 
     public function index(Request $request, string $publicSlug): InertiaResponse|RedirectResponse
@@ -208,6 +211,13 @@ class PublicGroupsController extends Controller
             'thumbnail_url' => ThumbnailGenerator::supports($file->mime_type)
                 ? route('public.thumbnail', [$publicSlug, $file->slug])
                 : null,
+            // Null whenever preview is unavailable, for any of the three
+            // reasons — switched off, wrong type, or the download limit
+            // spent — so a theme has one thing to check and the setting
+            // itself never ships to a visitor's browser. preview() below
+            // re-checks all three: this decides what to offer, not what
+            // is allowed.
+            'preview_url' => $this->previewUrlFor($file, $publicSlug),
             'download_url' => route('public.download', [$publicSlug, $file->slug]),
             // Same decided shape the listings send, so a theme's single
             // file page disables its button for the same reason a row
@@ -249,6 +259,58 @@ class PublicGroupsController extends Controller
             'Content-Type' => $file->mime_type,
             'Content-Disposition' => ContentDisposition::inline($file->original_name),
         ]);
+    }
+
+    /**
+     * The anonymous twin of FileThumbnailController::preview: a public
+     * file shown rather than handed over.
+     *
+     * Nothing is rendered or cached here — an anonymous viewer only ever
+     * previews the stored bytes. The watermark hook that decorates a
+     * client's image preview has no equivalent on this route, for the
+     * same reason thumbnail() hardcodes ImageAudience::External: there is
+     * no viewer to tell apart.
+     */
+    public function preview(string $publicSlug, File $file): Response|RedirectResponse
+    {
+        $this->guardSlug($publicSlug);
+
+        abort_unless($file->isEffectivelyPublic() && ! $file->isExpired(), 404);
+        abort_unless($this->settings->get(Setting::PublicListingPreviewEnabled) === true, 404);
+        abort_if(PreviewKind::forMime($file->mime_type) === null, 404);
+
+        // 403 rather than 404 for the same reason download() does it, and
+        // it is the same allowance being read: preview serves the whole
+        // file, so a spent cap has to close this door too or it closes
+        // nothing.
+        abort_unless($this->allowance->allows($file, null), 403);
+
+        $this->activity->log(Action::PublicFilePreviewed, subject: $file);
+
+        return $this->inline->make($file);
+    }
+
+    /**
+     * What showFile() offers, which is not the same question as what
+     * preview() permits — this one also declines to advertise a preview
+     * whose download limit is already spent, so a visitor is not given a
+     * button that can only answer 403.
+     */
+    private function previewUrlFor(File $file, string $publicSlug): ?string
+    {
+        if ($this->settings->get(Setting::PublicListingPreviewEnabled) !== true) {
+            return null;
+        }
+
+        if (PreviewKind::forMime($file->mime_type) === null) {
+            return null;
+        }
+
+        if (! $this->allowance->allows($file, null)) {
+            return null;
+        }
+
+        return route('public.preview', [$publicSlug, $file->slug]);
     }
 
     public function download(string $publicSlug, File $file): Response

--- a/app/Modules/Platform/Http/Controllers/PublicListingSettingsController.php
+++ b/app/Modules/Platform/Http/Controllers/PublicListingSettingsController.php
@@ -34,6 +34,7 @@ class PublicListingSettingsController extends Controller
         return Inertia::render('system/settings/public-listing', [
             'public_listing_enabled' => $this->settings->get(Setting::PublicListingEnabled),
             'public_listing_slug' => $this->settings->get(Setting::PublicListingSlug),
+            'public_listing_preview_enabled' => $this->settings->get(Setting::PublicListingPreviewEnabled),
         ]);
     }
 
@@ -42,10 +43,12 @@ class PublicListingSettingsController extends Controller
         $validated = $request->validate([
             'public_listing_enabled' => ['required', 'boolean'],
             'public_listing_slug' => ['required', 'string', 'max:255', 'regex:/^[a-z0-9]+(-[a-z0-9]+)*$/'],
+            'public_listing_preview_enabled' => ['required', 'boolean'],
         ]);
 
         $this->settings->set(Setting::PublicListingEnabled, $validated['public_listing_enabled']);
         $this->settings->set(Setting::PublicListingSlug, $validated['public_listing_slug']);
+        $this->settings->set(Setting::PublicListingPreviewEnabled, $validated['public_listing_preview_enabled']);
 
         $this->activity->log(Action::SettingsUpdated, context: ['section' => 'public_listing']);
 

--- a/app/Modules/Platform/Settings/Setting.php
+++ b/app/Modules/Platform/Settings/Setting.php
@@ -30,6 +30,14 @@ enum Setting: string
     // Days a denied membership request blocks re-requesting (0 = none).
     case ClientsMembershipDenyCooldownDays = 'clients_membership_deny_cooldown_days';
 
+    // Whether the client portal offers inline preview at all — the whole
+    // affordance, images included, not just the media types. Staff are
+    // never gated by it: it exists so an installation can decide that a
+    // client either downloads a file or does not get it, without taking
+    // the tool away from the people who administer the library. See
+    // PreviewKind and FileThumbnailController::preview.
+    case ClientsCanPreviewFiles = 'clients_can_preview_files';
+
     // Maximum upload size in MB (0 = unlimited).
     case MaxFileSizeMb = 'max_file_size_mb';
 
@@ -168,6 +176,12 @@ enum Setting: string
     // v1 parity: the public_listing_* feature, rescoped to v2's
     // group/file public flags instead of tokens. See PublicGroupsController.
     case PublicListingEnabled = 'public_listing_enabled';
+
+    // The same switch as ClientsCanPreviewFiles, for the anonymous side:
+    // whether a public file page offers to show the file as well as hand
+    // it over. v1 parity: public_listing_enable_preview. See
+    // PublicGroupsController::preview.
+    case PublicListingPreviewEnabled = 'public_listing_preview_enabled';
 
     // The configurable base URL segment for the public listing (e.g.
     // "public" -> /public, /public/{group-slug}). Consumed by
@@ -343,6 +357,8 @@ enum Setting: string
             self::EmailNotificationsEnabled,
             self::DiscourageSearchIndexing,
             self::PublicListingEnabled,
+            self::ClientsCanPreviewFiles,
+            self::PublicListingPreviewEnabled,
             self::CheckForUpdates,
             self::ExpiredFilesAutoDeleteEnabled,
             self::PublicCommentsEnabled,
@@ -410,6 +426,11 @@ enum Setting: string
 
             self::CheckForUpdates,
             self::CommentsGuestModeration,
+            // On, so that an installation updating into these switches
+            // keeps the preview it already had rather than losing it to a
+            // setting nobody has seen yet.
+            self::ClientsCanPreviewFiles,
+            self::PublicListingPreviewEnabled,
             // On by default, but only ever consulted once a provider is
             // configured — so a fresh install is not protecting forms it
             // has no keys for.

--- a/resources/js/components/file-preview-dialog.tsx
+++ b/resources/js/components/file-preview-dialog.tsx
@@ -3,14 +3,108 @@ import { useState } from 'react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { useTranslation } from '@/hooks/use-translation';
 import { cn } from '@/lib/utils';
+import { previewKind, type PreviewKind } from '@/lib/previews';
 
+/** Wide enough to read detail in; audio has nothing to look at. */
+export function previewDialogWidth(kind: PreviewKind): string {
+    return kind === 'audio' ? 'max-w-lg' : 'max-w-4xl';
+}
+
+/**
+ * What a preview actually shows, in whichever element the file's type
+ * calls for — shared by both ways of opening one (clicking the thumbnail,
+ * via FilePreviewDialog; or the explicit Preview action, via
+ * PreviewAction), so the players themselves exist once.
+ *
+ * Rendered only while the dialog is open, so closing it stops playback and
+ * drops the connection rather than leaving a video buffering behind a
+ * hidden panel. Callers enforce that by mounting this conditionally.
+ */
+export function FilePreviewBody({ previewUrl, mimeType, fileName }: { previewUrl: string; mimeType: string; fileName: string }) {
+    const { t } = useTranslation();
+    const kind = previewKind(mimeType);
+
+    if (kind === 'image') {
+        return <img src={previewUrl} alt={fileName} className="max-h-[80vh] w-full rounded object-contain" />;
+    }
+
+    if (kind === 'video') {
+        return (
+            // preload="metadata" so opening the dialog costs a few
+            // kilobytes and a duration, not the file — the rest arrives in
+            // ranges once someone presses play.
+            <video src={previewUrl} controls preload="metadata" className="max-h-[80vh] w-full rounded bg-black">
+                {t('Your browser cannot play this file. Download it to view it.')}
+            </video>
+        );
+    }
+
+    if (kind === 'audio') {
+        return (
+            <audio src={previewUrl} controls preload="metadata" className="w-full">
+                {t('Your browser cannot play this file. Download it to view it.')}
+            </audio>
+        );
+    }
+
+    if (kind === 'pdf') {
+        return (
+            // No `sandbox` attribute, and that is deliberate: Chrome
+            // refuses to run its PDF viewer in a sandboxed frame at all
+            // (ERR_BLOCKED_BY_CLIENT, with or without allow-same-origin),
+            // so adding one does not harden this — it removes the feature.
+            // Nor would it add anything if it worked: /protected-files/
+            // already answers with `Content-Security-Policy: sandbox;
+            // default-src 'none'`, which measurably does put a <video>
+            // frame in an opaque origin — and which Chrome exempts its PDF
+            // viewer from either way.
+            //
+            // What actually holds here is PreviewKind: only
+            // `application/pdf` reaches this element, never text/html or
+            // image/svg+xml, which are the types that would really execute
+            // script against this origin. A PDF's own JavaScript runs
+            // inside the browser's PDF sandbox, with no DOM and no cookies
+            // — the same footing every site that displays a PDF stands on.
+            <iframe src={previewUrl} title={t('Preview of :name', { name: fileName })} className="h-[80vh] w-full rounded border" />
+        );
+    }
+
+    return null;
+}
+
+/**
+ * A thumbnail (or a row's icon) turned into a click target that opens the
+ * file for a look.
+ *
+ * This is the *implicit* way in — the picture you can obviously click.
+ * The explicit one is <PreviewAction>, the labelled button or eye icon
+ * that sits with a row's other actions; a surface generally offers both,
+ * because a photograph invites a click and a PDF icon does not.
+ *
+ * Takes a URL rather than an id because the same dialog serves three
+ * surfaces that address a file differently: staff and the client portal
+ * build route('files.preview', id), while a public page is handed a
+ * server-decided URL. Null means this viewer is not offered a preview at
+ * all — the setting is off, or the server declined to advertise one — and
+ * is treated exactly like an unpreviewable type.
+ *
+ * `children` is whatever the calling surface already draws — a thumbnail
+ * for an image, that theme's own icon for anything else — so a theme keeps
+ * its own look and only gains a click target. A type with no inline view
+ * renders `children` untouched and adds nothing, so a caller whose
+ * fallback looks the same either way can wrap unconditionally; one whose
+ * fallback needs different markup (a grid tile that has to keep its own
+ * box) branches on isPreviewable() itself.
+ */
 export function FilePreviewDialog({
-    fileId,
+    previewUrl,
+    mimeType,
     fileName,
     className,
     children,
 }: {
-    fileId: number;
+    previewUrl: string | null;
+    mimeType: string;
     fileName: string;
     className?: string;
     children: React.ReactNode;
@@ -18,19 +112,33 @@ export function FilePreviewDialog({
     const { t } = useTranslation();
     const [open, setOpen] = useState(false);
 
+    const kind = previewKind(mimeType);
+
+    if (previewUrl === null || kind === null) {
+        return <>{children}</>;
+    }
+
     return (
         <>
             <button
                 type="button"
                 onClick={() => setOpen(true)}
-                className={cn('block appearance-none border-0 bg-transparent p-0 text-left', className)}
+                // Named for a screen reader, because what it wraps is a
+                // decorative thumbnail (alt="") or a bare icon — without
+                // this it announces as an unlabelled button.
+                aria-label={t('Preview :name', { name: fileName })}
+                title={t('Preview :name', { name: fileName })}
+                className={cn(
+                    'block cursor-pointer appearance-none border-0 bg-transparent p-0 text-left transition-opacity hover:opacity-80',
+                    className,
+                )}
             >
                 {children}
             </button>
             <Dialog open={open} onOpenChange={setOpen}>
-                <DialogContent className="max-w-3xl">
+                <DialogContent className={previewDialogWidth(kind)}>
                     <DialogTitle className="sr-only">{t('Preview of :name', { name: fileName })}</DialogTitle>
-                    {open && <img src={route('files.preview', fileId)} alt={fileName} className="max-h-[80vh] w-full rounded object-contain" />}
+                    {open && <FilePreviewBody previewUrl={previewUrl} mimeType={mimeType} fileName={fileName} />}
                 </DialogContent>
             </Dialog>
         </>

--- a/resources/js/components/preview-action.tsx
+++ b/resources/js/components/preview-action.tsx
@@ -1,0 +1,75 @@
+import { Eye } from 'lucide-react';
+import { useState } from 'react';
+
+import { FilePreviewBody, previewDialogWidth } from '@/components/file-preview-dialog';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { useTranslation } from '@/hooks/use-translation';
+import { previewKind } from '@/lib/previews';
+
+/**
+ * The explicit way to open a file for a look, sitting with a row's other
+ * actions — the twin of <DownloadAction>, and shaped like it on purpose:
+ * a theme renders it, never the rule behind it.
+ *
+ * <FilePreviewDialog> already makes a thumbnail clickable, and that stays
+ * the nicest way in for a photograph. It is not enough on its own: a PDF
+ * or an audio file has no thumbnail, only a generic icon, and nothing
+ * about a generic icon says "click me". This is what makes the affordance
+ * findable rather than discoverable by accident.
+ *
+ * Two shapes, because the surfaces genuinely differ. A roomy list row has
+ * space for a labelled button beside Download and reads better for it; a
+ * dense table row or a grid card's footer does not, and gets the eye icon
+ * instead. That is the one place a theme decides anything here — pass
+ * `iconOnly`.
+ *
+ * Renders nothing when there is no preview to offer (`previewUrl` null,
+ * or a type no browser plays), so a caller never needs its own guard.
+ */
+export function PreviewAction({
+    previewUrl,
+    mimeType,
+    fileName,
+    variant = 'outline',
+    size = 'sm',
+    iconOnly = false,
+    className,
+    iconClassName = 'size-4',
+}: {
+    previewUrl: string | null;
+    mimeType: string;
+    fileName: string;
+    variant?: 'outline' | 'ghost' | 'default' | 'secondary';
+    size?: 'sm' | 'lg' | 'default' | 'icon';
+    /** Render the label for screen readers only, for dense rows and cards. */
+    iconOnly?: boolean;
+    className?: string;
+    iconClassName?: string;
+}) {
+    const { t } = useTranslation();
+    const [open, setOpen] = useState(false);
+
+    const kind = previewKind(mimeType);
+
+    if (previewUrl === null || kind === null) {
+        return null;
+    }
+
+    const label = t('Preview');
+
+    return (
+        <>
+            <Button variant={variant} size={size} className={className} onClick={() => setOpen(true)} title={label}>
+                <Eye className={iconClassName} />
+                {iconOnly ? <span className="sr-only">{label}</span> : label}
+            </Button>
+            <Dialog open={open} onOpenChange={setOpen}>
+                <DialogContent className={previewDialogWidth(kind)}>
+                    <DialogTitle className="sr-only">{t('Preview of :name', { name: fileName })}</DialogTitle>
+                    {open && <FilePreviewBody previewUrl={previewUrl} mimeType={mimeType} fileName={fileName} />}
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}

--- a/resources/js/lib/previews.ts
+++ b/resources/js/lib/previews.ts
@@ -1,0 +1,52 @@
+// Mirrors App\Modules\Files\Preview\PreviewKind on the backend — which
+// element, if any, shows this file inline. Read that enum's docblock
+// before adding a type: this is a security allowlist on the server, and
+// widening it here only produces a player pointed at a URL that 404s.
+//
+// Distinct from isThumbnailable() in ./thumbnails, which answers the
+// narrower question of whether there is a thumbnail image to put in a
+// listing row. Every thumbnailable file is previewable; a PDF is
+// previewable with no thumbnail to click.
+export type PreviewKind = 'image' | 'video' | 'audio' | 'pdf';
+
+const VIDEO_MIME_TYPES = ['video/mp4', 'video/webm', 'video/ogg'];
+
+const AUDIO_MIME_TYPES = [
+    'audio/mpeg',
+    'audio/wav',
+    'audio/x-wav',
+    'audio/vnd.wave',
+    'audio/ogg',
+    'audio/webm',
+    'audio/mp4',
+    'audio/x-m4a',
+    'audio/aac',
+    'audio/flac',
+    'audio/x-flac',
+];
+
+const IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+
+export function previewKind(mimeType: string): PreviewKind | null {
+    if (IMAGE_MIME_TYPES.includes(mimeType)) {
+        return 'image';
+    }
+
+    if (VIDEO_MIME_TYPES.includes(mimeType)) {
+        return 'video';
+    }
+
+    if (AUDIO_MIME_TYPES.includes(mimeType)) {
+        return 'audio';
+    }
+
+    if (mimeType === 'application/pdf') {
+        return 'pdf';
+    }
+
+    return null;
+}
+
+export function isPreviewable(mimeType: string): boolean {
+    return previewKind(mimeType) !== null;
+}

--- a/resources/js/pages/files/edit.tsx
+++ b/resources/js/pages/files/edit.tsx
@@ -1,6 +1,6 @@
 import { type BreadcrumbItem } from '@/types';
 import { Head, router, useForm, usePage } from '@inertiajs/react';
-import { Check, Copy, Download, Loader2, X } from 'lucide-react';
+import { Check, Copy, Download, File as FileIcon, Loader2, X } from 'lucide-react';
 import { FormEventHandler, useEffect, useState } from 'react';
 
 import { CommentThread } from '@/components/comments/comment-thread';
@@ -25,6 +25,7 @@ import AppLayout from '@/layouts/app-layout';
 import { activityActorLabel } from '@/lib/activity-actor';
 import { categoryColor } from '@/lib/category-colors';
 import { formatBytes } from '@/lib/format-bytes';
+import { isPreviewable } from '@/lib/previews';
 import { isThumbnailable } from '@/lib/thumbnails';
 import { slugify } from '@/lib/utils';
 
@@ -277,9 +278,20 @@ export default function FilesEdit({
             <div className="px-4 py-6">
                 <div className="flex items-start justify-between">
                     <div className="flex items-start gap-4">
-                        {isThumbnailable(file.mime_type) && (
-                            <FilePreviewDialog fileId={file.id} fileName={file.original_name} className="shrink-0">
-                                <img src={route('files.thumbnail', file.id)} alt="" className="size-16 rounded border object-cover" />
+                        {isPreviewable(file.mime_type) && (
+                            <FilePreviewDialog
+                                previewUrl={route('files.preview', file.id)}
+                                mimeType={file.mime_type}
+                                fileName={file.original_name}
+                                className="shrink-0"
+                            >
+                                {isThumbnailable(file.mime_type) ? (
+                                    <img src={route('files.thumbnail', file.id)} alt="" className="size-16 rounded border object-cover" />
+                                ) : (
+                                    <span className="bg-muted flex size-16 items-center justify-center rounded border">
+                                        <FileIcon className="text-muted-foreground size-8" strokeWidth={1.25} />
+                                    </span>
+                                )}
                             </FilePreviewDialog>
                         )}
                         <Heading

--- a/resources/js/pages/files/index.tsx
+++ b/resources/js/pages/files/index.tsx
@@ -12,6 +12,7 @@ import { ConfirmDialog } from '@/components/confirm-dialog';
 import { DetailsPanel, DetailsTarget } from '@/components/details-panel';
 import { DragChip, DragData, DropZone, useFolderDrop, useRowDrag } from '@/components/file-dnd';
 import { FilePreviewDialog } from '@/components/file-preview-dialog';
+import { PreviewAction } from '@/components/preview-action';
 import { VersionBadge, type VersionLinks } from '@/components/files/version-badge';
 import Heading from '@/components/heading';
 import { FilterField, ListToolbar } from '@/components/list-toolbar';
@@ -33,6 +34,7 @@ import { useZipDownload } from '@/hooks/use-zip-download';
 import AppLayout from '@/layouts/app-layout';
 import { categoryColor } from '@/lib/category-colors';
 import { formatBytes } from '@/lib/format-bytes';
+import { isPreviewable } from '@/lib/previews';
 import { isThumbnailable } from '@/lib/thumbnails';
 import { slugify } from '@/lib/utils';
 
@@ -689,13 +691,18 @@ function FileRow({
             </td>
             <td className="px-4 py-2.5">
                 <div className="flex items-start gap-2">
-                    {isThumbnailable(row.mime_type) ? (
-                        <FilePreviewDialog fileId={row.id} fileName={row.original_name} className="shrink-0">
+                    <FilePreviewDialog
+                        previewUrl={route('files.preview', row.id)}
+                        mimeType={row.mime_type}
+                        fileName={row.original_name}
+                        className="shrink-0"
+                    >
+                        {isThumbnailable(row.mime_type) ? (
                             <img src={route('files.thumbnail', row.id)} alt="" className="size-10 rounded border object-cover" draggable={false} />
-                        </FilePreviewDialog>
-                    ) : (
-                        <FileIcon className="text-muted-foreground mt-0.5 size-10 shrink-0" strokeWidth={1.25} />
-                    )}
+                        ) : (
+                            <FileIcon className="text-muted-foreground mt-0.5 size-10 shrink-0" strokeWidth={1.25} />
+                        )}
+                    </FilePreviewDialog>
                     <div className="min-w-0">
                         <div className="flex items-center gap-1.5">
                             <Link href={route('files.edit', row.id)} draggable={false} className="font-medium">
@@ -765,6 +772,14 @@ function FileRow({
                             </a>
                         </Button>
                     )}
+                    <PreviewAction
+                        previewUrl={route('files.preview', row.id)}
+                        mimeType={row.mime_type}
+                        fileName={row.original_name}
+                        variant="ghost"
+                        size="sm"
+                        iconOnly
+                    />
                     <DownloadAction href={route('files.download', row.id)} limit={row.download_limit} variant="ghost" size="sm" iconOnly />
                     <Button variant="outline" size="sm" asChild>
                         <Link href={route('files.edit', row.id)}>{row.can_update ? t('Edit') : t('View')}</Link>
@@ -904,14 +919,25 @@ function FileCard({
                 className="bg-background/80 absolute top-3 left-3 z-10"
             />
 
-            {isThumbnailable(row.mime_type) ? (
-                <FilePreviewDialog fileId={row.id} fileName={row.original_name} className="bg-muted block aspect-square w-full overflow-hidden">
-                    <img
-                        src={route('files.thumbnail', row.id)}
-                        alt=""
-                        draggable={false}
-                        className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
-                    />
+            {isPreviewable(row.mime_type) ? (
+                <FilePreviewDialog
+                    previewUrl={route('files.preview', row.id)}
+                    mimeType={row.mime_type}
+                    fileName={row.original_name}
+                    className="bg-muted block aspect-square w-full overflow-hidden"
+                >
+                    {isThumbnailable(row.mime_type) ? (
+                        <img
+                            src={route('files.thumbnail', row.id)}
+                            alt=""
+                            draggable={false}
+                            className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                        />
+                    ) : (
+                        <div className="flex h-full w-full items-center justify-center">
+                            <FileIcon className="text-muted-foreground size-10" strokeWidth={1.25} />
+                        </div>
+                    )}
                 </FilePreviewDialog>
             ) : (
                 <div className="bg-muted flex aspect-square items-center justify-center">
@@ -969,6 +995,14 @@ function FileCard({
                             </a>
                         </Button>
                     )}
+                    <PreviewAction
+                        previewUrl={route('files.preview', row.id)}
+                        mimeType={row.mime_type}
+                        fileName={row.original_name}
+                        variant="ghost"
+                        size="sm"
+                        iconOnly
+                    />
                     <DownloadAction href={route('files.download', row.id)} limit={row.download_limit} variant="ghost" size="sm" iconOnly />
                     {row.can_delete && (
                         <ConfirmDialog

--- a/resources/js/pages/portal/themes/compact/my-files.tsx
+++ b/resources/js/pages/portal/themes/compact/my-files.tsx
@@ -4,6 +4,7 @@ import { Archive, File as FileIcon, Folder as FolderIcon, Globe, Upload } from '
 import { CommentsShellCompact } from '@/components/comments/shells/comments-shell-compact';
 import { DownloadAction } from '@/components/download-action';
 import { FilePreviewDialog } from '@/components/file-preview-dialog';
+import { PreviewAction } from '@/components/preview-action';
 import { CategoryBadges } from '@/components/files/category-badges';
 import { VersionBadge } from '@/components/files/version-badge';
 import Heading from '@/components/heading';
@@ -46,6 +47,7 @@ export default function MyFilesCompact(props: MyFilesFolderManagementProps) {
         can_upload_here,
         can_create_folders,
         comments_enabled,
+        preview_enabled,
     } = props;
     const {
         zip,
@@ -191,17 +193,22 @@ export default function MyFilesCompact(props: MyFilesFolderManagementProps) {
                                     </td>
                                     <td className="px-2 py-1">
                                         <div className="flex items-start gap-1.5">
-                                            {isThumbnailable(file.mime_type) ? (
-                                                <FilePreviewDialog fileId={file.id} fileName={file.original_name} className="shrink-0">
+                                            <FilePreviewDialog
+                                                previewUrl={preview_enabled ? route('files.preview', file.id) : null}
+                                                mimeType={file.mime_type}
+                                                fileName={file.original_name}
+                                                className="shrink-0"
+                                            >
+                                                {isThumbnailable(file.mime_type) ? (
                                                     <img
                                                         src={route('files.thumbnail', file.id)}
                                                         alt=""
                                                         className="size-5 border border-neutral-300 object-cover dark:border-neutral-700"
                                                     />
-                                                </FilePreviewDialog>
-                                            ) : (
-                                                <FileIcon className="mt-0.5 size-3.5 shrink-0 text-neutral-400" strokeWidth={1.5} />
-                                            )}
+                                                ) : (
+                                                    <FileIcon className="mt-0.5 size-3.5 shrink-0 text-neutral-400" strokeWidth={1.5} />
+                                                )}
+                                            </FilePreviewDialog>
                                             <div className="min-w-0">
                                                 <div className="flex items-center gap-1.5">
                                                     <p className="truncate font-medium">{file.name}</p>
@@ -231,6 +238,16 @@ export default function MyFilesCompact(props: MyFilesFolderManagementProps) {
                                                     unread={file.unread_comments_count}
                                                 />
                                             )}
+                                            <PreviewAction
+                                                previewUrl={preview_enabled ? route('files.preview', file.id) : null}
+                                                mimeType={file.mime_type}
+                                                fileName={file.original_name}
+                                                variant="ghost"
+                                                size="sm"
+                                                className="size-6 p-0"
+                                                iconClassName="size-3.5"
+                                                iconOnly
+                                            />
                                             <DownloadAction
                                                 href={route('files.download', file.id)}
                                                 limit={file.download_limit}

--- a/resources/js/pages/portal/themes/default/my-files.tsx
+++ b/resources/js/pages/portal/themes/default/my-files.tsx
@@ -5,6 +5,7 @@ import { Archive, File as FileIcon, Folder as FolderIcon, Globe, Upload } from '
 import { CommentsShellDefault } from '@/components/comments/shells/comments-shell-default';
 import { DownloadAction } from '@/components/download-action';
 import { FilePreviewDialog } from '@/components/file-preview-dialog';
+import { PreviewAction } from '@/components/preview-action';
 import { CategoryBadges } from '@/components/files/category-badges';
 import { VersionBadge } from '@/components/files/version-badge';
 import Heading from '@/components/heading';
@@ -26,6 +27,7 @@ import { useTranslation } from '@/hooks/use-translation';
 import { useViewMode } from '@/hooks/use-view-mode';
 import AppLayout from '@/layouts/app-layout';
 import { formatBytes } from '@/lib/format-bytes';
+import { isPreviewable } from '@/lib/previews';
 import { isThumbnailable } from '@/lib/thumbnails';
 import { type MyFilesFolderManagementProps } from '@/types/portal';
 
@@ -42,6 +44,7 @@ export default function MyFiles(props: MyFilesFolderManagementProps) {
         can_upload_here,
         can_create_folders,
         comments_enabled,
+        preview_enabled,
     } = props;
 
     const { t } = useTranslation();
@@ -164,20 +167,31 @@ export default function MyFiles(props: MyFilesFolderManagementProps) {
                         ))}
 
                         {files.map((file) => (
-                            <div key={`file-${file.id}`} className="bg-card flex items-center justify-between gap-4 rounded-lg border px-4 py-3">
-                                <div className="flex min-w-0 items-center gap-3">
+                            <div key={`file-${file.id}`} className="bg-card flex items-center gap-4 rounded-lg border px-4 py-3">
+                                {/* flex-1, not justify-between: with three
+                                    children the middle one lands wherever
+                                    the name block happens to end, so the
+                                    comment icon sat at a different place on
+                                    every row. The name takes the slack and
+                                    the actions are one group at the end. */}
+                                <div className="flex min-w-0 flex-1 items-center gap-3">
                                     <Checkbox
                                         checked={selectedFileIds.has(file.id)}
                                         onCheckedChange={() => toggleFile(file.id)}
                                         aria-label={t('Select :name', { name: file.name })}
                                     />
-                                    {isThumbnailable(file.mime_type) ? (
-                                        <FilePreviewDialog fileId={file.id} fileName={file.original_name} className="shrink-0">
+                                    <FilePreviewDialog
+                                        previewUrl={preview_enabled ? route('files.preview', file.id) : null}
+                                        mimeType={file.mime_type}
+                                        fileName={file.original_name}
+                                        className="shrink-0"
+                                    >
+                                        {isThumbnailable(file.mime_type) ? (
                                             <img src={route('files.thumbnail', file.id)} alt="" className="size-10 rounded border object-cover" />
-                                        </FilePreviewDialog>
-                                    ) : (
-                                        <FileIcon className="text-muted-foreground size-10 shrink-0" strokeWidth={1.25} />
-                                    )}
+                                        ) : (
+                                            <FileIcon className="text-muted-foreground size-10 shrink-0" strokeWidth={1.25} />
+                                        )}
+                                    </FilePreviewDialog>
                                     <div className="min-w-0">
                                         <div className="flex items-center gap-1.5">
                                             <p className="truncate text-sm font-medium">{file.name}</p>
@@ -195,16 +209,30 @@ export default function MyFiles(props: MyFilesFolderManagementProps) {
                                         <CategoryBadges categories={file.categories} className="mt-1" />
                                     </div>
                                 </div>
-                                {comments_enabled && (
-                                    <CommentsShellDefault
-                                        fileId={file.id}
-                                        defaultOpen={deepLinkedComments === file.id}
-                                        fileName={file.name}
-                                        count={file.comments_count}
-                                        unread={file.unread_comments_count}
+                                {/* One actions group, right-aligned: icons in
+                                    fixed-width slots so they form a column
+                                    down the list, then the buttons. */}
+                                <div className="flex shrink-0 items-center gap-2">
+                                    {comments_enabled && (
+                                        <div className="flex w-10 shrink-0 justify-center">
+                                            <CommentsShellDefault
+                                                fileId={file.id}
+                                                defaultOpen={deepLinkedComments === file.id}
+                                                fileName={file.name}
+                                                count={file.comments_count}
+                                                unread={file.unread_comments_count}
+                                            />
+                                        </div>
+                                    )}
+                                    <PreviewAction
+                                        previewUrl={preview_enabled ? route('files.preview', file.id) : null}
+                                        mimeType={file.mime_type}
+                                        fileName={file.original_name}
+                                        variant="ghost"
+                                        size="sm"
                                     />
-                                )}
-                                <DownloadAction href={route('files.download', file.id)} limit={file.download_limit} variant="outline" size="sm" />
+                                    <DownloadAction href={route('files.download', file.id)} limit={file.download_limit} variant="outline" size="sm" />
+                                </div>
                             </div>
                         ))}
                     </div>
@@ -253,18 +281,33 @@ export default function MyFiles(props: MyFilesFolderManagementProps) {
                                     className="bg-background/80 absolute top-3 left-3 z-10"
                                 />
 
-                                {isThumbnailable(file.mime_type) ? (
+                                {preview_enabled && isPreviewable(file.mime_type) ? (
                                     <FilePreviewDialog
-                                        fileId={file.id}
+                                        previewUrl={route('files.preview', file.id)}
+                                        mimeType={file.mime_type}
                                         fileName={file.original_name}
                                         className="bg-muted block aspect-square w-full overflow-hidden"
                                     >
+                                        {isThumbnailable(file.mime_type) ? (
+                                            <img
+                                                src={route('files.thumbnail', file.id)}
+                                                alt=""
+                                                className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                                            />
+                                        ) : (
+                                            <div className="flex h-full w-full items-center justify-center">
+                                                <FileIcon className="text-muted-foreground size-10" strokeWidth={1.25} />
+                                            </div>
+                                        )}
+                                    </FilePreviewDialog>
+                                ) : isThumbnailable(file.mime_type) ? (
+                                    <div className="bg-muted aspect-square w-full overflow-hidden">
                                         <img
                                             src={route('files.thumbnail', file.id)}
                                             alt=""
                                             className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
                                         />
-                                    </FilePreviewDialog>
+                                    </div>
                                 ) : (
                                     <div className="bg-muted flex aspect-square items-center justify-center">
                                         <FileIcon className="text-muted-foreground size-10" strokeWidth={1.25} />
@@ -288,22 +331,32 @@ export default function MyFiles(props: MyFilesFolderManagementProps) {
                                         </p>
                                         <CategoryBadges categories={file.categories} className="mt-1" />
                                     </div>
-                                    {comments_enabled && (
-                                        <CommentsShellDefault
-                                            fileId={file.id}
-                                            defaultOpen={deepLinkedComments === file.id}
-                                            fileName={file.name}
-                                            count={file.comments_count}
-                                            unread={file.unread_comments_count}
+                                    <div className="flex shrink-0 items-center">
+                                        {comments_enabled && (
+                                            <CommentsShellDefault
+                                                fileId={file.id}
+                                                defaultOpen={deepLinkedComments === file.id}
+                                                fileName={file.name}
+                                                count={file.comments_count}
+                                                unread={file.unread_comments_count}
+                                            />
+                                        )}
+                                        <PreviewAction
+                                            previewUrl={preview_enabled ? route('files.preview', file.id) : null}
+                                            mimeType={file.mime_type}
+                                            fileName={file.original_name}
+                                            variant="ghost"
+                                            size="sm"
+                                            iconOnly
                                         />
-                                    )}
-                                    <DownloadAction
-                                        href={route('files.download', file.id)}
-                                        limit={file.download_limit}
-                                        variant="ghost"
-                                        size="sm"
-                                        iconOnly
-                                    />
+                                        <DownloadAction
+                                            href={route('files.download', file.id)}
+                                            limit={file.download_limit}
+                                            variant="ghost"
+                                            size="sm"
+                                            iconOnly
+                                        />
+                                    </div>
                                 </div>
                             </div>
                         ))}

--- a/resources/js/pages/portal/themes/drive/my-files.tsx
+++ b/resources/js/pages/portal/themes/drive/my-files.tsx
@@ -4,6 +4,7 @@ import { Archive, Folder as FolderIcon, Globe, Upload } from 'lucide-react';
 import { CommentsShellDrive } from '@/components/comments/shells/comments-shell-drive';
 import { DownloadAction } from '@/components/download-action';
 import { FilePreviewDialog } from '@/components/file-preview-dialog';
+import { PreviewAction } from '@/components/preview-action';
 import { CategoryBadges } from '@/components/files/category-badges';
 import { VersionBadge } from '@/components/files/version-badge';
 import Heading from '@/components/heading';
@@ -47,6 +48,7 @@ export default function MyFilesDrive(props: MyFilesFolderManagementProps) {
         can_upload_here,
         can_create_folders,
         comments_enabled,
+        preview_enabled,
     } = props;
     const {
         zip,
@@ -197,13 +199,18 @@ export default function MyFilesDrive(props: MyFilesFolderManagementProps) {
                                     aria-label={t('Select :name', { name: file.name })}
                                 />
                                 <div className="flex min-w-0 flex-1 items-center gap-4">
-                                    {isThumbnailable(file.mime_type) ? (
-                                        <FilePreviewDialog fileId={file.id} fileName={file.original_name} className="shrink-0">
+                                    <FilePreviewDialog
+                                        previewUrl={preview_enabled ? route('files.preview', file.id) : null}
+                                        mimeType={file.mime_type}
+                                        fileName={file.original_name}
+                                        className="shrink-0"
+                                    >
+                                        {isThumbnailable(file.mime_type) ? (
                                             <img src={route('files.thumbnail', file.id)} alt="" className="size-9 rounded object-cover" />
-                                        </FilePreviewDialog>
-                                    ) : (
-                                        <Icon className={`size-6 shrink-0 ${color}`} strokeWidth={1.5} />
-                                    )}
+                                        ) : (
+                                            <Icon className={`size-6 shrink-0 ${color}`} strokeWidth={1.5} />
+                                        )}
+                                    </FilePreviewDialog>
                                     <div className="min-w-0">
                                         <div className="flex items-center gap-1.5">
                                             <p className="truncate text-sm font-medium text-neutral-800 dark:text-neutral-200">{file.name}</p>
@@ -222,15 +229,30 @@ export default function MyFilesDrive(props: MyFilesFolderManagementProps) {
                                     </div>
                                 </div>
                                 <span className="w-20 text-right text-sm text-neutral-500">{formatBytes(file.size)}</span>
+                                {/* Fixed-width slots, so the icons form a
+                                    column down the list instead of sliding
+                                    about with each row's comment count. */}
                                 {comments_enabled && (
-                                    <CommentsShellDrive
-                                        fileId={file.id}
-                                        defaultOpen={deepLinkedComments === file.id}
-                                        fileName={file.name}
-                                        count={file.comments_count}
-                                        unread={file.unread_comments_count}
-                                    />
+                                    <div className="flex w-9 shrink-0 justify-center">
+                                        <CommentsShellDrive
+                                            fileId={file.id}
+                                            defaultOpen={deepLinkedComments === file.id}
+                                            fileName={file.name}
+                                            count={file.comments_count}
+                                            unread={file.unread_comments_count}
+                                        />
+                                    </div>
                                 )}
+                                <PreviewAction
+                                    previewUrl={preview_enabled ? route('files.preview', file.id) : null}
+                                    mimeType={file.mime_type}
+                                    fileName={file.original_name}
+                                    variant="ghost"
+                                    size="sm"
+                                    className="w-9"
+                                    iconClassName="size-4 text-blue-600"
+                                    iconOnly
+                                />
                                 <DownloadAction
                                     href={route('files.download', file.id)}
                                     limit={file.download_limit}

--- a/resources/js/pages/portal/themes/gallery/my-files.tsx
+++ b/resources/js/pages/portal/themes/gallery/my-files.tsx
@@ -4,6 +4,7 @@ import { Archive, File as FileIcon, Folder as FolderIcon, Globe, Upload } from '
 import { CommentsShellGallery } from '@/components/comments/shells/comments-shell-gallery';
 import { DownloadAction } from '@/components/download-action';
 import { FilePreviewDialog } from '@/components/file-preview-dialog';
+import { PreviewAction } from '@/components/preview-action';
 import { CategoryBadges } from '@/components/files/category-badges';
 import { VersionBadge } from '@/components/files/version-badge';
 import Heading from '@/components/heading';
@@ -22,6 +23,7 @@ import { useFormatDate } from '@/hooks/use-format-date';
 import { usePortalFiles } from '@/hooks/use-portal-files';
 import { useTranslation } from '@/hooks/use-translation';
 import { formatBytes } from '@/lib/format-bytes';
+import { isPreviewable } from '@/lib/previews';
 import { isThumbnailable } from '@/lib/thumbnails';
 import { type MyFilesFolderManagementProps } from '@/types/portal';
 
@@ -47,6 +49,7 @@ export default function MyFilesGallery(props: MyFilesFolderManagementProps) {
         can_upload_here,
         can_create_folders,
         comments_enabled,
+        preview_enabled,
     } = props;
     const {
         zip,
@@ -180,26 +183,41 @@ export default function MyFilesGallery(props: MyFilesFolderManagementProps) {
                                 badge truncates it to nothing. */}
                             <VersionBadge version={file.version} variant="gallery" className="absolute top-3 right-3 z-10" />
 
-                            {isThumbnailable(file.mime_type) ? (
+                            {preview_enabled && isPreviewable(file.mime_type) ? (
                                 <FilePreviewDialog
-                                    fileId={file.id}
+                                    previewUrl={route('files.preview', file.id)}
+                                    mimeType={file.mime_type}
                                     fileName={file.original_name}
-                                    className="bg-muted block aspect-square overflow-hidden"
+                                    className="bg-muted block aspect-square w-full overflow-hidden"
                                 >
+                                    {isThumbnailable(file.mime_type) ? (
+                                        <img
+                                            src={route('files.thumbnail', file.id)}
+                                            alt=""
+                                            className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                                        />
+                                    ) : (
+                                        <div className="flex h-full w-full items-center justify-center">
+                                            <FileIcon className="text-muted-foreground size-10" strokeWidth={1.25} />
+                                        </div>
+                                    )}
+                                </FilePreviewDialog>
+                            ) : isThumbnailable(file.mime_type) ? (
+                                <div className="bg-muted aspect-square overflow-hidden">
                                     <img
                                         src={route('files.thumbnail', file.id)}
                                         alt=""
                                         className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
                                     />
-                                </FilePreviewDialog>
+                                </div>
                             ) : (
                                 <div className="bg-muted flex aspect-square items-center justify-center">
                                     <FileIcon className="text-muted-foreground size-10" strokeWidth={1.25} />
                                 </div>
                             )}
 
-                            <div className="flex items-center justify-between gap-2 p-3">
-                                <div className="min-w-0">
+                            <div className="flex items-center gap-2 p-3">
+                                <div className="min-w-0 flex-1">
                                     <div className="flex items-center gap-1.5">
                                         <p className="truncate text-sm font-medium">{file.name}</p>
                                         {file.public && (
@@ -214,22 +232,32 @@ export default function MyFilesGallery(props: MyFilesFolderManagementProps) {
                                     </p>
                                     <CategoryBadges categories={file.categories} className="mt-1" />
                                 </div>
-                                {comments_enabled && (
-                                    <CommentsShellGallery
-                                        fileId={file.id}
-                                        defaultOpen={deepLinkedComments === file.id}
-                                        fileName={file.name}
-                                        count={file.comments_count}
-                                        unread={file.unread_comments_count}
+                                <div className="flex shrink-0 items-center">
+                                    {comments_enabled && (
+                                        <CommentsShellGallery
+                                            fileId={file.id}
+                                            defaultOpen={deepLinkedComments === file.id}
+                                            fileName={file.name}
+                                            count={file.comments_count}
+                                            unread={file.unread_comments_count}
+                                        />
+                                    )}
+                                    <PreviewAction
+                                        previewUrl={preview_enabled ? route('files.preview', file.id) : null}
+                                        mimeType={file.mime_type}
+                                        fileName={file.original_name}
+                                        variant="ghost"
+                                        size="sm"
+                                        iconOnly
                                     />
-                                )}
-                                <DownloadAction
-                                    href={route('files.download', file.id)}
-                                    limit={file.download_limit}
-                                    variant="ghost"
-                                    size="sm"
-                                    iconOnly
-                                />
+                                    <DownloadAction
+                                        href={route('files.download', file.id)}
+                                        limit={file.download_limit}
+                                        variant="ghost"
+                                        size="sm"
+                                        iconOnly
+                                    />
+                                </div>
                             </div>
                         </div>
                     ))}

--- a/resources/js/pages/public/themes/compact/file.tsx
+++ b/resources/js/pages/public/themes/compact/file.tsx
@@ -1,12 +1,15 @@
 import { Head } from '@inertiajs/react';
+import { File as FileIcon } from 'lucide-react';
 
 import { CommentsShellCompact } from '@/components/comments/shells/comments-shell-compact';
 import { DownloadAction } from '@/components/download-action';
+import { PreviewAction } from '@/components/preview-action';
 import { CategoryBadges, type CategoryTag } from '@/components/files/category-badges';
 import { type VersionLinks } from '@/components/files/version-badge';
 import { VersionNotice } from '@/components/files/version-notice';
 import PublicLayoutCompact from '@/layouts/public-layout-compact';
 import { formatBytes } from '@/lib/format-bytes';
+import { FilePreviewDialog } from '@/components/file-preview-dialog';
 import { isThumbnailable } from '@/lib/thumbnails';
 import { type DownloadLimit } from '@/types/portal';
 
@@ -22,6 +25,12 @@ interface PublicFileShowProps {
         categories: CategoryTag[];
     };
     thumbnail_url: string | null;
+    /**
+     * Null unless this visitor is actually offered a preview — the
+     * server has already weighed the setting, the file's type and its
+     * download limit, so a theme never re-derives any of them.
+     */
+    preview_url: string | null;
     download_url: string;
     download_limit: DownloadLimit;
     comments_enabled: boolean;
@@ -31,6 +40,7 @@ interface PublicFileShowProps {
 export default function PublicFileShowCompact({
     file,
     thumbnail_url,
+    preview_url,
     download_url,
     download_limit,
     comments_enabled,
@@ -42,8 +52,21 @@ export default function PublicFileShowCompact({
             <Head title={file.name} />
 
             <div className="flex items-start gap-4 rounded-md border p-4">
-                {thumbnail_url && isThumbnailable(file.mime_type) && (
-                    <img src={thumbnail_url} alt="" className="size-24 shrink-0 rounded border object-cover" />
+                {((thumbnail_url && isThumbnailable(file.mime_type)) || preview_url) && (
+                    <FilePreviewDialog
+                        previewUrl={preview_url}
+                        mimeType={file.mime_type}
+                        fileName={file.original_name}
+                        className="shrink-0"
+                    >
+                        {thumbnail_url && isThumbnailable(file.mime_type) ? (
+                            <img src={thumbnail_url} alt="" className="size-24 rounded border object-cover" />
+                        ) : (
+                            <span className="bg-muted flex size-24 items-center justify-center rounded border">
+                                <FileIcon className="text-muted-foreground size-10" strokeWidth={1.25} />
+                            </span>
+                        )}
+                    </FilePreviewDialog>
                 )}
 
                 <div className="min-w-0 flex-1 space-y-2">
@@ -53,7 +76,16 @@ export default function PublicFileShowCompact({
 
                     <VersionNotice version={file.version} className="w-full" />
 
-                    <DownloadAction href={download_url} limit={download_limit} size="sm" />
+                    <div className="flex items-center gap-2">
+                        <PreviewAction
+                            previewUrl={preview_url}
+                            mimeType={file.mime_type}
+                            fileName={file.original_name}
+                            variant="outline"
+                            size="sm"
+                        />
+                        <DownloadAction href={download_url} limit={download_limit} size="sm" />
+                    </div>
                 </div>
             </div>
 

--- a/resources/js/pages/public/themes/default/file.tsx
+++ b/resources/js/pages/public/themes/default/file.tsx
@@ -1,12 +1,15 @@
 import { Head } from '@inertiajs/react';
+import { File as FileIcon } from 'lucide-react';
 
 import { CommentsShellDefault } from '@/components/comments/shells/comments-shell-default';
 import { DownloadAction } from '@/components/download-action';
+import { PreviewAction } from '@/components/preview-action';
 import { CategoryBadges, type CategoryTag } from '@/components/files/category-badges';
 import { type VersionLinks } from '@/components/files/version-badge';
 import { VersionNotice } from '@/components/files/version-notice';
 import PublicLayout from '@/layouts/public-layout';
 import { formatBytes } from '@/lib/format-bytes';
+import { FilePreviewDialog } from '@/components/file-preview-dialog';
 import { isThumbnailable } from '@/lib/thumbnails';
 import { type DownloadLimit } from '@/types/portal';
 
@@ -22,6 +25,12 @@ interface PublicFileShowProps {
         categories: CategoryTag[];
     };
     thumbnail_url: string | null;
+    /**
+     * Null unless this visitor is actually offered a preview — the
+     * server has already weighed the setting, the file's type and its
+     * download limit, so a theme never re-derives any of them.
+     */
+    preview_url: string | null;
     download_url: string;
     download_limit: DownloadLimit;
     comments_enabled: boolean;
@@ -31,6 +40,7 @@ interface PublicFileShowProps {
 export default function PublicFileShow({
     file,
     thumbnail_url,
+    preview_url,
     download_url,
     download_limit,
     comments_enabled,
@@ -42,8 +52,16 @@ export default function PublicFileShow({
             <Head title={file.name} />
 
             <div className="flex flex-col items-center gap-6">
-                {thumbnail_url && isThumbnailable(file.mime_type) && (
-                    <img src={thumbnail_url} alt="" className="max-h-80 max-w-full rounded-lg border object-contain" />
+                {((thumbnail_url && isThumbnailable(file.mime_type)) || preview_url) && (
+                    <FilePreviewDialog previewUrl={preview_url} mimeType={file.mime_type} fileName={file.original_name}>
+                        {thumbnail_url && isThumbnailable(file.mime_type) ? (
+                            <img src={thumbnail_url} alt="" className="max-h-80 max-w-full rounded-lg border object-contain" />
+                        ) : (
+                            <span className="bg-muted flex size-32 items-center justify-center rounded-lg border">
+                                <FileIcon className="text-muted-foreground size-12" strokeWidth={1.25} />
+                            </span>
+                        )}
+                    </FilePreviewDialog>
                 )}
 
                 {file.description && <p className="text-muted-foreground text-center text-sm">{file.description}</p>}
@@ -52,7 +70,16 @@ export default function PublicFileShow({
 
                 <VersionNotice version={file.version} className="w-full" />
 
-                <DownloadAction href={download_url} limit={download_limit} size="default" />
+                <div className="flex items-center gap-2">
+                    <PreviewAction
+                        previewUrl={preview_url}
+                        mimeType={file.mime_type}
+                        fileName={file.original_name}
+                        variant="outline"
+                        size="default"
+                    />
+                    <DownloadAction href={download_url} limit={download_limit} size="default" />
+                </div>
 
                 {comments_enabled && (
                     <div className="w-full max-w-lg">

--- a/resources/js/pages/public/themes/drive/file.tsx
+++ b/resources/js/pages/public/themes/drive/file.tsx
@@ -2,12 +2,14 @@ import { Head } from '@inertiajs/react';
 
 import { CommentsShellDrive } from '@/components/comments/shells/comments-shell-drive';
 import { DownloadAction } from '@/components/download-action';
+import { PreviewAction } from '@/components/preview-action';
 import { CategoryBadges, type CategoryTag } from '@/components/files/category-badges';
 import { type VersionLinks } from '@/components/files/version-badge';
 import { VersionNotice } from '@/components/files/version-notice';
 import PublicLayoutDrive from '@/layouts/public-layout-drive';
 import { driveFileIcon } from '@/lib/drive-file-icon';
 import { formatBytes } from '@/lib/format-bytes';
+import { FilePreviewDialog } from '@/components/file-preview-dialog';
 import { isThumbnailable } from '@/lib/thumbnails';
 import { type DownloadLimit } from '@/types/portal';
 
@@ -23,6 +25,12 @@ interface PublicFileShowProps {
         categories: CategoryTag[];
     };
     thumbnail_url: string | null;
+    /**
+     * Null unless this visitor is actually offered a preview — the
+     * server has already weighed the setting, the file's type and its
+     * download limit, so a theme never re-derives any of them.
+     */
+    preview_url: string | null;
     download_url: string;
     download_limit: DownloadLimit;
     comments_enabled: boolean;
@@ -32,6 +40,7 @@ interface PublicFileShowProps {
 export default function PublicFileShowDrive({
     file,
     thumbnail_url,
+    preview_url,
     download_url,
     download_limit,
     comments_enabled,
@@ -45,11 +54,18 @@ export default function PublicFileShowDrive({
 
             <div className="mx-auto flex max-w-lg flex-col items-center gap-6">
                 <div className="flex w-full items-center justify-center overflow-hidden rounded-lg border border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900">
-                    {thumbnail_url && isThumbnailable(file.mime_type) ? (
-                        <img src={thumbnail_url} alt="" className="max-h-80 w-full object-contain" />
-                    ) : (
-                        <Icon className={`m-16 size-16 ${color}`} strokeWidth={1.5} />
-                    )}
+                    <FilePreviewDialog
+                        previewUrl={preview_url}
+                        mimeType={file.mime_type}
+                        fileName={file.original_name}
+                        className="flex w-full items-center justify-center"
+                    >
+                        {thumbnail_url && isThumbnailable(file.mime_type) ? (
+                            <img src={thumbnail_url} alt="" className="max-h-80 w-full object-contain" />
+                        ) : (
+                            <Icon className={`m-16 size-16 ${color}`} strokeWidth={1.5} />
+                        )}
+                    </FilePreviewDialog>
                 </div>
 
                 {file.description && <p className="text-center text-sm text-neutral-500">{file.description}</p>}
@@ -58,13 +74,23 @@ export default function PublicFileShowDrive({
 
                 <VersionNotice version={file.version} className="w-full" />
 
-                <DownloadAction
-                    href={download_url}
-                    limit={download_limit}
-                    className="bg-blue-600 hover:bg-blue-700"
-                    variant="default"
-                    size="default"
-                />
+                <div className="flex items-center gap-2">
+                    <PreviewAction
+                        previewUrl={preview_url}
+                        mimeType={file.mime_type}
+                        fileName={file.original_name}
+                        className="border-blue-200 text-blue-700 hover:text-blue-800 dark:border-blue-900 dark:text-blue-400"
+                        variant="outline"
+                        size="default"
+                    />
+                    <DownloadAction
+                        href={download_url}
+                        limit={download_limit}
+                        className="bg-blue-600 hover:bg-blue-700"
+                        variant="default"
+                        size="default"
+                    />
+                </div>
 
                 {comments_enabled && (
                     <div className="w-full">

--- a/resources/js/pages/public/themes/gallery/file.tsx
+++ b/resources/js/pages/public/themes/gallery/file.tsx
@@ -3,10 +3,12 @@ import { File as FileIcon } from 'lucide-react';
 
 import { CommentsShellGallery } from '@/components/comments/shells/comments-shell-gallery';
 import { DownloadAction } from '@/components/download-action';
+import { PreviewAction } from '@/components/preview-action';
 import { CategoryBadges, type CategoryTag } from '@/components/files/category-badges';
 import { type VersionLinks } from '@/components/files/version-badge';
 import { VersionNotice } from '@/components/files/version-notice';
 import { formatBytes } from '@/lib/format-bytes';
+import { FilePreviewDialog } from '@/components/file-preview-dialog';
 import { isThumbnailable } from '@/lib/thumbnails';
 import { type DownloadLimit } from '@/types/portal';
 import PublicLayoutGallery from '../../../../layouts/public-layout-gallery';
@@ -23,6 +25,12 @@ interface PublicFileShowProps {
         categories: CategoryTag[];
     };
     thumbnail_url: string | null;
+    /**
+     * Null unless this visitor is actually offered a preview — the
+     * server has already weighed the setting, the file's type and its
+     * download limit, so a theme never re-derives any of them.
+     */
+    preview_url: string | null;
     download_url: string;
     download_limit: DownloadLimit;
     comments_enabled: boolean;
@@ -32,6 +40,7 @@ interface PublicFileShowProps {
 export default function PublicFileShowGallery({
     file,
     thumbnail_url,
+    preview_url,
     download_url,
     download_limit,
     comments_enabled,
@@ -44,11 +53,18 @@ export default function PublicFileShowGallery({
 
             <div className="mx-auto flex max-w-2xl flex-col items-center gap-6">
                 <div className="bg-muted flex w-full items-center justify-center overflow-hidden rounded-xl border shadow-lg">
-                    {thumbnail_url && isThumbnailable(file.mime_type) ? (
-                        <img src={thumbnail_url} alt="" className="max-h-[32rem] w-full object-contain" />
-                    ) : (
-                        <FileIcon className="text-muted-foreground m-24 size-20" strokeWidth={1.25} />
-                    )}
+                    <FilePreviewDialog
+                        previewUrl={preview_url}
+                        mimeType={file.mime_type}
+                        fileName={file.original_name}
+                        className="flex w-full items-center justify-center"
+                    >
+                        {thumbnail_url && isThumbnailable(file.mime_type) ? (
+                            <img src={thumbnail_url} alt="" className="max-h-[32rem] w-full object-contain" />
+                        ) : (
+                            <FileIcon className="text-muted-foreground m-24 size-20" strokeWidth={1.25} />
+                        )}
+                    </FilePreviewDialog>
                 </div>
 
                 {file.description && <p className="text-muted-foreground text-center text-sm">{file.description}</p>}
@@ -57,7 +73,16 @@ export default function PublicFileShowGallery({
 
                 <VersionNotice version={file.version} className="w-full" />
 
-                <DownloadAction href={download_url} limit={download_limit} size="lg" />
+                <div className="flex items-center gap-2">
+                    <PreviewAction
+                        previewUrl={preview_url}
+                        mimeType={file.mime_type}
+                        fileName={file.original_name}
+                        variant="outline"
+                        size="lg"
+                    />
+                    <DownloadAction href={download_url} limit={download_limit} size="lg" />
+                </div>
 
                 {comments_enabled && (
                     <div className="w-full">

--- a/resources/js/pages/system/settings/clients.tsx
+++ b/resources/js/pages/system/settings/clients.tsx
@@ -19,6 +19,7 @@ interface ClientSettingsProps {
     clients_can_select_group: string;
     clients_membership_deny_cooldown_days: number;
     default_client_storage_quota_mb: number;
+    clients_can_preview_files: boolean;
     groups: { id: number; name: string }[];
 }
 
@@ -29,6 +30,7 @@ export default function ClientSettings({
     clients_can_select_group,
     clients_membership_deny_cooldown_days,
     default_client_storage_quota_mb,
+    clients_can_preview_files,
     groups,
 }: ClientSettingsProps) {
     const { t } = useTranslation();
@@ -45,6 +47,7 @@ export default function ClientSettings({
         clients_can_select_group: clients_can_select_group,
         clients_membership_deny_cooldown_days: String(clients_membership_deny_cooldown_days),
         default_client_storage_quota_mb: String(default_client_storage_quota_mb),
+        clients_can_preview_files: clients_can_preview_files,
     });
 
     const submit: FormEventHandler = (e) => {
@@ -171,6 +174,25 @@ export default function ClientSettings({
                         </p>
                         <InputError message={errors.default_client_storage_quota_mb} />
                     </div>
+
+                    <div className="flex items-start gap-2">
+                        <Checkbox
+                            id="clients_can_preview_files"
+                            checked={data.clients_can_preview_files}
+                            onCheckedChange={(checked) => setData('clients_can_preview_files', checked === true)}
+                        />
+                        <div className="grid gap-1">
+                            <Label htmlFor="clients_can_preview_files" className="font-normal">
+                                {t('Clients can preview files')}
+                            </Label>
+                            <p className="text-muted-foreground text-sm">
+                                {t(
+                                    'Lets clients open an image, video, audio file or PDF in the portal instead of only downloading it. Turn it off to make downloading the only way to see a file. Staff can always preview.',
+                                )}
+                            </p>
+                        </div>
+                    </div>
+                    <InputError message={errors.clients_can_preview_files} />
 
                     <SaveButton processing={processing} recentlySuccessful={recentlySuccessful} />
                 </form>

--- a/resources/js/pages/system/settings/public-listing.tsx
+++ b/resources/js/pages/system/settings/public-listing.tsx
@@ -16,9 +16,14 @@ import AppLayout from '@/layouts/app-layout';
 interface PublicListingSettingsProps {
     public_listing_enabled: boolean;
     public_listing_slug: string;
+    public_listing_preview_enabled: boolean;
 }
 
-export default function PublicListingSettings({ public_listing_enabled, public_listing_slug }: PublicListingSettingsProps) {
+export default function PublicListingSettings({
+    public_listing_enabled,
+    public_listing_slug,
+    public_listing_preview_enabled,
+}: PublicListingSettingsProps) {
     const { t } = useTranslation();
 
     const breadcrumbs: BreadcrumbItem[] = [
@@ -29,6 +34,7 @@ export default function PublicListingSettings({ public_listing_enabled, public_l
     const { data, setData, patch, errors, processing, recentlySuccessful } = useForm({
         public_listing_enabled: public_listing_enabled,
         public_listing_slug: public_listing_slug,
+        public_listing_preview_enabled: public_listing_preview_enabled,
     });
 
     const submit: FormEventHandler = (e) => {
@@ -115,6 +121,31 @@ export default function PublicListingSettings({ public_listing_enabled, public_l
                             )}
                         </div>
                     )}
+
+                    {/* Outside the directory switch above on purpose: a public
+                        group's page works whether or not the directory is
+                        enabled, so its preview has to be configurable
+                        independently of it. */}
+                    <div className="grid gap-2">
+                        <div className="flex items-start gap-2">
+                            <Checkbox
+                                id="public_listing_preview_enabled"
+                                checked={data.public_listing_preview_enabled}
+                                onCheckedChange={(checked) => setData('public_listing_preview_enabled', checked === true)}
+                            />
+                            <div className="grid gap-1">
+                                <Label htmlFor="public_listing_preview_enabled" className="font-normal">
+                                    {t('Let visitors preview public files')}
+                                </Label>
+                                <p className="text-muted-foreground text-sm">
+                                    {t(
+                                        'Anyone with the link can open an image, video, audio file or PDF in the browser instead of downloading it. Turn it off to make downloading the only way to see a public file.',
+                                    )}
+                                </p>
+                            </div>
+                        </div>
+                        <InputError message={errors.public_listing_preview_enabled} />
+                    </div>
 
                     <SaveButton processing={processing} recentlySuccessful={recentlySuccessful} />
                 </form>

--- a/resources/js/types/portal.ts
+++ b/resources/js/types/portal.ts
@@ -88,6 +88,15 @@ export interface MyFilesProps {
      * a conversation the settings have turned off.
      */
     comments_enabled: boolean;
+    /**
+     * Whether this install lets clients look at a file as well as take it
+     * (Setting::ClientsCanPreviewFiles). Per page, not per file: which
+     * types can be shown is decided from the row's mime type by
+     * previewKind(), so all a theme needs from the server is whether the
+     * affordance is offered here at all. With it false a row is exactly
+     * what it was before preview existed — a name and a download.
+     */
+    preview_enabled: boolean;
 }
 
 /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -358,6 +358,11 @@ Route::post('{publicSlug}/files/{file:slug}/comments', [PublicFileCommentsContro
 // on this list, which is why the number is high. It is still a hard ceiling
 // against scraping the whole listing.
 Route::get('{publicSlug}/files/{file:slug}/thumbnail', [PublicGroupsController::class, 'thumbnail'])->middleware('throttle:240,1,public-thumbnail')->name('public.thumbnail')->fallback();
+// High for the same shape of reason as thumbnails, arrived at differently:
+// one <video> playing is a long tail of Range requests against this single
+// URL, and a viewer who scrubs a recording generates them faster than a
+// download ever would. Its own bucket, like every route in this block.
+Route::get('{publicSlug}/files/{file:slug}/preview', [PublicGroupsController::class, 'preview'])->middleware('throttle:240,1,public-preview')->name('public.preview')->fallback();
 Route::get('{publicSlug}/files/{file:slug}/download', [PublicGroupsController::class, 'download'])->middleware('throttle:30,1,public-download')->name('public.download')->fallback();
 // Must be registered before the generic {groupSlug} catch-all below, or
 // "folders" would be swallowed as a group slug value first.

--- a/tests/Feature/Clients/ClientsManagementTest.php
+++ b/tests/Feature/Clients/ClientsManagementTest.php
@@ -101,6 +101,7 @@ test('staff can update client settings and they take effect', function () {
         'clients_can_select_group' => 'none',
         'clients_membership_deny_cooldown_days' => 30,
         'default_client_storage_quota_mb' => 0,
+        'clients_can_preview_files' => true,
     ])->assertRedirect()->assertSessionDoesntHaveErrors();
 
     Auth::logout();

--- a/tests/Feature/Files/FilePreviewTest.php
+++ b/tests/Feature/Files/FilePreviewTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Audit\Action;
+use App\Modules\Audit\ActivityLog;
+use App\Modules\Files\Models\File;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Preview beyond images: the types a browser plays natively, which this
+ * app never decodes and therefore never renders, caches or watermarks.
+ * The allowlist that admits them is PreviewKind, deliberately separate
+ * from the rendition allowlist asserted in FileThumbnailsTest.
+ */
+beforeEach(function () {
+    Storage::fake('files');
+    $this->admin = User::factory()->create();
+
+    // Settings survive RefreshDatabase's rollback through their cache, so
+    // a test that means "the default" has to say so rather than assume it.
+    app(Settings::class)->set(Setting::ClientsCanPreviewFiles, true);
+});
+
+function uploadMediaFile(User $as, string $name, string $mimeType): File
+{
+    test()->actingAs($as)->post('/files', [
+        'file' => UploadedFile::fake()->create($name, 16, $mimeType),
+        'name' => '',
+        'description' => '',
+    ]);
+
+    return File::query()->latest('id')->firstOrFail();
+}
+
+test('a media file is served inline, as itself, from the local disk', function (string $name, string $mimeType) {
+    $file = uploadMediaFile($this->admin, $name, $mimeType);
+
+    $this->actingAs($this->admin)->get("/files/{$file->id}/preview")
+        ->assertOk()
+        ->assertHeader('Content-Type', $mimeType)
+        ->assertHeader('Content-Disposition', 'inline; filename="'.$name.'"')
+        ->assertHeader('X-Accel-Redirect', '/protected-files/'.$file->path)
+        ->assertHeader('Content-Length', (string) $file->size);
+})->with([
+    'mp4 video' => ['clip.mp4', 'video/mp4'],
+    'webm video' => ['clip.webm', 'video/webm'],
+    'mp3 audio' => ['song.mp3', 'audio/mpeg'],
+    'wav audio' => ['song.wav', 'audio/x-wav'],
+    'flac audio' => ['song.flac', 'audio/flac'],
+    'pdf' => ['contract.pdf', 'application/pdf'],
+]);
+
+// A format the browser would only show a black rectangle for is not
+// previewable, however happily it uploads and downloads.
+test('a media container no browser decodes is not previewable', function (string $name, string $mimeType) {
+    $file = uploadMediaFile($this->admin, $name, $mimeType);
+
+    $this->actingAs($this->admin)->get("/files/{$file->id}/preview")->assertNotFound();
+})->with([
+    'quicktime' => ['clip.mov', 'video/quicktime'],
+    'avi' => ['clip.avi', 'video/x-msvideo'],
+    'matroska' => ['clip.mkv', 'video/x-matroska'],
+]);
+
+// One deliberate act, however many Range requests the browser turns it
+// into. Without the guard, watching one video buries the activity log.
+test('replaying a preview logs it once, not once per request', function () {
+    $file = uploadMediaFile($this->admin, 'clip.mp4', 'video/mp4');
+
+    foreach (range(1, 5) as $ignored) {
+        $this->actingAs($this->admin)->get("/files/{$file->id}/preview")->assertOk();
+    }
+
+    expect(ActivityLog::query()->where('action', Action::FilePreviewed)->where('subject_id', $file->id)->count())->toBe(1);
+});
+
+// Keyed by viewer, so one person's playback cannot swallow the record of
+// somebody else looking at the same file.
+test('two viewers of the same file are each logged', function () {
+    $client = User::factory()->client()->create();
+    $file = uploadMediaFile($this->admin, 'clip.mp4', 'video/mp4');
+    shareFileWith($file, $client);
+
+    $this->actingAs($this->admin)->get("/files/{$file->id}/preview")->assertOk();
+    $this->actingAs($client)->get("/files/{$file->id}/preview")->assertOk();
+
+    $actors = ActivityLog::query()->where('action', Action::FilePreviewed)->where('subject_id', $file->id)
+        ->pluck('actor_id')->sort()->values()->all();
+
+    expect($actors)->toBe(collect([$this->admin->id, $client->id])->sort()->values()->all());
+});
+
+test('with client preview switched off a client cannot preview, and staff still can', function () {
+    app(Settings::class)->set(Setting::ClientsCanPreviewFiles, false);
+
+    $client = User::factory()->client()->create();
+    $file = uploadMediaFile($this->admin, 'contract.pdf', 'application/pdf');
+    shareFileWith($file, $client);
+
+    $this->actingAs($client)->get("/files/{$file->id}/preview")->assertNotFound();
+    $this->actingAs($this->admin)->get("/files/{$file->id}/preview")->assertOk();
+});
+
+// The switch is about looking, never about having: a client who is
+// refused a preview downloads exactly as before.
+test('a client refused a preview can still download the file', function () {
+    app(Settings::class)->set(Setting::ClientsCanPreviewFiles, false);
+
+    $client = User::factory()->client()->create();
+    $file = uploadMediaFile($this->admin, 'contract.pdf', 'application/pdf');
+    shareFileWith($file, $client);
+
+    $this->actingAs($client)->get("/files/{$file->id}/download")->assertOk();
+});
+
+test('the portal tells its theme whether preview is offered', function () {
+    app(Settings::class)->set(Setting::Theme, 'default');
+    $client = User::factory()->client()->create();
+
+    $this->actingAs($client)->get('/my-files')
+        ->assertInertia(fn ($page) => $page->where('preview_enabled', true));
+
+    app(Settings::class)->set(Setting::ClientsCanPreviewFiles, false);
+
+    $this->actingAs($client)->get('/my-files')
+        ->assertInertia(fn ($page) => $page->where('preview_enabled', false));
+});

--- a/tests/Feature/Files/FileThumbnailsTest.php
+++ b/tests/Feature/Files/FileThumbnailsTest.php
@@ -70,8 +70,26 @@ test('the preview endpoint serves the original file inline and logs a preview, n
     expect($entry->actor_id)->toBe($this->admin->id);
 });
 
-test('a non-renderable file 404s when a preview is requested', function () {
+// A PDF has no thumbnail (nothing here decodes one) but does have a
+// preview, which is the whole reason the two allowlists are separate.
+test('a file with no thumbnail can still be previewed', function () {
     $file = uploadPdfFile($this->admin);
+
+    $this->actingAs($this->admin)->get("/files/{$file->id}/preview")
+        ->assertOk()
+        ->assertHeader('Content-Type', 'application/pdf')
+        ->assertHeader('X-Accel-Redirect', '/protected-files/'.$file->path);
+});
+
+test('a file of a type no browser plays 404s when a preview is requested', function () {
+    $file = File::factory()->create([
+        'uploaded_by' => $this->admin->id,
+        'name' => 'archive',
+        'original_name' => 'archive.zip',
+        'path' => '2026/08/'.Str::uuid()->toString().'.zip',
+        'mime_type' => 'application/zip',
+        'size' => 64,
+    ]);
 
     $this->actingAs($this->admin)->get("/files/{$file->id}/preview")->assertNotFound();
 });

--- a/tests/Feature/Files/ThumbnailRenderingHookTest.php
+++ b/tests/Feature/Files/ThumbnailRenderingHookTest.php
@@ -213,6 +213,29 @@ test('core asks whether a preview must be rendered, and defaults to no', functio
     expect($asked)->toBe([[ImageAudience::External, ImageRendition::Preview, false]]);
 });
 
+// The trap this closes: the watermark listener decides on audience
+// alone, so if a PDF or a video reached the resolving hook it would come
+// back "render this" — and ThumbnailGenerator has no rendition for
+// either, which would 404 every non-image preview on a watermarking
+// installation. Core never asks about a type it cannot render.
+test('core does not ask about rendering a file it could never render', function () {
+    $client = User::factory()->client()->create();
+    $file = uploadDocumentFile($this->admin);
+    shareFileWith($file, $client);
+
+    $asked = [];
+    Event::listen(ResolvingImageRendering::class, function (ResolvingImageRendering $event) use (&$asked): void {
+        $asked[] = $event->mimeType;
+        $event->required = true;
+    });
+
+    $this->actingAs($client)->get("/files/{$file->id}/preview")
+        ->assertOk()
+        ->assertHeader('X-Accel-Redirect', '/protected-files/'.$file->path);
+
+    expect($asked)->toBe([]);
+});
+
 // A preview is a rendered view of a file, not the file — so a listener
 // that intends to decorate it (the watermark) can have it rendered, and
 // what the client then sees is the decorated copy rather than the

--- a/tests/Feature/Groups/MembershipRequestsTest.php
+++ b/tests/Feature/Groups/MembershipRequestsTest.php
@@ -180,6 +180,7 @@ test('the client settings screen validates the group options', function () {
         'clients_can_select_group' => 'public',
         'clients_membership_deny_cooldown_days' => 0,
         'default_client_storage_quota_mb' => 0,
+        'clients_can_preview_files' => true,
     ])->assertSessionDoesntHaveErrors();
 
     expect(app(Settings::class)->get(Setting::ClientsAutoGroup))->toBe($group->id);

--- a/tests/Feature/Groups/PublicFilePreviewTest.php
+++ b/tests/Feature/Groups/PublicFilePreviewTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Audit\Action;
+use App\Modules\Audit\ActivityLog;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * The anonymous half of preview: a public file shown in the browser
+ * rather than only handed over. Its own switch, separate from the
+ * client-portal one, because the audiences are different — anyone with
+ * the link, versus someone with an account.
+ *
+ * Shares publicListingFile()/publicListingImageFile() with
+ * PublicGroupsTest, which is where the surrounding public-listing
+ * behaviour (slugs, expiry, the directory switch) is covered.
+ */
+beforeEach(function () {
+    Storage::fake('files');
+
+    // EnsureSetupIsComplete sends every guest to /setup until staff exist.
+    $this->staff = User::factory()->create();
+
+    app(Settings::class)->set(Setting::PublicListingEnabled, true);
+    app(Settings::class)->set(Setting::PublicListingSlug, 'public');
+    app(Settings::class)->set(Setting::Theme, 'default');
+    app(Settings::class)->set(Setting::PublicListingPreviewEnabled, true);
+});
+
+test('a visitor can preview a public file, and it is logged as a public preview', function () {
+    $file = publicListingFile();
+
+    $this->get(route('public.preview', ['public', $file->slug]))
+        ->assertOk()
+        ->assertHeader('Content-Type', 'application/pdf')
+        ->assertHeader('Content-Disposition', 'inline; filename="report.pdf"')
+        ->assertHeader('X-Accel-Redirect', '/protected-files/'.$file->path);
+
+    expect(ActivityLog::query()->where('action', Action::PublicFilePreviewed)->where('subject_id', $file->id)->exists())->toBeTrue()
+        // Previewing is not taking. The download counters must not move.
+        ->and(ActivityLog::query()->where('action', Action::PublicFileDownloaded)->where('subject_id', $file->id)->exists())->toBeFalse();
+});
+
+test('a file that is not public, or has expired, has no preview', function () {
+    $private = publicListingFile(['public' => false]);
+    $expired = publicListingFile(['expires_at' => now()->subDay()]);
+
+    $this->get(route('public.preview', ['public', $private->slug]))->assertNotFound();
+    $this->get(route('public.preview', ['public', $expired->slug]))->assertNotFound();
+});
+
+test('with visitor preview switched off the route is gone but the download is not', function () {
+    app(Settings::class)->set(Setting::PublicListingPreviewEnabled, false);
+
+    $file = publicListingFile();
+
+    $this->get(route('public.preview', ['public', $file->slug]))->assertNotFound();
+    $this->get(route('public.download', ['public', $file->slug]))->assertOk();
+});
+
+test('a type no browser renders has no public preview either', function () {
+    $file = publicListingFile(['original_name' => 'archive.zip', 'mime_type' => 'application/zip']);
+
+    $this->get(route('public.preview', ['public', $file->slug]))->assertNotFound();
+});
+
+// 403, not 404, for the same reason download() does it: the link never
+// broke, the file has simply been taken as often as it was meant to be.
+test('a spent download limit closes the preview too', function () {
+    $file = publicListingFile(['download_limit' => 1]);
+
+    $this->get(route('public.download', ['public', $file->slug]))->assertOk();
+
+    $this->get(route('public.preview', ['public', $file->slug]))->assertForbidden();
+});
+
+test('the public file page carries a preview url only when a visitor may use one', function () {
+    $file = publicListingFile();
+
+    $this->get(route('public.file', ['public', $file->slug]))->assertInertia(
+        fn ($page) => $page->component('public/themes/default/file')
+            ->where('preview_url', route('public.preview', ['public', $file->slug])),
+    );
+
+    app(Settings::class)->set(Setting::PublicListingPreviewEnabled, false);
+
+    $this->get(route('public.file', ['public', $file->slug]))
+        ->assertInertia(fn ($page) => $page->where('preview_url', null));
+});
+
+// Offering a button whose only possible answer is 403 is worse than
+// offering none, so the page stops advertising a spent file.
+test('a public file whose limit is spent stops offering a preview', function () {
+    $file = publicListingFile(['download_limit' => 1]);
+
+    $this->get(route('public.download', ['public', $file->slug]))->assertOk();
+
+    $this->get(route('public.file', ['public', $file->slug]))
+        ->assertInertia(fn ($page) => $page->where('preview_url', null));
+});

--- a/tests/Feature/Platform/SettingsTest.php
+++ b/tests/Feature/Platform/SettingsTest.php
@@ -164,6 +164,7 @@ test('staff can enable the public listing and configure its base URL segment', f
     $this->patch('/system/settings/public-listing', [
         'public_listing_enabled' => true,
         'public_listing_slug' => 'shared',
+        'public_listing_preview_enabled' => true,
     ])->assertRedirect();
 
     expect(app(Settings::class)->get(Setting::PublicListingEnabled))->toBeTrue()


### PR DESCRIPTION
v1 could preview images, video, audio and PDF in a modal. v2 previewed only images — not by decision, but because preview shipped as part of the image *thumbnail* work (1c68aa1), so "previewable" quietly became a synonym for "GD can decode it".

## The shape of the fix

Rather than widen `ThumbnailGenerator::SUPPORTED_MIME_TYPES` — it drives `pathFor()`, `extensionFor()`, `generate()` and `FileDiskCleanup`, and a video reaching `getimagesize()` is a 500 — this separates two questions that had been conflated:

- **`PreviewKind`** (new) — may these bytes be served inline, and what element renders them?
- **`ThumbnailGenerator`** (unchanged) — can this app decode the file itself? That is what renditions, the cache and the watermark hook depend on.

`PreviewKind::Image` delegates to `ThumbnailGenerator::supports()` so the two cannot drift.

## Security

The allowlist remains a boundary. `mime_type` is sniffed from the bytes, so `text/html` and `image/svg+xml` stay out, and the list is deliberately narrower than "formats a browser might cope with" — no quicktime, avi or matroska, since an embedded player for those shows a black rectangle. Those download exactly as before.

`docs/security-audit-2026-08-05.md` finding 1 recorded that adding `application/pdf` "should be a conscious decision". This is that decision, and three things were **measured**, not assumed:

- **An `<iframe sandbox>` cannot be used.** Chrome refuses to run its PDF viewer in a sandboxed frame at all (`ERR_BLOCKED_BY_CLIENT`, with or without `allow-same-origin`). The attribute removes the feature; it does not harden it.
- **nginx's `Content-Security-Policy: sandbox; default-src 'none'` does work** — a `<video>` frame from `/protected-files/` lands in an opaque origin (reading `contentWindow.location` from the parent throws `SecurityError`) — but Chrome exempts its PDF viewer from it, so it is not what protects the PDF case.
- **What does** is the allowlist plus the browser's own PDF sandbox, where PDF JavaScript has no DOM and no cookies. Rendering confirmed in both Chrome and Firefox.

## Range requests

Verified end to end: `206` with a correct `Content-Range`, a byte-perfect file reassembled from three ranges, and a real browser seeking to 10s of a 20s clip. nginx drops the upstream `Content-Length` on the X-Accel path, so there is no collision.

## Settings

Two, both defaulting **on** so no installation loses what it already has:

| Setting | Screen | Gates |
|---|---|---|
| `clients_can_preview_files` | Client settings | The client portal |
| `public_listing_preview_enabled` | Public listing settings | Anonymous visitors (v1 parity: `public_listing_enable_preview`) |

Staff are never gated. The anonymous side needed a route of its own — there was no public preview endpoint — with its own throttle bucket, since a bare `throttle:` shares one counter across that whole block.

A preview now logs at most one `FilePreviewed` per viewer per file per five minutes: a `<video>` turns one deliberate act into a long tail of Range requests, and a row each would bury the log.

## Also: a row-layout bug the tests could never catch

A portal file row was `flex justify-between` with **three** children — name, comment trigger, download — so the middle one settled wherever the name happened to end and the comment icon sat at a different x on every row. The name block now takes the slack and every action lives in one trailing group, with the comment trigger in a fixed-width slot so the icons form a column.

And because half the previewable files have no thumbnail to click — a PDF, an mp3 and an mp4 all render as a generic icon — every row gains an explicit `PreviewAction` beside `DownloadAction`, matching whatever style that theme gives its download control (labelled where Download is labelled, icon where it isn't).

## Verification

- All four checks green against a **clean tree**: pest (1744 passed), phpstan, tsc, eslint.
- Driven in a real browser across every surface: staff list + grid, all four portal themes (both render modes), all four public file pages, and both settings screens. Each preview kind confirmed to open and play — image, PDF, mp3 (15s), mp4 (20s).
