### PR TITLE
Accept only notification types that can actually notify

### DIFF
--- a/app/Modules/Notifications/Http/Controllers/NotificationPreferencesController.php
+++ b/app/Modules/Notifications/Http/Controllers/NotificationPreferencesController.php
@@ -7,9 +7,11 @@ namespace App\Modules\Notifications\Http\Controllers;
 use App\Http\Controllers\Controller;
 use App\Modules\Notifications\NotificationPreference;
 use App\Modules\Notifications\NotificationPreferences;
+use App\Modules\Notifications\NotificationTypeDefinition;
 use App\Modules\Notifications\NotificationTypeRegistry;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -30,21 +32,12 @@ class NotificationPreferencesController extends Controller
         $user = $request->user();
         assert($user !== null);
 
-        // Only types that can email at all have anything to opt in or out
-        // of — a pure in-app type has no toggle to show. Either route
-        // counts: Notifier sending a mail class directly, or the digest
-        // buffering and sending one.
-        $emailable = array_values(array_filter(
-            $this->types->all(),
-            fn ($type) => $type->mailNotification !== null || $type->digestMail !== null,
-        ));
-
         return Inertia::render('settings/notifications', [
-            'types' => array_map(fn ($type) => [
+            'types' => array_map(fn (NotificationTypeDefinition $type): array => [
                 'key' => $type->key,
                 'label' => $type->label,
                 'email_enabled' => $this->preferences->emailEnabledFor($user, $type),
-            ], $emailable),
+            ], $this->emailable()),
         ]);
     }
 
@@ -55,7 +48,11 @@ class NotificationPreferencesController extends Controller
 
         $validated = $request->validate([
             'preferences' => ['required', 'array'],
-            'preferences.*.type' => ['required', 'string'],
+            // Against the registry, not merely "a string": a preference row
+            // for a type nothing can send is a row that will never be read
+            // again, and the screen only ever offers back what edit() gave
+            // it.
+            'preferences.*.type' => ['required', 'string', Rule::in($this->emailableKeys())],
             'preferences.*.email_enabled' => ['required', 'boolean'],
         ]);
 
@@ -67,5 +64,32 @@ class NotificationPreferencesController extends Controller
         }
 
         return back();
+    }
+
+    /**
+     * Only types that can email at all have anything to opt in or out of —
+     * a pure in-app type has no toggle to show. Either route counts:
+     * Notifier sending a mail class directly, or the digest buffering and
+     * sending one.
+     *
+     * Shared by both halves on purpose, so what the screen offers and what
+     * it accepts back cannot drift apart.
+     *
+     * @return list<NotificationTypeDefinition>
+     */
+    private function emailable(): array
+    {
+        return array_values(array_filter(
+            $this->types->all(),
+            fn (NotificationTypeDefinition $type): bool => $type->mailNotification !== null || $type->digestMail !== null,
+        ));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function emailableKeys(): array
+    {
+        return array_map(fn (NotificationTypeDefinition $type): string => $type->key, $this->emailable());
     }
 }

--- a/tests/Feature/Notifications/NotificationPreferencesTest.php
+++ b/tests/Feature/Notifications/NotificationPreferencesTest.php
@@ -59,6 +59,46 @@ test('updating preferences via the settings page persists a row per type', funct
     expect($row->email_enabled)->toBeFalse();
 });
 
+test('a preference for a type nothing has registered is refused', function () {
+    $client = User::factory()->client()->create();
+
+    $this->actingAs($client)->put('/settings/notifications', [
+        'preferences' => [
+            ['type' => 'not.a.real.type', 'email_enabled' => false],
+        ],
+    ])->assertInvalid(['preferences.0.type']);
+
+    expect(NotificationPreference::query()->where('user_id', $client->id)->exists())->toBeFalse();
+});
+
+test('a preference for a registered type that cannot email is refused', function () {
+    $client = User::factory()->client()->create();
+
+    // A real key, but one the screen never offers a toggle for — a row for
+    // it could never change what anybody receives.
+    $this->actingAs($client)->put('/settings/notifications', [
+        'preferences' => [
+            ['type' => 'client_uploaded', 'email_enabled' => true],
+        ],
+    ])->assertInvalid(['preferences.0.type']);
+
+    expect(NotificationPreference::query()->where('user_id', $client->id)->exists())->toBeFalse();
+});
+
+test('one bad key rejects the whole submission, leaving no half-applied state', function () {
+    $client = User::factory()->client()->create();
+
+    $this->actingAs($client)->put('/settings/notifications', [
+        'preferences' => [
+            ['type' => 'group.membership_approved', 'email_enabled' => false],
+            ['type' => 'not.a.real.type', 'email_enabled' => false],
+        ],
+    ])->assertInvalid(['preferences.1.type']);
+
+    // Validation runs before the loop, so the good row is not written either.
+    expect(NotificationPreference::query()->where('user_id', $client->id)->exists())->toBeFalse();
+});
+
 test('the master switch off suppresses email regardless of an explicit per-user opt-in', function () {
     Notification::fake();
     app(Settings::class)->set(Setting::EmailNotificationsEnabled, false);


### PR DESCRIPTION
## The problem

`NotificationPreferencesController::update()` validated the type key as nothing
more than a string:

```php
$validated = $request->validate([
    'preferences' => ['required', 'array'],
    'preferences.*.type' => ['required', 'string'],
    'preferences.*.email_enabled' => ['required', 'boolean'],
]);

foreach ($validated['preferences'] as $preference) {
    NotificationPreference::query()->updateOrCreate(
        ['user_id' => $user->id, 'type' => $preference['type']],
        ['email_enabled' => $preference['email_enabled']],
    );
}
```

So `{"preferences":[{"type":"anything at all","email_enabled":false}]}` is
accepted and written.

Nothing ever reads it back. `NotificationPreferences::emailEnabledFor()` is
asked about a `NotificationTypeDefinition` the registry holds, so a row stored
under a key the registry does not know is invisible from that moment on — it
cannot be seen, explained, or removed through the interface.

**This is not an authorization hole.** `user_id` comes from the session and
never from the payload, so there is no way to write into somebody else's
settings. The cost is a table that quietly accumulates unreachable rows.

## The fix

`edit()` already knew the right answer — it filters the registry down to the
types that can email by either route and renders exactly those as toggles:

```php
$type->mailNotification !== null || $type->digestMail !== null
```

That list is now derived once and used by both halves, so what the screen offers
and what it accepts back cannot drift apart:

```php
'preferences.*.type' => ['required', 'string', Rule::in($this->emailableKeys())],
```

Rejecting a **registered but unmailable** key is deliberate rather than
incidental. `client_uploaded` is the one in tree, and `FilesServiceProvider`
explains why it has no mail companion:

> this event is already sent separately, to whatever raw addresses
> `Setting::AdminNotificationEmails` lists … Routing it through Notifier's mail
> dispatch too would risk double-emailing any staff member who happens to also
> be in that address list.

A preference row for it could never change what anybody receives, so accepting
one would only be storing a promise the app cannot keep.

### Not changed (deliberate)

- **The screen and its payload shape.** `settings/notifications.tsx` builds its
  payload by mapping over the `types` prop this controller gave it, so it cannot
  produce a key the rule rejects — the 422 is unreachable from the interface,
  and only a hand-rolled request meets it. No frontend change is needed and none
  is made.
- **Existing rows.** No migration prunes what earlier submissions may have
  written; that would be a data change riding along with a validation fix, and
  the rows are inert.
- **`email_enabled`.** Already `['required','boolean']`.

## Tests

Three cases added to `tests/Feature/Notifications/NotificationPreferencesTest.php`:
an unregistered key, a registered-but-unmailable key (`client_uploaded`), and a
mixed submission where one bad key rejects the whole thing rather than
half-applying it.

Counter-check: all three fail against the unfixed controller — the row is
written and `assertInvalid` finds no error. The five existing cases in that file
pass either way.

Full suite passes (1838 passed / 2 skipped), PHPStan level 8 clean.