### PR TITLE
Show the dashboard's actorless activity as "Anonymous", not "System"

### DIFF
--- a/app/Modules/Audit/Http/Controllers/DashboardController.php
+++ b/app/Modules/Audit/Http/Controllers/DashboardController.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use App\Modules\Api\ApiUsage;
 use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLog;
+use App\Modules\Audit\ActivityPresenter;
 use App\Modules\Audit\DashboardWidgetPreferences;
 use App\Modules\Clients\ClientStorageUsage;
 use App\Modules\Files\Models\File;
@@ -50,6 +51,7 @@ class DashboardController extends Controller
         private readonly Installation $installation,
         private readonly TimezoneRegistry $timezones,
         private readonly SystemEnvironment $environment,
+        private readonly ActivityPresenter $presenter,
     ) {}
 
     public function __invoke(Request $request): Response
@@ -398,26 +400,17 @@ class DashboardController extends Controller
      */
     private function recentActivity(): array
     {
+        // Presented through the shared ActivityPresenter, not rebuilt inline —
+        // the same sentence-ready shape the activity page and detail panels
+        // use. Rebuilding it here once dropped `origin`, which is the only
+        // thing that tells an actorless "Anonymous" entry from a "System" one.
         return ActivityLog::query()
             ->orderByDesc('created_at')
             ->orderByDesc('id')
             ->limit(8)
             ->get()
-            ->map(fn (ActivityLog $entry): array => [
-                'id' => $entry->id,
-                'created_at' => $entry->created_at->toIso8601String(),
-                'actor_name' => $entry->actor_name,
-                'actor_type' => $entry->actor_type,
-                'template' => $entry->action->template(),
-                'replacements' => [
-                    'subject' => $entry->subject_name
-                        ?? ($entry->subject_id !== null ? __('(deleted account)') : ''),
-                    ...collect($entry->context ?? [])
-                        ->filter(fn ($value): bool => is_scalar($value))
-                        ->map(fn ($value): string => (string) $value)
-                        ->all(),
-                ],
-            ])->all();
+            ->map(fn (ActivityLog $entry): array => $this->presenter->present($entry))
+            ->all();
     }
 
     /**

--- a/tests/Feature/Audit/DashboardTest.php
+++ b/tests/Feature/Audit/DashboardTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Models\User;
 use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLog;
+use App\Modules\Audit\ActivityOrigin;
 use App\Modules\Files\Models\File;
 use App\Modules\Files\Models\ShareLink;
 use App\Modules\Groups\Models\Group;
@@ -314,4 +315,24 @@ test('clients get the portal dashboard with their own numbers', function () {
     );
 
     expect((string) $response->getContent())->not->toContain('Hidden');
+});
+
+test('the recent-activity widget carries origin so an actorless entry is not mislabelled', function () {
+    // An anonymous entry (a public/share-link download) and a system entry
+    // are both actor_name null; only `origin` separates "Anonymous" from
+    // "System" on the frontend. The dashboard used to rebuild the row inline
+    // and drop it, so every actorless entry showed as "System".
+    ActivityLog::query()->create([
+        'actor_id' => null, 'actor_name' => null, 'actor_type' => null,
+        'origin' => ActivityOrigin::Public,
+        'action' => Action::PublicFileDownloaded,
+        'subject_name' => 'report.pdf', 'created_at' => now(),
+    ]);
+
+    $this->actingAs($this->admin)->get('/dashboard')->assertInertia(
+        fn (AssertableInertia $page) => $page
+            ->has('recent', 1)
+            ->where('recent.0.origin', 'public')
+            ->where('recent.0.actor_name', null),
+    );
 });


### PR DESCRIPTION
The dashboard's **Recent activity** widget rebuilt each log entry inline (`DashboardController::recentActivity()`) instead of going through `ActivityPresenter`, and the inline copy dropped the `origin` field.

On the frontend, "System" and "Anonymous" are both `actor_name === null`, and only `origin` tells them apart (`resources/js/lib/activity-actor.ts`: `origin === 'public' ? Anonymous : System`). With `origin` missing, every actorless entry — public and share-link downloads, anonymous comments — rendered as **"System …"** on the dashboard. The activity page and the detail panels present the same entries correctly, because they carry `origin`; the widget's own `RecentEntry` interface already requires it.

`ActivityPresenter` exists precisely so "the dashboard, the activity page, and per-item detail panels all present entries identically" (its own docblock), and its `origin` line is commented *"Needed to render an actorless entry: 'System' and 'Anonymous' are both actor_name null, and only the origin separates them."* — the dashboard was the one caller that reconstructed the row by hand and reintroduced the omission. The inline copy was otherwise identical to the presenter, field for field, down to the `(deleted account)` fallback.

### Fix

Present the entries through the shared `ActivityPresenter` rather than rebuilding the shape inline. Fixes the missing `origin` and removes the duplicated shape, so the dashboard can't drift from the other surfaces again. (Net: the controller gets shorter. The CSV export also prints `actor_name ?? 'System'`, but it carries the origin label in its own column right next to it — left alone here.)

### Tests

Added to `tests/Feature/Audit/DashboardTest.php`: an actorless `ActivityOrigin::Public` entry now appears in the `recent` widget with `origin === 'public'` (so the frontend renders "Anonymous"), asserted alongside `actor_name === null`. Against the unfixed controller the test fails — `recent.0.origin` is missing entirely.

Full suite passes (1821 passed / 1 skipped), PHPStan level 8 clean.