### PR TITLE
Land a successful create where a create-only role can actually go

### DIFF
--- a/app/Modules/Clients/Http/Controllers/ClientsController.php
+++ b/app/Modules/Clients/Http/Controllers/ClientsController.php
@@ -130,7 +130,17 @@ class ClientsController extends Controller
             $client->notify(new ClientWelcomeNotification);
         }
 
-        return redirect()->route('clients.edit', $client)->with('success', __('Client created.'));
+        // A role can hold create_clients without edit_clients, and the edit
+        // page this used to land on unconditionally answers such a role
+        // with a 403 — after the client was created, logged and welcomed.
+        // Fall back to the create form: it shares this route's own gate, so
+        // it is reachable by exactly whoever just created the record, and
+        // the success toast shows there.
+        $target = $request->user()?->can('edit_clients')
+            ? redirect()->route('clients.edit', $client)
+            : redirect()->route('clients.create');
+
+        return $target->with('success', __('Client created.'));
     }
 
     public function edit(User $client): Response

--- a/app/Modules/Files/Http/Controllers/CategoriesController.php
+++ b/app/Modules/Files/Http/Controllers/CategoriesController.php
@@ -81,7 +81,14 @@ class CategoriesController extends Controller
 
         $this->activity->log(Action::CategoryCreated, subject: $category);
 
-        return redirect()->route('categories.edit', $category)->with('success', __('Category created.'));
+        // Same create-without-edit rule as ClientsController::store() — and
+        // the most reachable case of it: the sidebar shows Categories from
+        // create_categories alone, with no manage tier in between.
+        $target = $request->user()?->can('edit_categories')
+            ? redirect()->route('categories.edit', $category)
+            : redirect()->route('categories.create');
+
+        return $target->with('success', __('Category created.'));
     }
 
     public function edit(Category $category): Response

--- a/app/Modules/Groups/Http/Controllers/GroupsController.php
+++ b/app/Modules/Groups/Http/Controllers/GroupsController.php
@@ -92,7 +92,12 @@ class GroupsController extends Controller
             $this->activity->log(Action::GroupMadePublic, subject: $group, context: ['slug' => $group->slug]);
         }
 
-        return redirect()->route('groups.edit', $group)->with('success', __('Group created.'));
+        // Same create-without-edit rule as ClientsController::store().
+        $target = $request->user()?->can('edit_groups')
+            ? redirect()->route('groups.edit', $group)
+            : redirect()->route('groups.create');
+
+        return $target->with('success', __('Group created.'));
     }
 
     public function edit(Group $group): Response

--- a/app/Modules/Identity/Http/Controllers/UsersController.php
+++ b/app/Modules/Identity/Http/Controllers/UsersController.php
@@ -126,7 +126,12 @@ class UsersController extends Controller
             'password' => $validated['password'],
         ], $validated['assigned_clients'] ?? []);
 
-        return redirect()->route('users.edit', $user)->with('success', __('User created.'));
+        // Same create-without-edit rule as ClientsController::store().
+        $target = $this->actor()->can('edit_users')
+            ? redirect()->route('users.edit', $user)
+            : redirect()->route('users.create');
+
+        return $target->with('success', __('User created.'));
     }
 
     public function edit(User $user): Response

--- a/tests/Feature/Identity/CreateWithoutEditRedirectTest.php
+++ b/tests/Feature/Identity/CreateWithoutEditRedirectTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Files\Models\Category;
+use App\Modules\Groups\Models\Group;
+use App\Modules\Identity\Models\Role;
+use App\Modules\Identity\Models\RolePermission;
+
+/**
+ * A role can hold create_* without edit_*, and a successful create used
+ * to redirect unconditionally to the new record's edit page — whose
+ * can:edit_* middleware answers such a role with a 403 after the record
+ * was created, logged and (for clients) welcomed. The store() methods
+ * now fall back to the create form, which shares store()'s own gate and
+ * is therefore reachable by exactly whoever just created the record.
+ *
+ * One test per entity rather than a clever loop, because each store()
+ * wants its own payload — but the rule under test is the same four
+ * times, and a fifth create flow should copy it.
+ */
+function roleHolding(array $permissions): User
+{
+    $role = Role::query()->create(['name' => 'Holder '.uniqid()]);
+
+    foreach ($permissions as $permission) {
+        RolePermission::query()->create(['role_id' => $role->id, 'permission' => $permission]);
+    }
+
+    return User::factory()->create(['role_id' => $role->id]);
+}
+
+/** A role with no permissions at all — grantable by any staff actor. */
+function grantableEmptyRole(): Role
+{
+    return Role::query()->create(['name' => 'Empty '.uniqid()]);
+}
+
+test('a create-only clients role lands back on the create form, success flashed', function () {
+    $creator = roleHolding(['create_clients']);
+
+    $response = $this->actingAs($creator)->post('/clients', [
+        'name' => 'New Client',
+        'email' => 'create-only-client@example.com',
+        'password' => 'Sup3r-secret!22',
+        'password_confirmation' => 'Sup3r-secret!22',
+    ]);
+
+    expect(User::query()->where('email', 'create-only-client@example.com')->exists())->toBeTrue();
+
+    $response->assertRedirect(route('clients.create'))->assertSessionHas('success');
+    $this->actingAs($creator)->get(route('clients.create'))->assertOk();
+});
+
+test('a clients role that may edit keeps landing on the edit page', function () {
+    $creator = roleHolding(['create_clients', 'edit_clients']);
+
+    $response = $this->actingAs($creator)->post('/clients', [
+        'name' => 'Editable Client',
+        'email' => 'editable-client@example.com',
+        'password' => 'Sup3r-secret!22',
+        'password_confirmation' => 'Sup3r-secret!22',
+    ]);
+
+    $client = User::query()->where('email', 'editable-client@example.com')->firstOrFail();
+
+    $response->assertRedirect(route('clients.edit', $client))->assertSessionHas('success');
+    $this->actingAs($creator)->get(route('clients.edit', $client))->assertOk();
+});
+
+test('a create-only users role lands back on the create form, success flashed', function () {
+    // manage_users guards the whole route group, store included, so a
+    // users creator always holds it alongside create_users.
+    $creator = roleHolding(['manage_users', 'create_users']);
+
+    $response = $this->actingAs($creator)->post('/users', [
+        'name' => 'New Staffer',
+        'email' => 'create-only-staffer@example.com',
+        'role_id' => grantableEmptyRole()->id,
+        'password' => 'Sup3r-secret!22',
+        'password_confirmation' => 'Sup3r-secret!22',
+    ]);
+
+    expect(User::query()->where('email', 'create-only-staffer@example.com')->exists())->toBeTrue();
+
+    $response->assertRedirect(route('users.create'))->assertSessionHas('success');
+    $this->actingAs($creator)->get(route('users.create'))->assertOk();
+});
+
+test('a users role that may edit keeps landing on the edit page', function () {
+    $creator = roleHolding(['manage_users', 'create_users', 'edit_users']);
+
+    $response = $this->actingAs($creator)->post('/users', [
+        'name' => 'Editable Staffer',
+        'email' => 'editable-staffer@example.com',
+        'role_id' => grantableEmptyRole()->id,
+        'password' => 'Sup3r-secret!22',
+        'password_confirmation' => 'Sup3r-secret!22',
+    ]);
+
+    $user = User::query()->where('email', 'editable-staffer@example.com')->firstOrFail();
+
+    $response->assertRedirect(route('users.edit', $user))->assertSessionHas('success');
+    $this->actingAs($creator)->get(route('users.edit', $user))->assertOk();
+});
+
+test('a create-only groups role lands back on the create form, success flashed', function () {
+    $creator = roleHolding(['create_groups']);
+
+    $response = $this->actingAs($creator)->post('/groups', ['name' => 'New Group', 'public' => false]);
+
+    expect(Group::query()->where('name', 'New Group')->exists())->toBeTrue();
+
+    $response->assertRedirect(route('groups.create'))->assertSessionHas('success');
+    $this->actingAs($creator)->get(route('groups.create'))->assertOk();
+});
+
+test('a groups role that may edit keeps landing on the edit page', function () {
+    $creator = roleHolding(['create_groups', 'edit_groups']);
+
+    $response = $this->actingAs($creator)->post('/groups', ['name' => 'Editable Group', 'public' => false]);
+
+    $group = Group::query()->where('name', 'Editable Group')->firstOrFail();
+
+    $response->assertRedirect(route('groups.edit', $group))->assertSessionHas('success');
+    $this->actingAs($creator)->get(route('groups.edit', $group))->assertOk();
+});
+
+test('a create-only categories role lands back on the create form, success flashed', function () {
+    // The most reachable case: the sidebar shows Categories from
+    // create_categories alone, so this whole flow is plain UI clicks.
+    $creator = roleHolding(['create_categories']);
+
+    $response = $this->actingAs($creator)->post('/categories', ['name' => 'New Category']);
+
+    expect(Category::query()->where('name', 'New Category')->exists())->toBeTrue();
+
+    $response->assertRedirect(route('categories.create'))->assertSessionHas('success');
+    $this->actingAs($creator)->get(route('categories.create'))->assertOk();
+});
+
+test('a categories role that may edit keeps landing on the edit page', function () {
+    $creator = roleHolding(['create_categories', 'edit_categories']);
+
+    $response = $this->actingAs($creator)->post('/categories', ['name' => 'Editable Category']);
+
+    $category = Category::query()->where('name', 'Editable Category')->firstOrFail();
+
+    $response->assertRedirect(route('categories.edit', $category))->assertSessionHas('success');
+    $this->actingAs($creator)->get(route('categories.edit', $category))->assertOk();
+});


### PR DESCRIPTION
Four create flows redirect to the new record's **edit** page on success — but `store` is gated by `create_*` while the edit page is gated by `edit_*`, and `PermissionChecker` has no create→edit implication. A role that holds `create_*` without `edit_*` therefore:

1. reaches the create form and submits it;
2. the record **is** created — the write, the activity log entry, and (for clients) the welcome notification all run;
3. the success redirect issues a `302 → GET <entity>.edit`, which the `can:edit_*` middleware answers with **403**.

So the action succeeded, but the user gets a 403, never sees the "… created" flash, and has no way to tell whether it worked — which also invites a duplicate submit.

| Entity | `store` → redirected to | `store` gate | edit gate |
|---|---|---|---|
| Clients | `clients.edit` | `create_clients` | `edit_clients` |
| Users | `users.edit` | `create_users` (group adds `manage_users`) | `edit_users` |
| Groups | `groups.edit` | `create_groups` | `edit_groups` |
| Categories | `categories.edit` | `create_categories` | `edit_categories` |

Categories is the most reachable case: the sidebar shows the section from `create_categories` alone (there is no `manage_categories` tier), so a create-only role hits the 403 with plain UI clicks. Administrators are unaffected (`is_administrator` bypasses every gate).

(Working correctly today, for the same reason: `files.store` → `files.edit` — the uploader always passes `FilePolicy::view` on their own file; `roles.*` and the custom-field flows sit behind one shared group gate.)

### Fix

Keep landing on the edit page for anyone who may edit, and divert only those who can't — to the **create form**, which shares `store`'s own gate and is therefore reachable by exactly whoever just created the record. The success flash shows there ("… created", ready to add the next one): the flash is shared app-wide and rendered by the global toaster on every page.

```php
$target = $request->user()?->can('edit_clients')
    ? redirect()->route('clients.edit', $client)
    : redirect()->route('clients.create');

return $target->with('success', __('Client created.'));
```

Same shape in all four `store()` methods. `$user->can('edit_*')` and the target route's `can:edit_*` middleware are the same mechanism (one Gate per permission key, defined on `PermissionChecker::allows`), so when the edit branch is chosen the page cannot 403.

The index was deliberately **not** used as the fallback: the Clients/Groups index pages are gated by `manage_*`, which `store` itself does not require, so a hand-crafted create-only role POSTing directly would 403 there too. Fixing it at the permission level instead (treating `create_*` as implying `edit_*`) would silently widen existing custom roles — `edit_*` has no own/others split here, so a deliberately narrow "may only add new clients" role would gain edit, including the two-factor reset, on every existing client. Changing no permission at all felt like the safer shape; happy to adjust if you'd rather draw the line differently.

### Tests

`tests/Feature/Identity/CreateWithoutEditRedirectTest.php` (8 cases): per entity, a create-only role creates the record and lands on the create form with the success flash (302, record exists, follow-up GET 200) — and a role that also holds `edit_*` keeps landing on the edit page exactly as before. Against the unfixed controllers the four create-only cases fail (redirect goes to the edit page).

Full suite passes (1828 passed / 1 skipped), PHPStan level 8 clean.