### PR TITLE
A Downloads & previews tab on the file page

### DIFF
--- a/app/Modules/Files/Http/Controllers/FileDetailsController.php
+++ b/app/Modules/Files/Http/Controllers/FileDetailsController.php
@@ -41,25 +41,37 @@ class FileDetailsController extends Controller
     private const DOWNLOADS_SUMMARY_LIMIT = 500;
 
     /**
+     * How a file leaves: three actions, because *how* it left matters —
+     * a signed-in recipient, somebody following a public link, and a
+     * visitor to a public group listing are all recorded separately.
+     *
+     * @var non-empty-list<Action>
+     */
+    private const DOWNLOAD_ACTIONS = [Action::FileDownloaded, Action::ShareLinkDownloaded, Action::PublicFileDownloaded];
+
+    /**
+     * Looking at a file without taking it. One action today; if a second
+     * way to preview is ever recorded separately, add it here and give
+     * previews an ACTION_GROUPS entry the way downloads has one.
+     *
+     * @var non-empty-list<Action>
+     */
+    private const PREVIEW_ACTIONS = [Action::FilePreviewed];
+
+    /**
      * Filters that stand for a question rather than for one logged action.
      *
-     * "Who downloaded this file?" is not one action: a signed-in recipient,
-     * somebody following a public link and a visitor to a public group
-     * listing are recorded separately, on purpose, because *how* a file
-     * left matters. But nobody reading a file's history wants to ask the
-     * question three times, so this offers it once — and only when the
-     * file's own log holds more than one of the members, since otherwise
-     * it would filter to exactly what its single member already offers.
-     *
-     * Previewing has one action today, so it needs no group; give it one
-     * here if a second way to preview a file is ever recorded separately.
+     * Nobody reading a file's history wants to ask "who downloaded this?"
+     * three times, so this offers it once — and only when the file's own
+     * log holds more than one of the members, since otherwise it would
+     * filter to exactly what its single member already offers.
      *
      * @var array<string, array{label: string, actions: non-empty-list<Action>}>
      */
     private const ACTION_GROUPS = [
         'downloads' => [
             'label' => 'All downloads',
-            'actions' => [Action::FileDownloaded, Action::ShareLinkDownloaded, Action::PublicFileDownloaded],
+            'actions' => self::DOWNLOAD_ACTIONS,
         ],
     ];
 
@@ -167,6 +179,65 @@ class FileDetailsController extends Controller
     }
 
     /**
+     * Who has actually had this file: its downloads and previews, newest
+     * first, with a count of each.
+     *
+     * A narrower question than activity() and a much more frequent one —
+     * "did they ever actually get it?" — which the full log answers only
+     * by being read past everything else that has happened to the file.
+     */
+    public function access(Request $request, File $file): JsonResponse
+    {
+        $viewer = $request->user();
+        assert($viewer !== null);
+        Gate::forUser($viewer)->authorize('view', $file);
+        abort_unless($viewer->can('view_actions_log'), 403);
+
+        $base = fn (): Builder => ActivityLog::query()
+            ->where('subject_type', $file->getMorphClass())
+            ->where('subject_id', $file->id);
+
+        $entries = $base()
+            ->whereIn('action', [...self::DOWNLOAD_ACTIONS, ...self::PREVIEW_ACTIONS])
+            ->orderByDesc('created_at')->orderByDesc('id')
+            ->limit(20)->get()
+            ->map(fn (ActivityLog $entry): array => [
+                // The sentence the presenter builds already says which of
+                // the two this was ("Downloaded the file …"), so nothing
+                // here has to label the row a second time.
+                ...$this->presenter->present($entry),
+                // Subject to the privacy setting that decides whether an
+                // address is recorded at all, so it is often null.
+                'ip_address' => $entry->ip_address,
+            ]);
+
+        return response()->json([
+            'entries' => $entries,
+            'downloads_total' => $base()->whereIn('action', self::DOWNLOAD_ACTIONS)->count(),
+            'previews_total' => $base()->whereIn('action', self::PREVIEW_ACTIONS)->count(),
+            // Built here rather than in the page: which filter value stands
+            // for "every download" is a fact about the log's vocabulary,
+            // and a group key only exists while the group does.
+            'downloads_url' => $this->historyUrl($file, 'downloads', self::DOWNLOAD_ACTIONS),
+            'previews_url' => $this->historyUrl($file, 'previews', self::PREVIEW_ACTIONS),
+        ]);
+    }
+
+    /**
+     * The file's history, pre-filtered to one question: by the group when
+     * one covers these actions, and by the action itself when the group
+     * would have a single member and therefore does not exist.
+     *
+     * @param  non-empty-list<Action>  $actions
+     */
+    private function historyUrl(File $file, string $groupKey, array $actions): string
+    {
+        $filter = isset(self::ACTION_GROUPS[$groupKey]) ? $groupKey : $actions[0]->value;
+
+        return route('files.activity.history', $file, false).'?action='.$filter;
+    }
+
+    /**
      * Full, paginated activity history for a file — the "View full
      * history" destination linked from the details panel's Activity tab,
      * which only shows the most recent 20 entries.
@@ -211,7 +282,7 @@ class FileDetailsController extends Controller
         $query = ActivityLog::query()
             ->where('subject_type', $file->getMorphClass())
             ->where('subject_id', $file->id)
-            ->whereIn('action', [Action::FileDownloaded, Action::ShareLinkDownloaded, Action::PublicFileDownloaded]);
+            ->whereIn('action', self::DOWNLOAD_ACTIONS);
 
         $total = (clone $query)->count();
 
@@ -386,7 +457,7 @@ class FileDetailsController extends Controller
                 'total' => $entries->total(),
             ],
             'filters' => $filters,
-            'action_options' => $this->actionOptions($morphClass, $subjectId),
+            'action_options' => $this->actionOptions($morphClass, $subjectId, $filters['action']),
             'subject_name' => $subjectName,
             'back_url' => $backUrl,
             'route_name' => $routeName,
@@ -405,7 +476,7 @@ class FileDetailsController extends Controller
      *
      * @return list<array{key: string, label: string, count: int}>
      */
-    private function actionOptions(string $morphClass, int $subjectId): array
+    private function actionOptions(string $morphClass, int $subjectId, ?string $active): array
     {
         /** @var array<string, int> $counts */
         $counts = ActivityLog::query()
@@ -423,8 +494,11 @@ class FileDetailsController extends Controller
             $present = array_filter($group['actions'], fn (Action $action): bool => isset($counts[$action->value]));
 
             // One member present means the group would filter to exactly
-            // what its member already offers, under a vaguer name.
-            if (count($present) < 2) {
+            // what its member already offers, under a vaguer name — unless
+            // this *is* what is currently being filtered on (the file
+            // page's "View all downloads" button links straight to it), in
+            // which case the dropdown has to be able to show its own value.
+            if (count($present) < 2 && $active !== $key) {
                 continue;
             }
 
@@ -438,14 +512,17 @@ class FileDetailsController extends Controller
         // Enum order, not count order, so the list does not rearrange
         // itself under the reader every time the file is downloaded.
         foreach (Action::cases() as $action) {
-            if (! isset($counts[$action->value])) {
+            // Same reason as the group above: a filter arrived at from a
+            // link stays visible in the dropdown even at a count of zero,
+            // rather than leaving it blank over an empty table.
+            if (! isset($counts[$action->value]) && $active !== $action->value) {
                 continue;
             }
 
             $options[] = [
                 'key' => $action->value,
                 'label' => $action->description(),
-                'count' => $counts[$action->value],
+                'count' => $counts[$action->value] ?? 0,
             ];
         }
 

--- a/resources/js/pages/files/edit.tsx
+++ b/resources/js/pages/files/edit.tsx
@@ -1,6 +1,6 @@
 import { type BreadcrumbItem } from '@/types';
 import { Head, router, useForm, usePage } from '@inertiajs/react';
-import { Check, Copy, Download, File as FileIcon, Loader2, X } from 'lucide-react';
+import { Check, Copy, Download, Eye, File as FileIcon, Loader2, X } from 'lucide-react';
 import { FormEventHandler, useEffect, useState } from 'react';
 
 import { CommentThread } from '@/components/comments/comment-thread';
@@ -49,7 +49,7 @@ interface CategoryTag {
     color: string;
 }
 
-type Tab = 'general' | 'sharing' | 'links' | 'versions' | 'comments' | 'activity';
+type Tab = 'general' | 'sharing' | 'links' | 'versions' | 'comments' | 'access' | 'activity';
 
 /** One line of this file's history, as /files/{id}/activity presents it. */
 interface ActivityEntry {
@@ -61,6 +61,21 @@ interface ActivityEntry {
     origin: string;
     template: string;
     replacements: Record<string, string>;
+}
+
+/** One download or preview of this file, as /files/{id}/access presents it. */
+interface AccessEntry extends ActivityEntry {
+    /** Null wherever the privacy settings say not to record an address. */
+    ip_address: string | null;
+}
+
+interface Access {
+    entries: AccessEntry[];
+    downloads_total: number;
+    previews_total: number;
+    /** The file's own history, pre-filtered — the server owns which filter value that is. */
+    downloads_url: string;
+    previews_url: string;
 }
 
 interface FilesEditProps {
@@ -173,6 +188,19 @@ export default function FilesEdit({
     // should not pay for the query.
     const [activity, setActivity] = useState<ActivityEntry[] | null>(null);
     const [activityTotal, setActivityTotal] = useState(0);
+
+    // "Did they ever actually get it?" — the same twenty-entry shape as
+    // the Activity tab, narrowed to the two actions that answer it.
+    const [access, setAccess] = useState<Access | null>(null);
+
+    useEffect(() => {
+        if (tab !== 'access' || access !== null || !can_view_activity) return;
+
+        fetch(route('files.access', file.id), { headers: { Accept: 'application/json' }, credentials: 'same-origin' })
+            .then((r) => r.json())
+            .then(setAccess);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [tab]);
 
     useEffect(() => {
         if (tab !== 'activity' || activity !== null || !can_view_activity) return;
@@ -330,19 +358,19 @@ export default function FilesEdit({
                 </div>
 
                 {(can_update || comments_enabled || can_view_activity) && (
-                    <nav className="mt-6 flex gap-1 border-b">
+                    <nav className="mt-6 flex gap-1 overflow-x-auto border-b">
                         {[
                             ...(can_update ? (['general', 'sharing', 'links'] as Tab[]) : []),
                             ...(can_set_version ? (['versions'] as Tab[]) : []),
                             ...(comments_enabled ? (['comments'] as Tab[]) : []),
-                            ...(can_view_activity ? (['activity'] as Tab[]) : []),
+                            ...(can_view_activity ? (['access', 'activity'] as Tab[]) : []),
                         ]
                             .filter((tabKey) => tabKey !== 'links' || can_manage_public)
                             .map((tabKey) => (
                                 <button
                                     key={tabKey}
                                     onClick={() => setTab(tabKey)}
-                                    className={`border-b-2 px-3 py-2 text-sm ${tab === tabKey ? 'border-primary text-foreground font-medium' : 'text-muted-foreground border-transparent'}`}
+                                    className={`border-b-2 px-3 py-2 text-sm whitespace-nowrap ${tab === tabKey ? 'border-primary text-foreground font-medium' : 'text-muted-foreground border-transparent'}`}
                                 >
                                     {tabKey === 'general'
                                         ? t('General')
@@ -354,14 +382,74 @@ export default function FilesEdit({
                                               ? t('Versions')
                                               : tabKey === 'comments'
                                                 ? t('Comments')
-                                                : t('Activity')}
+                                                : tabKey === 'access'
+                                                  ? t('Downloads & previews')
+                                                  : t('Activity')}
                                 </button>
                             ))}
                     </nav>
                 )}
 
                 <div className="mt-6">
-                    {tab === 'activity' ? (
+                    {tab === 'access' ? (
+                        <div className="max-w-2xl">
+                            {access === null ? (
+                                <div className="text-muted-foreground flex items-center gap-2 text-sm">
+                                    <Loader2 className="size-4 animate-spin" /> {t('Loading…')}
+                                </div>
+                            ) : access.entries.length === 0 ? (
+                                <p className="text-muted-foreground text-sm">{t('Nobody has downloaded or previewed this file yet.')}</p>
+                            ) : (
+                                <>
+                                    <p className="text-muted-foreground mb-3 text-sm">
+                                        {t('Downloads: :count', { count: access.downloads_total })}
+                                        {' · '}
+                                        {t('Previews: :count', { count: access.previews_total })}
+                                    </p>
+
+                                    <div className="divide-y rounded-md border">
+                                        {access.entries.map((entry) => (
+                                            <div key={entry.id} className="flex items-baseline justify-between gap-4 px-4 py-3 text-sm">
+                                                <p>
+                                                    <span className="font-medium">{t(activityActorLabel(entry).key)}</span>{' '}
+                                                    <span className="text-muted-foreground">{t(entry.template, entry.replacements)}</span>
+                                                </p>
+                                                <p className="text-muted-foreground shrink-0 text-right text-xs">
+                                                    {dateTime(entry.created_at)}
+                                                    {entry.ip_address !== null && <span className="block font-mono">{entry.ip_address}</span>}
+                                                </p>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </>
+                            )}
+
+                            {/* Each button is the same history page the Activity
+                                tab links to, arriving with one question already
+                                asked. Offered only where there is something to
+                                read: a filter over nothing is a dead end. */}
+                            {access !== null && (access.downloads_total > 0 || access.previews_total > 0) && (
+                                <div className="mt-4 flex flex-wrap gap-2">
+                                    {access.downloads_total > 0 && (
+                                        <Button variant="outline" size="sm" asChild>
+                                            <a href={access.downloads_url}>
+                                                <Download className="size-4" />
+                                                {t('View all downloads (:count)', { count: access.downloads_total })}
+                                            </a>
+                                        </Button>
+                                    )}
+                                    {access.previews_total > 0 && (
+                                        <Button variant="outline" size="sm" asChild>
+                                            <a href={access.previews_url}>
+                                                <Eye className="size-4" />
+                                                {t('View all previews (:count)', { count: access.previews_total })}
+                                            </a>
+                                        </Button>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    ) : tab === 'activity' ? (
                         <div className="max-w-2xl">
                             {activity === null ? (
                                 <div className="text-muted-foreground flex items-center gap-2 text-sm">

--- a/routes/web.php
+++ b/routes/web.php
@@ -125,6 +125,7 @@ Route::middleware(['auth'])->group(function () {
     Route::get('files/{file}/details', [FileDetailsController::class, 'show'])->middleware('staff')->name('files.details');
     Route::get('files/{file}/activity', [FileDetailsController::class, 'activity'])->middleware('staff')->name('files.activity');
     Route::get('files/{file}/activity/history', [FileDetailsController::class, 'activityHistory'])->middleware('staff')->name('files.activity.history');
+    Route::get('files/{file}/access', [FileDetailsController::class, 'access'])->middleware('staff')->name('files.access');
     Route::get('files/{file}/downloads', [FileDetailsController::class, 'downloads'])->middleware('staff')->name('files.downloads');
     Route::get('files/{file}/downloads/history', [FileDetailsController::class, 'downloadsHistory'])->middleware('staff')->name('files.downloads.history');
     // Must be registered before files/{file} below, or "bulk-edit" would be

--- a/tests/Feature/Files/FileActivityHistoryTest.php
+++ b/tests/Feature/Files/FileActivityHistoryTest.php
@@ -277,3 +277,106 @@ test('the file activity history filters by action, and offers only the actions t
     );
     $this->actingAs($this->admin)->get("/files/{$file->id}/activity/history?action=nonsense")->assertSessionHasErrors('action');
 });
+
+test('the access endpoint answers who downloaded and who previewed the file', function () {
+    $file = uploadImageFile($this->admin);
+    $client = User::factory()->client()->create(['name' => 'Acme Design']);
+
+    $log = function (Action $action, ?User $actor = null, ?string $ip = null) use ($file): void {
+        ActivityLog::create([
+            'action' => $action,
+            'subject_type' => $file->getMorphClass(),
+            'subject_id' => $file->id,
+            'subject_name' => $file->name,
+            'actor_id' => $actor?->id,
+            'actor_name' => $actor?->name,
+            'actor_type' => $actor === null ? null : 'client',
+            'ip_address' => $ip,
+            'created_at' => now(),
+        ]);
+    };
+
+    $log(Action::FileDownloaded, $client, '10.0.0.1');
+    $log(Action::ShareLinkDownloaded, null, '10.0.0.2');
+    $log(Action::PublicFileDownloaded);
+    $log(Action::FilePreviewed, $client);
+    // Neither a download nor a preview: this tab is not the activity log.
+    $log(Action::FileUpdated, $this->admin);
+
+    $response = $this->actingAs($this->admin)->getJson("/files/{$file->id}/access")->assertOk();
+
+    expect($response->json('downloads_total'))->toBe(3)
+        ->and($response->json('previews_total'))->toBe(1)
+        // Four rows, not five: the edit entry (and the upload) are excluded.
+        ->and($response->json('entries'))->toHaveCount(4)
+        ->and($response->json('entries.0.template'))->toBe('Previewed the file ":subject"')
+        ->and($response->json('entries.0.actor_name'))->toBe('Acme Design')
+        ->and($response->json('entries.3.ip_address'))->toBe('10.0.0.1');
+
+    // The buttons carry the filter the history page understands: a group
+    // for downloads, the action itself for previews (which have no group
+    // while only one action records them).
+    expect($response->json('downloads_url'))->toBe("/files/{$file->id}/activity/history?action=downloads")
+        ->and($response->json('previews_url'))->toBe("/files/{$file->id}/activity/history?action=file.previewed");
+
+    // Following either one lands on a history page filtered to just that.
+    $this->actingAs($this->admin)->get($response->json('downloads_url'))->assertInertia(
+        fn (AssertableInertia $page) => $page->component('activity/subject')->has('entries', 3),
+    );
+    $this->actingAs($this->admin)->get($response->json('previews_url'))->assertInertia(
+        fn (AssertableInertia $page) => $page->has('entries', 1),
+    );
+});
+
+test('the access endpoint is capped at 20 rows and honours the activity-log permission', function () {
+    $file = uploadImageFile($this->admin);
+
+    for ($i = 0; $i < 24; $i++) {
+        ActivityLog::create([
+            'action' => Action::FileDownloaded,
+            'subject_type' => $file->getMorphClass(),
+            'subject_id' => $file->id,
+            'subject_name' => $file->name,
+            'actor_id' => $this->admin->id,
+            'actor_name' => $this->admin->name,
+            'actor_type' => 'staff',
+            'created_at' => now(),
+        ]);
+    }
+
+    $response = $this->actingAs($this->admin)->getJson("/files/{$file->id}/access")->assertOk();
+    expect($response->json('entries'))->toHaveCount(20)
+        ->and($response->json('downloads_total'))->toBe(24);
+
+    $role = Role::query()->create(['name' => 'No Access Log', 'is_administrator' => false, 'is_system' => false]);
+    RolePermission::query()->insert([['role_id' => $role->id, 'permission' => 'upload']]);
+    $restricted = User::factory()->create(['role_id' => $role->id]);
+
+    $this->actingAs($restricted)->getJson("/files/{$file->id}/access")->assertForbidden();
+});
+
+test('a filter arrived at from a button stays visible in the dropdown at a count of zero', function () {
+    $file = uploadImageFile($this->admin);
+    ActivityLog::create([
+        'action' => Action::FileDownloaded,
+        'subject_type' => $file->getMorphClass(),
+        'subject_id' => $file->id,
+        'subject_name' => $file->name,
+        'actor_id' => $this->admin->id,
+        'actor_name' => $this->admin->name,
+        'actor_type' => 'staff',
+        'created_at' => now(),
+    ]);
+
+    // One download flavour, so the group would normally be left out — but
+    // the "View all downloads" button links straight to it, and a select
+    // whose value is missing from its own options renders blank.
+    $options = $this->actingAs($this->admin)->get("/files/{$file->id}/activity/history?action=downloads")
+        ->viewData('page')['props']['action_options'];
+    expect(collect($options)->firstWhere('key', 'downloads'))->not->toBeNull();
+
+    // Same for a single action the file has never seen.
+    $options = $this->actingAs($this->admin)->get("/files/{$file->id}/activity/history?action=file.previewed")
+        ->viewData('page')['props']['action_options'];
+    expect(collect($options)->firstWhere('key', 'file.previewed'))->toMatchArray(['count' => 0]);
+});


### PR DESCRIPTION
## Why

"Did the client ever actually download this?" and "has anyone even looked at it?" are the two things staff ask most often about a file — and both were answerable only by reading the whole activity log past everything else that had happened to it, or by going back to the library list to open the details panel.

## What changed

**A `Downloads & previews` tab on the file's own page**, between Comments and Activity, behind the same `view_actions_log` permission as the rest. It shows the twenty most recent times the file was taken or looked at — who did it, the sentence from the log, the timestamp, and the address where one was recorded — above a running count of each. Fetched only when the tab is opened.

**Two buttons open the file's full history already filtered**, one to every download and one to every preview, so the narrow question is one click and the whole log is one click further. Each is offered only when there is something behind it.

Which filter value stands for "every download" is decided server-side and travels with the payload (`downloads_url` / `previews_url`), because it is a fact about the log's vocabulary rather than about the page: downloads are three separate actions sharing a group, previews are one action and are filtered by name. When a second way to preview a file is ever recorded, previews get a group the same way and nothing on the page changes.

**A follow-up fix to the history page those buttons land on:** it now keeps whatever filter it was sent with visible in its dropdown even at a count of zero. Without it, a button could land somebody on an empty table above a select that had gone blank, because the action list is built from what the file's log actually contains.

New endpoint: `GET /files/{file}/access`.

## Verification

- Full suite: 1753 passed, 1 skipped. PHPStan, `tsc`, ESLint and the production build clean.
- Three new tests: the endpoint's counts and its exclusion of non-access actions, the 20-row cap and its 403 for a role without the permission, the exact pre-filtered URLs and that following each one lands on a correctly filtered history, and the zero-count dropdown case for both a group and a single action.
- Driven in a real browser over CDP: the tab renders its rows and counts, and both buttons land on the history filtered to `All downloads (2)` and `A file was previewed (2)` respectively.