### PR TITLE
Finalise each chunked upload once, under a per-session lock

### DIFF
--- a/app/Modules/Files/Http/Controllers/ChunkedUploadsController.php
+++ b/app/Modules/Files/Http/Controllers/ChunkedUploadsController.php
@@ -29,6 +29,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -240,6 +241,33 @@ class ChunkedUploadsController extends Controller
         $user = $request->user();
         assert($user !== null);
 
+        // Serialise completion per session: two concurrent completes (an Uppy
+        // retry, a double submit, a lost-connection resend) would otherwise
+        // both assemble into the one target file and create two File rows.
+        // The lock's TTL releases the claim if a completion dies mid-flight,
+        // so a later retry still works.
+        $lock = Cache::lock('upload-complete:'.$session->id, 120);
+
+        if (! $lock->get()) {
+            throw ValidationException::withMessages([
+                'parts' => __('This upload is already being finalised.'),
+            ]);
+        }
+
+        try {
+            return $this->finalise($session, $user);
+        } finally {
+            $lock->release();
+        }
+    }
+
+    /**
+     * Assemble a session's received parts into a stored File. Runs under
+     * complete()'s per-session lock, so it is the single writer to the
+     * session's target path and the only creator of its File row.
+     */
+    private function finalise(UploadSession $session, User $user): JsonResponse
+    {
         $extension = strtolower(pathinfo($session->original_name, PATHINFO_EXTENSION));
         $targetPath = now()->format('Y/m').'/'.Str::uuid()->toString().($extension !== '' ? '.'.$extension : '');
 

--- a/app/Modules/Files/Http/Controllers/ChunkedUploadsController.php
+++ b/app/Modules/Files/Http/Controllers/ChunkedUploadsController.php
@@ -249,6 +249,22 @@ class ChunkedUploadsController extends Controller
             throw ValidationException::withMessages(['parts' => $exception->getMessage()]);
         }
 
+        // store()'s size check ran against the client-declared, unverified
+        // size, so a small declared size would otherwise let an upload of any
+        // size through here. Re-check the real assembled byte count against
+        // the same limit store() applies to everyone. No File row exists yet
+        // at this point, so cleanup only needs to undo what assemble() wrote.
+        $maxMb = (int) $this->settings->get(Setting::MaxFileSizeMb);
+
+        if ($maxMb > 0 && $assembled['size'] > $maxMb * 1024 * 1024) {
+            Storage::disk($assembled['disk'])->delete($assembled['path']);
+            $session->delete();
+
+            throw ValidationException::withMessages([
+                'size' => __('This file exceeds the maximum allowed size of :max MB.', ['max' => (string) $maxMb]),
+            ]);
+        }
+
         // store()'s quota check used a client-declared, unverified size —
         // re-check against the real assembled byte count before this
         // becomes a File row. No File row exists yet at this point, so

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "Això elimina permanentment totes les tasques fallides de la llista sense reintentar-ne cap. No es pot desfer.",
     "This role is assigned to accounts and cannot be deleted.": "Aquest rol està assignat a comptes i no es pot eliminar.",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "Aquest rol només veu els fitxers i les carpetes d'aquests clients, a més de les seves pròpies pujades.",
+    "This upload is already being finalised.": "Aquesta pujada ja s'està finalitzant.",
     "This upload would exceed your storage quota of :quota MB.": "Aquesta pujada superaria la teva quota d'emmagatzematge de :quota MB.",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "Consell: arrossega fitxers i carpetes sobre una carpeta o sobre el rastre de navegació per moure'ls.",
     "Title": "Títol",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "Tímto trvale odstraníte všechny neúspěšné úlohy ze seznamu, aniž byste kteroukoli zopakovali. Tuto akci nelze vrátit zpět.",
     "This role is assigned to accounts and cannot be deleted.": "Tato role je přiřazena účtům a nelze ji smazat.",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "Tato role vidí pouze soubory a složky těchto klientů a k tomu vlastní nahrané soubory.",
+    "This upload is already being finalised.": "Toto nahrání se již dokončuje.",
     "This upload would exceed your storage quota of :quota MB.": "Toto nahrání by překročilo vaši kvótu úložiště :quota MB.",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "Tip: soubory a složky přesunete přetažením na složku nebo na drobečkovou navigaci.",
     "Title": "Nadpis",

--- a/lang/de.json
+++ b/lang/de.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "Damit werden alle fehlgeschlagenen Aufträge dauerhaft aus der Liste entfernt, ohne dass einer davon wiederholt wird. Das lässt sich nicht rückgängig machen.",
     "This role is assigned to accounts and cannot be deleted.": "Diese Rolle ist Konten zugewiesen und kann nicht gelöscht werden.",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "Diese Rolle sieht nur Dateien und Ordner dieser Kunden sowie ihre eigenen Uploads.",
+    "This upload is already being finalised.": "Dieser Upload wird bereits abgeschlossen.",
     "This upload would exceed your storage quota of :quota MB.": "Dieser Upload würde Ihr Speicherkontingent von :quota MB überschreiten.",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "Tipp: Ziehen Sie Dateien und Ordner auf einen Ordner oder einen Pfadeintrag, um sie zu verschieben.",
     "Title": "Titel",

--- a/lang/es.json
+++ b/lang/es.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "Esto elimina permanentemente todos los trabajos fallidos de la lista sin reintentar ninguno. No se puede deshacer.",
     "This role is assigned to accounts and cannot be deleted.": "Este rol está asignado a cuentas y no se puede eliminar.",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "Este rol solo ve los archivos y carpetas de estos clientes, además de sus propias subidas.",
+    "This upload is already being finalised.": "Esta subida ya se está finalizando.",
     "This upload would exceed your storage quota of :quota MB.": "Esta subida superaría tu cuota de almacenamiento de :quota MB.",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "Consejo: arrastra archivos y carpetas sobre una carpeta o una miga de pan para moverlos.",
     "Title": "Título",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "Cela supprime définitivement toutes les tâches échouées de la liste sans en réessayer aucune. Cette action est irréversible.",
     "This role is assigned to accounts and cannot be deleted.": "Ce rôle est attribué à des comptes et ne peut pas être supprimé.",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "Ce rôle ne voit que les fichiers et dossiers de ces clients, ainsi que ses propres téléversements.",
+    "This upload is already being finalised.": "Ce téléversement est déjà en cours de finalisation.",
     "This upload would exceed your storage quota of :quota MB.": "Ce téléversement dépasserait votre quota de stockage de :quota Mo.",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "Astuce : faites glisser fichiers et dossiers sur un dossier ou un fil d'Ariane pour les déplacer.",
     "Title": "Titre",

--- a/lang/id.json
+++ b/lang/id.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "Ini menghapus permanen semua tugas yang gagal dari daftar tanpa mencoba ulang satu pun. Tindakan ini tidak dapat dibatalkan.",
     "This role is assigned to accounts and cannot be deleted.": "Peran ini sedang dipakai oleh sejumlah akun sehingga tidak bisa dihapus.",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "Peran ini hanya melihat berkas dan folder milik klien berikut, ditambah unggahannya sendiri.",
+    "This upload is already being finalised.": "Unggahan ini sedang diselesaikan.",
     "This upload would exceed your storage quota of :quota MB.": "Unggahan ini akan melampaui kuota penyimpanan Anda sebesar :quota MB.",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "Tips: seret berkas dan folder ke sebuah folder atau ke jalur navigasi untuk memindahkannya.",
     "Title": "Judul",

--- a/lang/it.json
+++ b/lang/it.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "Questa operazione rimuove definitivamente tutte le operazioni fallite dall'elenco senza riprovarne nessuna. Non può essere annullata.",
     "This role is assigned to accounts and cannot be deleted.": "Questo ruolo è assegnato ad alcuni account e non può essere eliminato.",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "Questo ruolo vede solo i file e le cartelle di questi clienti, oltre ai propri caricamenti.",
+    "This upload is already being finalised.": "Questo caricamento è già in fase di finalizzazione.",
     "This upload would exceed your storage quota of :quota MB.": "Questo caricamento supererebbe la tua quota di spazio di :quota MB.",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "Suggerimento: trascina file e cartelle su una cartella o su un percorso di navigazione per spostarli.",
     "Title": "Titolo",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "失敗したジョブをすべて、再実行せずにリストから完全に削除します。この操作は取り消せません。",
     "This role is assigned to accounts and cannot be deleted.": "このロールはアカウントに割り当てられているため削除できません。",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "このロールには、以下のクライアントのファイルとフォルダ、そして自分がアップロードしたものだけが表示されます。",
+    "This upload is already being finalised.": "このアップロードは既に完了処理中です。",
     "This upload would exceed your storage quota of :quota MB.": "このアップロードは、ストレージ上限 :quota MB を超えてしまいます。",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "ヒント: ファイルやフォルダをフォルダやパンくずリストにドラッグすると移動できます。",
     "Title": "タイトル",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "Dit verwijdert alle mislukte taken definitief uit de lijst zonder er ook maar één opnieuw te proberen. Dit kan niet ongedaan worden gemaakt.",
     "This role is assigned to accounts and cannot be deleted.": "Deze rol is aan accounts toegewezen en kan niet worden verwijderd.",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "Deze rol ziet alleen bestanden en mappen van deze klanten, plus de eigen uploads.",
+    "This upload is already being finalised.": "Deze upload wordt al afgerond.",
     "This upload would exceed your storage quota of :quota MB.": "Deze upload zou je opslagquotum van :quota MB overschrijden.",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "Tip: sleep bestanden en mappen op een map of op het kruimelpad om ze te verplaatsen.",
     "Title": "Titel",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "Trwale usuwa z listy wszystkie nieudane zadania, nie ponawiając żadnego z nich. Tej operacji nie można cofnąć.",
     "This role is assigned to accounts and cannot be deleted.": "Ta rola jest przypisana do kont i nie można jej usunąć.",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "Ta rola widzi tylko pliki i foldery tych klientów oraz to, co sama przesłała.",
+    "This upload is already being finalised.": "To przesłanie jest już finalizowane.",
     "This upload would exceed your storage quota of :quota MB.": "To przesłanie przekroczyłoby Twój limit miejsca wynoszący :quota MB.",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "Wskazówka: przeciągnij pliki i foldery na folder lub na ścieżkę nawigacji, aby je przenieść.",
     "Title": "Tytuł",

--- a/lang/pt_BR.json
+++ b/lang/pt_BR.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "Isto remove permanentemente todas as tarefas com falha da lista sem tentar nenhuma novamente. Não é possível desfazer.",
     "This role is assigned to accounts and cannot be deleted.": "Esta função está atribuída a contas e não pode ser excluída.",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "Esta função só vê arquivos e pastas destes clientes, além dos próprios envios.",
+    "This upload is already being finalised.": "Este envio já está sendo finalizado.",
     "This upload would exceed your storage quota of :quota MB.": "Este envio excederia sua cota de armazenamento de :quota MB.",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "Dica: arraste arquivos e pastas para uma pasta ou para a trilha de navegação para movê-los.",
     "Title": "Título",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "Безвозвратно удаляет из списка все неудавшиеся задачи, не повторяя ни одну из них. Отменить это действие нельзя.",
     "This role is assigned to accounts and cannot be deleted.": "Эта роль назначена учётным записям, поэтому удалить её нельзя.",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "Эта роль видит только файлы и папки указанных клиентов, а также собственные загрузки.",
+    "This upload is already being finalised.": "Эта загрузка уже завершается.",
     "This upload would exceed your storage quota of :quota MB.": "Эта загрузка превысила бы вашу квоту хранилища в :quota МБ.",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "Подсказка: чтобы переместить файлы и папки, перетащите их на папку или на строку навигации.",
     "Title": "Заголовок",

--- a/lang/sw.json
+++ b/lang/sw.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "Hii huondoa kabisa kila kazi iliyoshindwa kwenye orodha bila kujaribu tena hata moja. Haiwezi kutenduliwa.",
     "This role is assigned to accounts and cannot be deleted.": "Jukumu hili limegawiwa kwa akaunti kadhaa, hivyo haliwezi kufutwa.",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "Jukumu hili huona tu mafaili na folda za wateja hawa, pamoja na yale lililoyapakia lenyewe.",
+    "This upload is already being finalised.": "Upakiaji huu tayari unakamilishwa.",
     "This upload would exceed your storage quota of :quota MB.": "Upakiaji huu ungezidi kiasi chako cha hifadhi cha MB :quota.",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "Dokezo: buruta mafaili na folda hadi kwenye folda au njia ya urambazaji ili kuvihamisha.",
     "Title": "Kichwa",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "Bu, listedeki tüm başarısız işleri hiçbirini yeniden denemeden kalıcı olarak siler. Geri alınamaz.",
     "This role is assigned to accounts and cannot be deleted.": "Bu rol hesaplara atanmış durumda ve silinemez.",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "Bu rol yalnızca bu müşterilerin dosya ve klasörlerini, bir de kendi yüklediklerini görür.",
+    "This upload is already being finalised.": "Bu yükleme zaten tamamlanıyor.",
     "This upload would exceed your storage quota of :quota MB.": "Bu yükleme, :quota MB'lik depolama kotanızı aşardı.",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "İpucu: dosya ve klasörleri taşımak için bir klasörün ya da yol izinin üzerine sürükleyin.",
     "Title": "Başlık",

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "Thao tác này xóa vĩnh viễn mọi tác vụ thất bại khỏi danh sách mà không thử lại bất kỳ tác vụ nào. Không thể hoàn tác.",
     "This role is assigned to accounts and cannot be deleted.": "Vai trò này đang được gán cho một số tài khoản nên không thể xóa.",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "Vai trò này chỉ thấy tệp và thư mục của những khách hàng dưới đây, cùng những gì chính họ tải lên.",
+    "This upload is already being finalised.": "Lần tải lên này đang được hoàn tất.",
     "This upload would exceed your storage quota of :quota MB.": "Lần tải lên này sẽ vượt quá hạn mức lưu trữ :quota MB của bạn.",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "Mẹo: kéo tệp và thư mục thả vào một thư mục hoặc lên thanh đường dẫn để di chuyển chúng.",
     "Title": "Tiêu đề",

--- a/lang/zh_CN.json
+++ b/lang/zh_CN.json
@@ -896,6 +896,7 @@
     "This permanently removes every failed job from the list without retrying any of them. This cannot be undone.": "这将从列表中永久删除所有失败的任务，且不会重试其中任何一个。此操作无法撤销。",
     "This role is assigned to accounts and cannot be deleted.": "此角色已分配给账户，无法删除。",
     "This role only sees files and folders belonging to these clients, plus its own uploads.": "此角色只能看到以下客户的文件和文件夹，以及自己上传的内容。",
+    "This upload is already being finalised.": "此次上传已在完成处理中。",
     "This upload would exceed your storage quota of :quota MB.": "此次上传会超出你 :quota MB 的存储配额。",
     "Tip: drag files and folders onto a folder or a breadcrumb to move them.": "提示：把文件和文件夹拖到某个文件夹或面包屑导航上即可移动。",
     "Title": "标题",

--- a/tests/Feature/Files/ChunkedUploadsTest.php
+++ b/tests/Feature/Files/ChunkedUploadsTest.php
@@ -152,6 +152,41 @@ test('a staff account without the upload permission cannot create sessions', fun
     $this->postJson('/uploads', ['filename' => 'x.zip', 'size' => 10])->assertForbidden();
 });
 
+test('complete refuses a file whose real assembled size exceeds the limit, even when a tiny size was declared', function () {
+    $this->actingAs($this->admin);
+
+    // A 1 MB cap. The session is declared as a single byte, so it sails
+    // through store()'s check against the client-supplied size.
+    app(Settings::class)->set(Setting::MaxFileSizeMb, 1);
+    $sessionId = createSession(1, 'sneaky.zip');
+
+    // But the real parts stream ~1.5 MB.
+    $chunk = str_repeat('a', 800 * 1024);
+    putPart($sessionId, 1, $chunk)->assertOk();
+    putPart($sessionId, 2, $chunk)->assertOk();
+
+    $this->postJson("/uploads/{$sessionId}/complete")->assertStatus(422);
+
+    // Nothing is kept: no File row, the assembled bytes are removed, and the
+    // session is gone.
+    expect(File::query()->count())->toBe(0)
+        ->and(UploadSession::query()->find($sessionId))->toBeNull()
+        ->and(Storage::disk('files')->allFiles())->toBe([]);
+});
+
+test('complete still accepts a file at exactly the limit', function () {
+    $this->actingAs($this->admin);
+
+    app(Settings::class)->set(Setting::MaxFileSizeMb, 1);
+    $sessionId = createSession(1024 * 1024, 'exact.zip');
+
+    putPart($sessionId, 1, str_repeat('a', 1024 * 1024))->assertOk();
+
+    $response = $this->postJson("/uploads/{$sessionId}/complete")->assertOk();
+
+    expect(File::query()->findOrFail($response->json('file_id'))->size)->toBe(1024 * 1024);
+});
+
 test('a client with the upload permission can create a session and complete an upload', function () {
     $client = User::factory()->client()->create();
     grantChunkedUploadPermission($client);

--- a/tests/Feature/Files/ChunkedUploadsTest.php
+++ b/tests/Feature/Files/ChunkedUploadsTest.php
@@ -12,6 +12,7 @@ use App\Modules\Identity\Permissions\Permission;
 use App\Modules\Identity\Permissions\SystemRole;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Testing\TestResponse;
 
@@ -315,4 +316,27 @@ test('a storage backend that refuses the write fails the upload instead of recor
 
     // The point of the whole test: no row for bytes that were never stored.
     expect(File::query()->count())->toBe($before);
+});
+
+test('a second complete is refused while one is already finalising the session', function () {
+    $this->actingAs($this->admin);
+    $sessionId = createSession(11, 'locked.txt');
+    putPart($sessionId, 1, 'hello-');
+    putPart($sessionId, 2, 'world');
+
+    // Stand in for a completion already in flight by holding the session's
+    // lock — a concurrent complete must not assemble the same target file a
+    // second time or create a second File row.
+    $lock = Cache::lock('upload-complete:'.$sessionId, 120);
+    expect($lock->get())->toBeTrue();
+
+    $this->postJson("/uploads/{$sessionId}/complete")->assertStatus(422);
+
+    expect(File::query()->count())->toBe(0)
+        ->and(UploadSession::query()->find($sessionId))->not->toBeNull();
+
+    // Once the in-flight completion releases the lock, completing works.
+    $lock->release();
+    $this->postJson("/uploads/{$sessionId}/complete")->assertOk();
+    expect(File::query()->count())->toBe(1);
 });


### PR DESCRIPTION
> **Builds on #1682** — the first commit here is that PR (both change `complete()`, so this branch stacks on it to avoid an artificial conflict). This PR's own changes are the second and third commits (the fix, plus the sixteen translations of its refusal message); once #1682 merges, the diff collapses to just them.

`ChunkedUploadsController::complete()` assembles the received parts into the one target file and creates the `File` row with **no guard against a second `complete()` for the same session running concurrently** — an Uppy retry, a double submit, a resend after a lost connection.

Two of them:

- both open the session's single `assembled` path (`LocalPartStore::assemble()` writes a fixed `{sessiondir}/assembled`) with `'wb'` and interleave their writes — the stored bytes then no longer match the SHA-256, which is computed from the in-memory part buffers, not re-read from the file, so the row looks valid while the content is corrupt;
- can each reach `File::create()` (on Linux the second `assemble()` can still run — `unlink()` on already-open fds), producing two rows for one upload.

(`UploadSession::STATUS_OPEN` is declared but never read or set anywhere, so nothing serialises this today.)

### Fix

Take a per-session lock around the finalisation (`Cache::lock('upload-complete:'.$session->id, 120)`, the same primitive `OAuthCodeFlowBroker` already uses) and fail a second caller fast with a validation error. The lock's TTL releases the claim if a completion dies mid-flight, so a genuine retry still works — unlike a persisted status flag, which would strand the session. The lock is released in a `finally`, so every existing failure path (missing parts, the quota and size checks) stays retryable. The body moves to a `finalise()` helper so `complete()` reads as *auth + lock + finalise*; the helper is a pure move, no line of it changed.

The refusal message ships translated into all sixteen languages, wording aligned with each file's existing upload strings.

### Tests

Added to `tests/Feature/Files/ChunkedUploadsTest.php`: with the session's lock already held (standing in for an in-flight completion), a second `complete()` is refused (422, no `File` row, session preserved); once the lock is released, completing works. Against the unlocked controller the test fails — the second complete sails through with 200. (The test cache store is `array`, which implements `LockProvider`; production uses the Redis store with its dedicated lock connection.)

Full suite passes (1823 passed / 1 skipped), PHPStan level 8 clean.