### PR TITLE
Send the browser to the provider, not the XHR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ a version is cut.
 
 ### Fixed
 
+- **Connecting a provider to an account that already has one.** Signing in with Google, Microsoft or
+  a custom provider worked, but attaching one to an existing account did not: the **Connect** button
+  on Settings → Connected accounts appeared to do nothing at all. The button asks the server in the
+  background, and the server answered by redirecting to the provider — a redirect a browser will not
+  follow out of a background request to another site. The page sat there with no consent screen and
+  no error to explain it, so the only reading available was that the button was dead. The server now
+  tells the browser to go to the provider itself, and the flow starts as it should. Signing in from
+  the login page was never affected, and neither is it now.
+  ([#1676](https://github.com/projectsend/projectsend/pull/1676), found and fixed by
+  [@denkfabrik-li](https://github.com/denkfabrik-li))
+
 - **Downloads on a host where the web server is not PHP's user.** A download is not served by PHP:
   PHP checks permissions and then hands the web server the path to stream. Where the two run as
   different users — cPanel and Plesk commonly arrange it that way — the web server could not open

--- a/app/Modules/Identity/Http/Controllers/SocialLoginController.php
+++ b/app/Modules/Identity/Http/Controllers/SocialLoginController.php
@@ -15,7 +15,8 @@ use App\Modules\Identity\Social\SocialProvider;
 use App\Modules\Identity\Social\SocialSettings;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse;
+use Inertia\Inertia;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -57,13 +58,13 @@ class SocialLoginController extends Controller
     }
 
     /** Begin a sign-in. */
-    public function redirect(Request $request, string $provider): SymfonyRedirectResponse|RedirectResponse
+    public function redirect(Request $request, string $provider): Response
     {
         return $this->begin($request, $provider, 'login');
     }
 
     /** Begin connecting a provider to the signed-in account. */
-    public function connect(Request $request, string $provider): SymfonyRedirectResponse|RedirectResponse
+    public function connect(Request $request, string $provider): Response
     {
         return $this->begin($request, $provider, 'link');
     }
@@ -130,7 +131,7 @@ class SocialLoginController extends Controller
         return redirect()->intended(route('dashboard', absolute: false));
     }
 
-    private function begin(Request $request, string $provider, string $intent): SymfonyRedirectResponse|RedirectResponse
+    private function begin(Request $request, string $provider, string $intent): Response
     {
         $case = $this->provider($provider);
         $settings = SocialSettings::for($case);
@@ -142,7 +143,13 @@ class SocialLoginController extends Controller
 
         $request->session()->put([self::INTENT => $intent, self::PROVIDER => $case->value]);
 
-        return $this->gateway()->redirect($settings);
+        // Inertia::location(), not the redirect itself. Connecting starts
+        // as an Inertia XHR from the settings screen, and an XHR follows a
+        // 302 to the provider cross-origin, where CORS kills it before the
+        // person ever leaves the page. The 409 + X-Inertia-Location pair
+        // makes the client navigate top-level instead; a plain browser
+        // request — the login flow — passes through unchanged.
+        return Inertia::location($this->gateway()->redirect($settings));
     }
 
     private function completeLink(Request $request, SocialSettings $settings, SocialIdentity $identity): RedirectResponse

--- a/tests/Feature/Identity/ConnectedAccountsTest.php
+++ b/tests/Feature/Identity/ConnectedAccountsTest.php
@@ -88,6 +88,35 @@ test('reconnecting a different account at the same provider replaces the link', 
 
 /*
 |--------------------------------------------------------------------------
+| Starting the exchange
+|--------------------------------------------------------------------------
+|
+| Connecting starts as an Inertia XHR, and an XHR cannot follow a 302 to
+| the provider: the browser refuses the cross-origin hop and nobody goes
+| anywhere. Inertia's 409 + X-Inertia-Location pair is what turns the
+| same answer into a real top-level navigation.
+|
+*/
+
+test('connecting from the settings screen navigates the browser, not the XHR', function () {
+    test()->swap(SocialGateway::class, new FakeSocialGateway);
+
+    $this->actingAs($this->staff)
+        ->post(route('connected-accounts.connect', ['provider' => 'google']), [], ['X-Inertia' => 'true'])
+        ->assertStatus(409)
+        ->assertHeader('X-Inertia-Location', 'https://provider.test/authorize');
+});
+
+test('a plain request is still given the provider redirect itself', function () {
+    test()->swap(SocialGateway::class, new FakeSocialGateway);
+
+    $this->actingAs($this->staff)
+        ->post(route('connected-accounts.connect', ['provider' => 'google']))
+        ->assertRedirect('https://provider.test/authorize');
+});
+
+/*
+|--------------------------------------------------------------------------
 | Disconnecting
 |--------------------------------------------------------------------------
 */


### PR DESCRIPTION
Connecting a provider from Settings → Connected accounts never reached the provider: the button posts through Inertia's XHR, and the plain 302 to the provider's authorize URL sends that XHR into a cross-origin CORS wall — the page just sits there and the OAuth flow never starts.

`SocialLoginController::begin()` now answers with `Inertia::location()`, whose 409/`X-Inertia-Location` handshake turns the redirect into a real top-level navigation. Non-Inertia requests still get an ordinary redirect, so the login-page flow — a plain `<a href>`, never an XHR — is unaffected.

Tested: two new Pest tests in ConnectedAccountsTest cover the Inertia and non-Inertia paths; full suite green; verified in the browser that the consent screen now opens.

Changelog entry added under **Unreleased → Fixed**.
