### PR TITLE
Keep preview renditions out of the orphan-file scan

### DIFF
--- a/app/Modules/Files/OrphanFileScanner.php
+++ b/app/Modules/Files/OrphanFileScanner.php
@@ -6,6 +6,7 @@ namespace App\Modules\Files;
 
 use App\Models\User;
 use App\Modules\Files\Models\File;
+use App\Modules\Files\Thumbnails\ImageRendition;
 use App\Modules\Files\Uploads\UploadExtensionPolicy;
 use App\Modules\Platform\Settings\ExternalStorageConfigApplier;
 use App\Modules\Platform\Settings\ExternalStorageSettings;
@@ -20,13 +21,6 @@ use Illuminate\Support\Facades\Storage;
  */
 class OrphanFileScanner
 {
-    // Derived artifacts written by FileThumbnailController and
-    // BuildZipDownloadJob respectively — never orphaned uploads, so
-    // never candidates regardless of what's in the files table.
-    // Thumbnails are always local; zips would be too if that job ever
-    // ran against 'files_external', so the exclusion applies per-disk.
-    private const EXCLUDED_PREFIXES = ['thumbnails/', 'zips/'];
-
     public function __construct(
         private readonly UploadExtensionPolicy $extensionPolicy,
         private readonly ExternalStorageConfigApplier $externalStorage,
@@ -160,9 +154,32 @@ class OrphanFileScanner
         ));
     }
 
+    /**
+     * Path prefixes that are derived artifacts, never orphaned uploads, so
+     * never candidates regardless of what's in the files table: every image
+     * rendition's cache directory (taken from ImageRendition so a new
+     * rendition can't be forgotten here — previews used to be) plus the
+     * download-bundle job's 'zips'. Thumbnails and previews are always local;
+     * zips would be too if that job ever ran against 'files_external', so the
+     * exclusion applies per-disk.
+     *
+     * @return list<string>
+     */
+    private function excludedPrefixes(): array
+    {
+        $prefixes = array_map(
+            static fn (ImageRendition $rendition): string => $rendition->directory().'/',
+            ImageRendition::cases(),
+        );
+
+        $prefixes[] = 'zips/';
+
+        return $prefixes;
+    }
+
     private function isExcluded(string $path): bool
     {
-        foreach (self::EXCLUDED_PREFIXES as $prefix) {
+        foreach ($this->excludedPrefixes() as $prefix) {
             if (str_starts_with($path, $prefix)) {
                 return true;
             }

--- a/tests/Feature/Files/OrphanFilesTest.php
+++ b/tests/Feature/Files/OrphanFilesTest.php
@@ -44,6 +44,8 @@ function orphanDelete(array $items): TestResponse
 test('scanning excludes derived-artifact prefixes and anything already claimed by a file row, including soft-deleted ones', function () {
     makeOrphanFile('2026/07/orphan.pdf');
     makeOrphanFile('thumbnails/2026/07/some.jpg');
+    makeOrphanFile('previews/2026/07/some.jpg');
+    makeOrphanFile('previews/external/some.jpg');
     makeOrphanFile('zips/some.zip');
 
     $adopted = makeAdoptedFile($this->admin, '2026/07/adopted.pdf');


### PR DESCRIPTION
The orphan scanner skips derived artifacts by path prefix, but the list was a hard-coded `['thumbnails/', 'zips/']` that never learned about `previews/`. `ImageRendition::Preview` caches under `previews/` (and `previews/external/`) on the local `files` disk, so every cached preview was reported as an orphan:

- **offered for import** on the orphans screen (`OrphanFilesController::import` accepts jpg/png over 0 bytes), and
- **deleted by the purge command** once past the grace period (`PurgeOrphanFilesCommand`).

An imported preview also became a `File` row pointing at a path the rendition cache owns — destroyed the moment its source file was deleted (`FileDiskCleanup`) or the cache was flushed (`RenderedImageCache::flush()`), leaving a row with no bytes.

### Fix

Derive the rendition prefixes from `ImageRendition::cases()` (each `->directory().'/'`) rather than repeating them, so a future rendition can't be forgotten here the way previews were — the same pattern `ThumbnailGenerator::pathsFor()` already uses for deletion. `'zips/'` (the download-bundle job's) stays as it was.

```php
private function excludedPrefixes(): array
{
    $prefixes = array_map(
        static fn (ImageRendition $rendition): string => $rendition->directory().'/',
        ImageRendition::cases(),
    );
    $prefixes[] = 'zips/';
    return $prefixes;
}
```

Since `isOrphan()` runs the same exclusion, the import and delete endpoints refuse rendition paths too, not just the listing.

No cleanup gap opens up by excluding previews: renditions live and die with their source file — `FileDiskCleanup` deletes every rendition path on file deletion — exactly as it always has for the already-excluded `thumbnails/`.

### Tests

Extended the existing exclusion test in `tests/Feature/Files/OrphanFilesTest.php` with `previews/2026/07/some.jpg` and `previews/external/some.jpg`; both must be excluded (the `previews/` prefix also covers the `external/` subdirectory), so the scan still reports exactly one orphan. Against the unfixed scanner the test fails with 3 orphans instead of 1.

Full suite passes (1820 passed / 1 skipped), PHPStan level 8 clean.