### PR TITLE
Answer redirected writes with 303 so expired sessions show the login page, not a 405

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -19,6 +19,7 @@ use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Request;
 use Illuminate\Session\Middleware\AuthenticateSession;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -112,5 +113,22 @@ return Application::configure(basePath: dirname(__DIR__))
             return $problems->shouldHandle($request)
                 ? $problems->render($request, $e)
                 : null;
+        });
+
+        // A redirect born in exception handling — the guest redirect after
+        // an expired login, above all — never travels back through the
+        // middleware stack, so Inertia's usual 302→303 upgrade cannot reach
+        // it. Browsers follow a 302 by replaying the request method on the
+        // redirect target (only POST is downgraded to GET), so a PUT that
+        // should land on the login page replays as PUT /login and dies with
+        // a 405 that hides the real "please sign in again". 303 makes the
+        // follow-up a GET, which is the only sensible thing after a write.
+        $exceptions->respond(function (SymfonyResponse $response, Throwable $e, Request $request) {
+            if ($response->getStatusCode() === SymfonyResponse::HTTP_FOUND
+                && in_array($request->method(), ['PUT', 'PATCH', 'DELETE'], true)) {
+                $response->setStatusCode(SymfonyResponse::HTTP_SEE_OTHER);
+            }
+
+            return $response;
         });
     })->create();

--- a/tests/Feature/Auth/WriteRedirectStatusTest.php
+++ b/tests/Feature/Auth/WriteRedirectStatusTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\User;
+
+// A redirect answered to a PUT/PATCH/DELETE must be a 303, not a 302:
+// browsers follow a 302 by replaying the same method on the redirect
+// target (only POST is downgraded to GET), so "your session expired,
+// please sign in" turns into PUT /login — and /login only takes GET and
+// POST, so the user sees an unexplainable 405 instead of the login page.
+// Redirects born in exception handling (the guest redirect above all)
+// never pass back through Inertia's middleware, which normally does this
+// upgrade — bootstrap/app.php repeats it for them. See issue #1673.
+
+it('answers an unauthenticated write with 303 so the browser lands on the login page', function () {
+    $this->put(route('dashboard.widgets.update'), [])
+        ->assertStatus(303)
+        ->assertRedirect(route('login'));
+});
+
+it('answers an unauthenticated delete with 303 as well', function () {
+    $user = User::factory()->create();
+
+    $this->delete(route('users.destroy', $user))
+        ->assertStatus(303)
+        ->assertRedirect(route('login'));
+});
+
+it('keeps the plain 302 for unauthenticated reads', function () {
+    $this->get(route('dashboard'))
+        ->assertStatus(302)
+        ->assertRedirect(route('login'));
+});


### PR DESCRIPTION
Fixes #1673

**What the reporter saw**

```
"PUT /index.php" 302
"PUT /index.php" 405
```

Browsers follow a **302** by replaying the request method on the redirect target — only POST is downgraded to GET. So when a widget save (`PUT /dashboard/widgets`) runs into an expired session and gets redirected to the login page, the browser replays `PUT /login`, which only accepts GET/POST → **405**, and Inertia shows the error modal instead of the login screen. The `PATCH … 405` in the original report is the same failure on a PATCH-based settings save. It only strikes when a *write* request gets redirected, which is why it looked so random — the reporter's sessions were being killed constantly by the untrusted-proxy problem (#1672, addressed by #1674).

**Why Inertia's own 303 upgrade didn't cover this**

`Inertia\Middleware` upgrades 302→303 for PUT/PATCH/DELETE, but a redirect created during *exception handling* — the guest redirect after `AuthenticationException`, above all — never travels back through the middleware stack, so the upgrade never runs. Reproduced directly: an unauthenticated `PUT /dashboard/widgets` with a valid CSRF token answers `302 Location: /login`.

**The fix**

A `respond` hook in `bootstrap/app.php`: any 302 rendered from an exception in reply to a PUT/PATCH/DELETE becomes a **303** ("see other" — follow with GET). Reads keep their 302; POST needs nothing.

**Tests**

- unauthenticated `PUT` (widget save) → 303 to the login page (was 302, failing before the fix)
- unauthenticated `DELETE` → 303 to the login page
- unauthenticated `GET` → still a plain 302

**Not covered on purpose**

The direct (non-exception) redirects issued by `EnsureSetupIsComplete`, `EnsureAccountIsActive` and `EnforceTwoFactor` sit *outside* `HandleInertiaRequests` in the web group, so a write request caught by one of those can still produce the same 405 pattern (e.g. an account deactivated mid-session saving a form). Much rarer, and each wants its own decision about the right status — happy to follow up if wanted.