### PR TITLE
Enforce the max file size against the bytes a chunked upload assembles

### DIFF
--- a/app/Modules/Files/Http/Controllers/ChunkedUploadsController.php
+++ b/app/Modules/Files/Http/Controllers/ChunkedUploadsController.php
@@ -249,6 +249,22 @@ class ChunkedUploadsController extends Controller
             throw ValidationException::withMessages(['parts' => $exception->getMessage()]);
         }
 
+        // store()'s size check ran against the client-declared, unverified
+        // size, so a small declared size would otherwise let an upload of any
+        // size through here. Re-check the real assembled byte count against
+        // the same limit store() applies to everyone. No File row exists yet
+        // at this point, so cleanup only needs to undo what assemble() wrote.
+        $maxMb = (int) $this->settings->get(Setting::MaxFileSizeMb);
+
+        if ($maxMb > 0 && $assembled['size'] > $maxMb * 1024 * 1024) {
+            Storage::disk($assembled['disk'])->delete($assembled['path']);
+            $session->delete();
+
+            throw ValidationException::withMessages([
+                'size' => __('This file exceeds the maximum allowed size of :max MB.', ['max' => (string) $maxMb]),
+            ]);
+        }
+
         // store()'s quota check used a client-declared, unverified size —
         // re-check against the real assembled byte count before this
         // becomes a File row. No File row exists yet at this point, so

--- a/tests/Feature/Files/ChunkedUploadsTest.php
+++ b/tests/Feature/Files/ChunkedUploadsTest.php
@@ -152,6 +152,41 @@ test('a staff account without the upload permission cannot create sessions', fun
     $this->postJson('/uploads', ['filename' => 'x.zip', 'size' => 10])->assertForbidden();
 });
 
+test('complete refuses a file whose real assembled size exceeds the limit, even when a tiny size was declared', function () {
+    $this->actingAs($this->admin);
+
+    // A 1 MB cap. The session is declared as a single byte, so it sails
+    // through store()'s check against the client-supplied size.
+    app(Settings::class)->set(Setting::MaxFileSizeMb, 1);
+    $sessionId = createSession(1, 'sneaky.zip');
+
+    // But the real parts stream ~1.5 MB.
+    $chunk = str_repeat('a', 800 * 1024);
+    putPart($sessionId, 1, $chunk)->assertOk();
+    putPart($sessionId, 2, $chunk)->assertOk();
+
+    $this->postJson("/uploads/{$sessionId}/complete")->assertStatus(422);
+
+    // Nothing is kept: no File row, the assembled bytes are removed, and the
+    // session is gone.
+    expect(File::query()->count())->toBe(0)
+        ->and(UploadSession::query()->find($sessionId))->toBeNull()
+        ->and(Storage::disk('files')->allFiles())->toBe([]);
+});
+
+test('complete still accepts a file at exactly the limit', function () {
+    $this->actingAs($this->admin);
+
+    app(Settings::class)->set(Setting::MaxFileSizeMb, 1);
+    $sessionId = createSession(1024 * 1024, 'exact.zip');
+
+    putPart($sessionId, 1, str_repeat('a', 1024 * 1024))->assertOk();
+
+    $response = $this->postJson("/uploads/{$sessionId}/complete")->assertOk();
+
+    expect(File::query()->findOrFail($response->json('file_id'))->size)->toBe(1024 * 1024);
+});
+
 test('a client with the upload permission can create a session and complete an upload', function () {
     $client = User::factory()->client()->create();
     grantChunkedUploadPermission($client);


### PR DESCRIPTION
`ChunkedUploadsController::store()` checks `Setting::MaxFileSizeMb` against the size the client **declares** when it opens the session, and `complete()` re-checks the storage **quota** against the real assembled byte count — but nothing re-checked the **size limit** itself against the real bytes.

A client that declares a one-byte upload and then streams gigabytes of parts passes `store()`'s check and is never stopped, so the configured limit does not hold for the resumable path — which is the path real uploads use (`FilesController::store()` is a test-only fixture).

**This is not an intentional staff exemption.** The code draws the user-type line explicitly, and draws it around the *quota*, not the size limit:

- The **quota** is guarded `if ($user->isClient())` everywhere, with the comment in the single-request API `store()`: *"Inert for a staff token — the quota is a client-portal concept."*
- The **size limit** has no user-type guard in any of the three upload paths. The single-request API `store()` (`Api/FilesController.php:184-190`) enforces it against the **real** uploaded bytes for everyone, staff included; both `store()` paths apply it before the client-only quota block; the existing test "a session within the size limit is created; over the limit is refused" refuses an oversized declaration from an admin; and `max_file_size_mb` is surfaced to both the staff upload page and the client portal.

So `complete()` re-checking only the quota (client-only) and not the size (universal) is an oversight, not a policy. The method's own docblock already promised the size check: *"The declared size is re-checked against the assembled bytes when the upload completes."* And `0 = unlimited` is preserved — the guard is `$maxMb > 0`.

### Fix

Re-check the assembled byte count against `MaxFileSizeMb` in `complete()`, cleaning up the assembled bytes and the session exactly as the adjacent quota branch already does. The error message is the one `store()` already uses, so every existing translation covers it. Since the same controller serves the web and API upload routes, both paths are covered.

### Tests

Added to `tests/Feature/Files/ChunkedUploadsTest.php`:

- `complete` refuses a file whose real assembled size exceeds the limit even when a tiny size was declared (422, no File row, assembled bytes removed, session gone);
- `complete` still accepts a file at exactly the limit.

Full suite passes (1822 passed / 1 skipped), PHPStan level 8 clean.