### PR TITLE
Let a deleted account's email address come back into use

### DIFF
--- a/app/Http/Controllers/Settings/ProfileController.php
+++ b/app/Http/Controllers/Settings/ProfileController.php
@@ -8,6 +8,7 @@ use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLogger;
 use App\Modules\Clients\ClientFieldContext;
 use App\Modules\Clients\ClientPortalCustomFields;
+use App\Modules\Identity\Erasure\ErasureSchedule;
 use App\Modules\Platform\Localization\TimezoneRegistry;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
@@ -107,8 +108,7 @@ class ProfileController extends Controller
 
         // Self-deletion: soft delete now, permanent GDPR erasure after
         // the disclosed grace period (Setting::AccountErasureGraceDays).
-        $graceDays = (int) app(Settings::class)->get(Setting::AccountErasureGraceDays);
-        $user->forceFill(['erase_after' => now()->addDays($graceDays)])->save();
+        app(ErasureSchedule::class)->apply($user);
         $user->delete();
 
         app(ActivityLogger::class)->log(Action::UserDeleted, $user, context: ['name' => $user->name]);

--- a/app/Modules/Clients/Http/Controllers/Api/ClientsController.php
+++ b/app/Modules/Clients/Http/Controllers/Api/ClientsController.php
@@ -18,6 +18,8 @@ use App\Modules\Clients\Notifications\ClientAccountEditedNotification;
 use App\Modules\Clients\Notifications\ClientWelcomeNotification;
 use App\Modules\Files\DeletedAccountContent;
 use App\Modules\Identity\AccountContentDeletion;
+use App\Modules\Identity\Erasure\AvailableEmailRule;
+use App\Modules\Identity\Erasure\ErasureSchedule;
 use App\Modules\Identity\Models\Role;
 use App\Modules\Identity\Permissions\SystemRole;
 use App\Modules\Identity\TwoFactor\TwoFactorAdministration;
@@ -54,6 +56,7 @@ class ClientsController extends Controller
         private readonly ClientStorageUsage $storageUsage,
         private readonly DeletedAccountContent $accountContent,
         private readonly AccountContentDeletion $accountDeletion,
+        private readonly ErasureSchedule $erasure,
     ) {}
 
     public function index(Request $request): AnonymousResourceCollection
@@ -90,7 +93,7 @@ class ClientsController extends Controller
     {
         $validated = $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:users,email'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', new AvailableEmailRule],
             // No `confirmed`: repeating a password is a defence against a
             // human mistyping into a form, and an API caller has no second
             // field to mistype. This installation's password policy still
@@ -235,6 +238,7 @@ class ClientsController extends Controller
         $validated = $this->accountDeletion->validate($request, $client);
 
         $name = $client->name;
+        $this->erasure->apply($client);
         $client->delete();
 
         $this->activity->log(Action::UserDeleted, context: ['name' => $name]);

--- a/app/Modules/Clients/Http/Controllers/ClientsController.php
+++ b/app/Modules/Clients/Http/Controllers/ClientsController.php
@@ -16,6 +16,8 @@ use App\Modules\Clients\Notifications\ClientAccountEditedNotification;
 use App\Modules\Clients\Notifications\ClientWelcomeNotification;
 use App\Modules\Files\DeletedAccountContent;
 use App\Modules\Identity\AccountContentDeletion;
+use App\Modules\Identity\Erasure\AvailableEmailRule;
+use App\Modules\Identity\Erasure\ErasureSchedule;
 use App\Modules\Identity\Models\Role;
 use App\Modules\Identity\Permissions\SystemRole;
 use App\Modules\Identity\TwoFactor\TwoFactorAdministration;
@@ -44,6 +46,7 @@ class ClientsController extends Controller
         private readonly ClientStorageUsage $storageUsage,
         private readonly DeletedAccountContent $accountContent,
         private readonly AccountContentDeletion $accountDeletion,
+        private readonly ErasureSchedule $erasure,
     ) {}
 
     public function index(Request $request): Response
@@ -100,7 +103,7 @@ class ClientsController extends Controller
     {
         $validated = $request->validate(array_merge([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:users,email'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', new AvailableEmailRule],
             'password' => ['required', 'confirmed', Password::defaults()],
             'storage_quota_mb' => ['nullable', 'integer', 'min:0'],
         ], $this->customFieldRules()));
@@ -235,6 +238,7 @@ class ClientsController extends Controller
         $validated = $this->accountDeletion->validate($request, $client);
 
         $name = $client->name;
+        $this->erasure->apply($client);
         $client->delete();
 
         $this->activity->log(Action::UserDeleted, context: ['name' => $name]);

--- a/app/Modules/Identity/Console/CreateAdminCommand.php
+++ b/app/Modules/Identity/Console/CreateAdminCommand.php
@@ -7,6 +7,7 @@ namespace App\Modules\Identity\Console;
 use App\Models\User;
 use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLogger;
+use App\Modules\Identity\Erasure\AvailableEmailRule;
 use App\Modules\Identity\Models\Role;
 use App\Modules\Identity\Permissions\SystemRole;
 use App\Modules\Identity\UserType;
@@ -43,7 +44,7 @@ class CreateAdminCommand extends Command
             ['name' => $name, 'email' => $email, 'password' => $password],
             [
                 'name' => ['required', 'string', 'max:255'],
-                'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email'],
+                'email' => ['required', 'string', 'email', 'max:255', new AvailableEmailRule],
                 'password' => ['required', Password::defaults()],
             ],
         );

--- a/app/Modules/Identity/Console/PurgeErasuresCommand.php
+++ b/app/Modules/Identity/Console/PurgeErasuresCommand.php
@@ -12,7 +12,7 @@ class PurgeErasuresCommand extends Command
 {
     protected $signature = 'projectsend:purge-erasures';
 
-    protected $description = 'Permanently erase self-deleted accounts whose grace period has passed (runs daily)';
+    protected $description = 'Permanently erase deleted accounts whose grace period has passed (runs daily)';
 
     public function handle(AccountEraser $eraser): int
     {

--- a/app/Modules/Identity/Erasure/AvailableEmailRule.php
+++ b/app/Modules/Identity/Erasure/AvailableEmailRule.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Identity\Erasure;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+/**
+ * `unique:users,email` with an answer for the case that rule cannot
+ * explain: the address is held by a soft-deleted account.
+ *
+ * The unique index on users.email spans trashed rows on purpose — an
+ * email address is a login identity, and it must not become
+ * re-registerable while the account holding it is merely pending erasure.
+ * But the stock message ("has already been taken") then names a conflict
+ * the person at the form cannot see or clear from any screen (#1648).
+ * This rule keeps the refusal and explains it: when the address frees
+ * itself, or — for accounts deleted before erasure scheduling existed —
+ * which command frees it.
+ *
+ * Staff surfaces only. Public registration keeps the stock rule
+ * deliberately: telling an anonymous visitor "this address belongs to a
+ * deleted account" confirms the address had an account here, which is
+ * exactly the disclosure the generic message avoids.
+ */
+class AvailableEmailRule implements ValidationRule
+{
+    /**
+     * @param  Closure(string, string|null=): PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || $value === '') {
+            // required/string/email own that refusal.
+            return;
+        }
+
+        $holder = User::withTrashed()->where('email', $value)->first();
+
+        if ($holder === null) {
+            return;
+        }
+
+        if (! $holder->trashed()) {
+            // A living account: the stock unique message said all there
+            // is to say.
+            $fail('validation.unique')->translate();
+
+            return;
+        }
+
+        if ($holder->erase_after !== null) {
+            $fail(__('This email address belongs to a deleted account that is scheduled for permanent erasure. The address becomes available on :date. To free it sooner, erase the account with the projectsend:erase-account console command.', [
+                'date' => $holder->erase_after->toFormattedDateString(),
+            ]));
+
+            return;
+        }
+
+        // Deleted before erasure scheduling existed, so no purge will ever
+        // reach it — only the operator command can free the address.
+        $fail(__('This email address belongs to a deleted account that has no erasure scheduled. Run the projectsend:erase-account console command to erase it and free the address.'));
+    }
+}

--- a/app/Modules/Identity/Erasure/ErasureSchedule.php
+++ b/app/Modules/Identity/Erasure/ErasureSchedule.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modules\Identity\Erasure;
+
+use App\Models\User;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+
+/**
+ * Stamps the moment a soft-deleted account graduates to permanent
+ * erasure: now plus the installation's grace period.
+ *
+ * Every deletion path calls this right before delete(), self-service and
+ * administrative alike, so PurgeErasuresCommand eventually reaches every
+ * deleted account — and the email address its row keeps reserved under
+ * the unique index is freed. Only self-deletion did this at first, which
+ * left admin-deleted accounts trashed forever and their addresses
+ * unusable (#1648).
+ */
+class ErasureSchedule
+{
+    public function __construct(
+        private readonly Settings $settings,
+    ) {}
+
+    public function apply(User $user): void
+    {
+        $graceDays = (int) $this->settings->get(Setting::AccountErasureGraceDays);
+
+        $user->forceFill(['erase_after' => now()->addDays($graceDays)])->save();
+    }
+}

--- a/app/Modules/Identity/Http/Controllers/Api/UsersController.php
+++ b/app/Modules/Identity/Http/Controllers/Api/UsersController.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use App\Modules\Api\Support\PollingQuery;
 use App\Modules\Files\DeletedAccountContent;
 use App\Modules\Identity\AccountContentDeletion;
+use App\Modules\Identity\Erasure\AvailableEmailRule;
 use App\Modules\Identity\Http\Resources\Api\StaffUserResource;
 use App\Modules\Identity\StaffAccounts;
 use App\Modules\Identity\TwoFactor\TwoFactorAdministration;
@@ -118,7 +119,7 @@ class UsersController extends Controller
 
         $validated = $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:users,email'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', new AvailableEmailRule],
             'role_id' => ['required', 'integer', Rule::in($this->accounts->assignableRoleIds($actor))],
             // No `confirmed`: repeating a password defends against a human
             // mistyping into a form, and an API caller has no second field

--- a/app/Modules/Identity/Http/Controllers/UsersController.php
+++ b/app/Modules/Identity/Http/Controllers/UsersController.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use App\Modules\Api\Auth\ApiTokens;
 use App\Modules\Files\DeletedAccountContent;
 use App\Modules\Identity\AccountContentDeletion;
+use App\Modules\Identity\Erasure\AvailableEmailRule;
 use App\Modules\Identity\Models\Role;
 use App\Modules\Identity\StaffAccounts;
 use App\Modules\Identity\TwoFactor\TwoFactorAdministration;
@@ -112,7 +113,7 @@ class UsersController extends Controller
     {
         $validated = $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:users,email'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', new AvailableEmailRule],
             'role_id' => ['required', 'integer', Rule::in($this->accounts->assignableRoleIds($this->actor()))],
             'password' => ['required', 'confirmed', Password::defaults()],
             'assigned_clients' => ['array'],

--- a/app/Modules/Identity/StaffAccounts.php
+++ b/app/Modules/Identity/StaffAccounts.php
@@ -7,6 +7,7 @@ namespace App\Modules\Identity;
 use App\Models\User;
 use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLogger;
+use App\Modules\Identity\Erasure\ErasureSchedule;
 use App\Modules\Identity\Models\Role;
 use App\Modules\Identity\Permissions\PermissionChecker;
 use App\Modules\Identity\Permissions\SystemRole;
@@ -34,6 +35,7 @@ class StaffAccounts
     public function __construct(
         private readonly ActivityLogger $activity,
         private readonly PermissionChecker $permissions,
+        private readonly ErasureSchedule $erasure,
     ) {}
 
     /**
@@ -294,9 +296,10 @@ class StaffAccounts
     }
 
     /**
-     * Soft-delete the account and record it. Returns the name, which the
-     * caller needs afterwards for the content-reassignment step — by then
-     * the model is trashed and reading it back is needless ceremony.
+     * Soft-delete the account, schedule its permanent erasure and record
+     * it. Returns the name, which the caller needs afterwards for the
+     * content-reassignment step — by then the model is trashed and reading
+     * it back is needless ceremony.
      *
      * **This is only half of deleting somebody.** What happens to the
      * files and folders they own is the other half, and it lives in
@@ -315,6 +318,7 @@ class StaffAccounts
     {
         $name = $user->name;
 
+        $this->erasure->apply($user);
         $user->delete();
 
         $this->activity->log(Action::UserDeleted, context: ['name' => $name]);

--- a/app/Modules/Platform/Settings/Setting.php
+++ b/app/Modules/Platform/Settings/Setting.php
@@ -137,9 +137,9 @@ enum Setting: string
     case FailedJobRetentionDays = 'failed_job_retention_days';
     case NotificationRetentionDays = 'notification_retention_days';
 
-    // How many days a self-deleted account is retained (soft-deleted)
-    // before PurgeErasuresCommand permanently erases it. Consumed by
-    // ProfileController.
+    // How many days a deleted account is retained (soft-deleted) before
+    // PurgeErasuresCommand permanently erases it. Consumed by
+    // ErasureSchedule, which every deletion path calls.
     case AccountErasureGraceDays = 'account_erasure_grace_days';
 
     // What the unattended erasure does with the files and folders a purged

--- a/tests/Feature/Identity/AccountErasureTest.php
+++ b/tests/Feature/Identity/AccountErasureTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 use App\Models\User;
 use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLog;
+use App\Modules\Files\Models\File;
 use App\Modules\Identity\Erasure\AccountEraser;
+use App\Modules\Identity\Permissions\Permission;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
 use Inertia\Testing\AssertableInertia;
@@ -30,13 +32,16 @@ test('self-deletion schedules permanent erasure after the grace period', functio
 });
 
 test('the purge command erases only accounts past their grace period', function () {
+    app(Settings::class)->set(Setting::AccountErasureGraceDays, 30);
+
     $due = User::factory()->client()->create(['name' => 'Due Person']);
     $this->actingAs($due)->delete('/settings/profile', ['password' => 'password']);
 
     $notDue = User::factory()->client()->create();
     $this->actingAs($notDue)->delete('/settings/profile', ['password' => 'password']);
 
-    // Admin-deleted accounts have no erase_after and are never purged.
+    // Admin-deleted accounts are scheduled the same way (#1648), so this
+    // one comes due alongside the self-deleted one.
     $adminDeleted = User::factory()->client()->create();
     $this->actingAs($this->admin)->delete("/clients/{$adminDeleted->id}");
 
@@ -48,8 +53,37 @@ test('the purge command erases only accounts past their grace period', function 
 
     expect(User::withTrashed()->find($due->id))->toBeNull()
         ->and(User::withTrashed()->find($notDue->id))->not->toBeNull()
-        ->and(User::withTrashed()->find($adminDeleted->id))->not->toBeNull()
-        ->and(ActivityLog::query()->where('action', Action::AccountErased)->count())->toBe(1);
+        ->and(User::withTrashed()->find($adminDeleted->id))->toBeNull()
+        ->and(ActivityLog::query()->where('action', Action::AccountErased)->count())->toBe(2);
+});
+
+test('every administrative deletion path schedules permanent erasure', function () {
+    app(Settings::class)->set(Setting::AccountErasureGraceDays, 30);
+
+    $token = $this->admin->createToken('t', [
+        Permission::ManageUsers->value,
+        Permission::DeleteUsers->value,
+        Permission::ManageClients->value,
+        Permission::DeleteClients->value,
+    ])->plainTextToken;
+
+    $staffUi = User::factory()->create();
+    $this->actingAs($this->admin)->delete("/users/{$staffUi->id}")->assertRedirect('/users');
+
+    $clientUi = User::factory()->client()->create();
+    $this->actingAs($this->admin)->delete("/clients/{$clientUi->id}")->assertRedirect('/clients');
+
+    $staffApi = User::factory()->create();
+    $this->withToken($token)->deleteJson("/api/v1/users/{$staffApi->id}")->assertNoContent();
+
+    $clientApi = User::factory()->client()->create();
+    $this->withToken($token)->deleteJson("/api/v1/clients/{$clientApi->id}")->assertNoContent();
+
+    foreach ([$staffUi, $clientUi, $staffApi, $clientApi] as $account) {
+        $trashed = User::withTrashed()->findOrFail($account->id);
+        expect($trashed->deleted_at)->not->toBeNull()
+            ->and($trashed->erase_after?->isSameDay(now()->addDays(30)))->toBeTrue();
+    }
 });
 
 test('erasure anonymizes every identifying snapshot in the activity log', function () {
@@ -102,11 +136,11 @@ test('erasure deletes the account\'s files by default (cascade)', function () {
     app(Settings::class)->set(Setting::AccountErasureContentAction, 'cascade_delete');
 
     $client = User::factory()->client()->create();
-    $file = App\Modules\Files\Models\File::factory()->create(['uploaded_by' => $client->id]);
+    $file = File::factory()->create(['uploaded_by' => $client->id]);
 
     app(AccountEraser::class)->erase($client);
 
-    expect(App\Modules\Files\Models\File::find($file->id))->toBeNull()
+    expect(File::find($file->id))->toBeNull()
         ->and(ActivityLog::query()->where('action', Action::AccountContentCascadeDeleted->value)->exists())->toBeTrue();
 
     // The content-handling entry the erasure just wrote must not keep the
@@ -122,12 +156,12 @@ test('erasure reassigns the account\'s files to the configured fallback', functi
     app(Settings::class)->set(Setting::AccountErasureReassignTo, $fallback->id);
 
     $client = User::factory()->client()->create();
-    $file = App\Modules\Files\Models\File::factory()->create(['uploaded_by' => $client->id]);
+    $file = File::factory()->create(['uploaded_by' => $client->id]);
 
     app(AccountEraser::class)->erase($client);
 
     $entry = ActivityLog::query()->where('action', Action::AccountContentReassigned->value)->sole();
-    expect(App\Modules\Files\Models\File::find($file->id)?->uploaded_by)->toBe($fallback->id)
+    expect(File::find($file->id)?->uploaded_by)->toBe($fallback->id)
         // The erased person's name is scrubbed, but the inheritor's — a
         // still-active account — is a legitimate audit fact and stays.
         ->and($entry->context['name'] ?? null)->toBeNull()
@@ -142,10 +176,10 @@ test('reassign falls back to cascade when the target is no longer valid', functi
     app(Settings::class)->set(Setting::AccountErasureReassignTo, $gone->id);
 
     $client = User::factory()->client()->create();
-    $file = App\Modules\Files\Models\File::factory()->create(['uploaded_by' => $client->id]);
+    $file = File::factory()->create(['uploaded_by' => $client->id]);
 
     app(AccountEraser::class)->erase($client);
 
-    expect(App\Modules\Files\Models\File::find($file->id))->toBeNull()
+    expect(File::find($file->id))->toBeNull()
         ->and(ActivityLog::query()->where('action', Action::AccountContentCascadeDeleted->value)->exists())->toBeTrue();
 });

--- a/tests/Feature/Identity/DeletedAccountEmailReuseTest.php
+++ b/tests/Feature/Identity/DeletedAccountEmailReuseTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Identity\Erasure\ErasureSchedule;
+use App\Modules\Identity\Permissions\Permission;
+use App\Modules\Platform\Captcha\Captcha;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+
+/*
+|--------------------------------------------------------------------------
+| Reusing a deleted account's email address (#1648)
+|--------------------------------------------------------------------------
+|
+| The unique index on users.email spans soft-deleted rows on purpose: an
+| email address is a login identity and stays reserved while the account
+| holding it waits out its erasure grace period. What changed is that the
+| wait now ends — every deletion path schedules the erasure — and that the
+| staff screens explain the conflict instead of claiming the address "has
+| already been taken" by nothing anyone can see.
+|
+*/
+
+beforeEach(function () {
+    $this->admin = User::factory()->create();
+    app(Settings::class)->set(Setting::AccountErasureGraceDays, 30);
+});
+
+/** The client-creation payload every case here varies only the email of. */
+function clientPayload(string $email): array
+{
+    return [
+        'name' => 'Replacement',
+        'email' => $email,
+        'password' => 'super-secret-password',
+        'password_confirmation' => 'super-secret-password',
+    ];
+}
+
+test('once the purge has run, the address can be registered again', function () {
+    $client = User::factory()->client()->create(['email' => 'reuse@example.com']);
+    $this->actingAs($this->admin)->delete("/clients/{$client->id}");
+
+    // Still inside the grace period: reserved.
+    $this->actingAs($this->admin)->post('/clients', clientPayload('reuse@example.com'))
+        ->assertSessionHasErrors('email');
+
+    $this->travel(31)->days();
+    $this->artisan('projectsend:purge-erasures')->assertSuccessful();
+
+    $this->actingAs($this->admin)->post('/clients', clientPayload('reuse@example.com'))
+        ->assertSessionDoesntHaveErrors();
+
+    expect(User::query()->where('email', 'reuse@example.com')->sole()->name)->toBe('Replacement');
+});
+
+test('the staff screens name the date a deleted account\'s address becomes available', function () {
+    $client = User::factory()->client()->create(['email' => 'held@example.com']);
+    $this->actingAs($this->admin)->delete("/clients/{$client->id}");
+
+    $date = now()->addDays(30)->toFormattedDateString();
+
+    $this->actingAs($this->admin)->post('/clients', clientPayload('held@example.com'))
+        ->assertSessionHasErrors([
+            'email' => "This email address belongs to a deleted account that is scheduled for permanent erasure. The address becomes available on {$date}. To free it sooner, erase the account with the projectsend:erase-account console command.",
+        ]);
+});
+
+test('an account deleted before scheduling existed points at the erase command', function () {
+    // A bare model delete is exactly what the application did before
+    // erasure scheduling: trashed, no erase_after, reserved forever.
+    $legacy = User::factory()->client()->create(['email' => 'legacy@example.com']);
+    $legacy->delete();
+
+    $this->actingAs($this->admin)->post('/clients', clientPayload('legacy@example.com'))
+        ->assertSessionHasErrors([
+            'email' => 'This email address belongs to a deleted account that has no erasure scheduled. Run the projectsend:erase-account console command to erase it and free the address.',
+        ]);
+});
+
+test('a living account keeps the stock message', function () {
+    User::factory()->client()->create(['email' => 'taken@example.com']);
+
+    $this->actingAs($this->admin)->post('/clients', clientPayload('taken@example.com'))
+        ->assertSessionHasErrors(['email' => 'The email has already been taken.']);
+});
+
+test('public registration stays generic about deleted accounts', function () {
+    // Whether an address ever had an account here is nobody's business at
+    // the public form: the deleted-account explanation is for staff only.
+    app(Settings::class)->set(Setting::ClientsCanRegister, true);
+    app(Settings::class)->set(Setting::CaptchaProvider, 'none');
+    Captcha::forgetDisplayCache();
+
+    // Built directly rather than through the admin screen: /register is
+    // behind the guest middleware, so this test must never sign anyone in.
+    $client = User::factory()->client()->create(['email' => 'gone@example.com']);
+    app(ErasureSchedule::class)->apply($client);
+    $client->delete();
+
+    $this->post('/register', clientPayload('gone@example.com'))
+        ->assertSessionHasErrors(['email' => 'The email has already been taken.']);
+});
+
+test('the api reports the reserved address as a validation error on email', function () {
+    $token = $this->admin->createToken('t', [
+        Permission::ManageClients->value,
+        Permission::CreateClients->value,
+    ])->plainTextToken;
+
+    $client = User::factory()->client()->create(['email' => 'held@example.com']);
+    $this->actingAs($this->admin)->delete("/clients/{$client->id}");
+
+    $date = now()->addDays(30)->toFormattedDateString();
+
+    $this->withToken($token)
+        ->postJson('/api/v1/clients', [
+            'name' => 'Replacement',
+            'email' => 'held@example.com',
+            'password' => 'super-secret-password',
+        ])
+        ->assertUnprocessable()
+        ->assertJsonPath(
+            'errors.email.0',
+            "This email address belongs to a deleted account that is scheduled for permanent erasure. The address becomes available on {$date}. To free it sooner, erase the account with the projectsend:erase-account console command.",
+        );
+});
+
+test('the admin console command explains the reserved address too', function () {
+    $client = User::factory()->client()->create(['email' => 'held@example.com']);
+    $this->actingAs($this->admin)->delete("/clients/{$client->id}");
+
+    $this->artisan('projectsend:admin', [
+        '--name' => 'New Admin',
+        '--email' => 'held@example.com',
+        '--password' => 'super-secret-password',
+    ])
+        ->expectsOutputToContain('scheduled for permanent erasure')
+        ->assertFailed();
+});


### PR DESCRIPTION
Fixes #1648 — the issue's option 3, both halves. With it, the last open
item of #1647's audit of unique indexes on soft-deleting tables is
resolved: users.email, the one that needed a different answer than slug
vacating because an email address is a login identity.

**Every deletion path now schedules the erasure.** Only self-deletion set
`erase_after`; an account deleted by an administrator was soft-deleted
with the column null, so `projectsend:purge-erasures` — which filters on
`whereNotNull('erase_after')` — never reached it, and the unique index on
`users.email` kept the address reserved forever. The stamp now lives in
one place, `ErasureSchedule`: self-deletion switched to it, and
`StaffAccounts::delete` (shared by the web screen and the API) and both
client controllers call it right before `delete()`. Same grace period,
same purge, whoever deleted the account.

Deliberately no backfill: accounts deleted before this change keep their
null `erase_after`. Stamping them during an update would quietly start a
countdown to data erasure that nobody chose at deletion time; the new
validation message covers them instead.

**The staff creation paths explain the conflict.** They swap
`unique:users,email` for `AvailableEmailRule`, which keeps exactly the
same refusals but can explain the one the stock message can't:

- living account → the stock "The email has already been taken."
- deleted, erasure scheduled → "This email address belongs to a deleted
  account that is scheduled for permanent erasure. The address becomes
  available on :date. To free it sooner, erase the account with the
  projectsend:erase-account console command."
- deleted before scheduling existed → points at
  `projectsend:erase-account` alone

Public registration keeps the stock rule on purpose: telling an anonymous
visitor the address belongs to a deleted account would confirm the
address had an account here, which is exactly the disclosure the generic
message avoids.

Covered by tests: every deletion path stamps `erase_after`, the purge now
reaches admin-deleted accounts and the address becomes registerable
again, all three message variants, registration staying generic, the API
error shape, and `projectsend:admin`.