### PR TITLE
Don't name a subfolder to a client who cannot open it

### DIFF
--- a/app/Modules/Files/Http/Controllers/MyFilesController.php
+++ b/app/Modules/Files/Http/Controllers/MyFilesController.php
@@ -122,15 +122,23 @@ class MyFilesController extends Controller
 
             // Subfolders: at root, every visible folder whose parent isn't
             // itself visible (top of each shared subtree, or a client-owned
-            // folder with no visible parent); inside a folder, its direct
-            // children.
+            // folder with no visible parent); inside a folder, the visible
+            // ones among its direct children.
+            //
+            // Both branches narrow to $visibleIds. Being handed a folder is
+            // not permission to read the names of everything filed inside
+            // it: a client-created folder is visible through created_by,
+            // which says nothing about a subfolder staff later put there.
             if ($current === null) {
                 $folders = Folder::query()
                     ->whereIn('id', $visibleIds)
                     ->where(fn ($q) => $q->whereNull('parent_id')->orWhereNotIn('parent_id', $visibleIds))
                     ->orderBy('name');
             } else {
-                $folders = Folder::query()->where('parent_id', $current->id)->orderBy('name');
+                $folders = Folder::query()
+                    ->whereIn('id', $visibleIds)
+                    ->where('parent_id', $current->id)
+                    ->orderBy('name');
             }
 
             // Files: inside a folder, that folder's files; at root, only

--- a/tests/Feature/Files/ClientFoldersTest.php
+++ b/tests/Feature/Files/ClientFoldersTest.php
@@ -223,3 +223,34 @@ test('a loose file inside a client-created folder shows nested, not at root', fu
         fn (AssertableInertia $page) => $page->has('files', 1)->where('files.0.name', 'note'),
     );
 });
+
+test('a subfolder the client cannot enter is not named to them either', function () {
+    $client = User::factory()->client()->create();
+    $this->actingAs($client)->post('/my-folders', ['name' => 'My Uploads'])->assertRedirect();
+    $mine = Folder::query()->where('name', 'My Uploads')->sole();
+
+    // Staff files something of another client's away inside it. The client
+    // may open their own folder, but this subfolder was never shared with
+    // them — and its name alone would say that other client exists.
+    $this->actingAs($this->admin);
+    $hidden = makeStaffFolder('Northwind Traders - contracts', $mine);
+
+    $this->actingAs($client)->get('/my-files?folder='.$mine->id)->assertInertia(
+        fn (AssertableInertia $page) => $page->has('folders', 0),
+    );
+
+    // Entering it was already refused; the name was the whole leak.
+    $this->actingAs($client)->get('/my-files?folder='.$hidden->id)->assertNotFound();
+});
+
+test('a client browsing their own folder still sees the subfolders they may enter', function () {
+    $client = User::factory()->client()->create();
+    $this->actingAs($client)->post('/my-folders', ['name' => 'Parent'])->assertRedirect();
+    $parent = Folder::query()->where('name', 'Parent')->sole();
+    $this->actingAs($client)->post('/my-folders', ['name' => 'Child', 'parent_id' => $parent->id])->assertRedirect();
+
+    // The narrowing must not swallow the client's own nesting.
+    $this->actingAs($client)->get('/my-files?folder='.$parent->id)->assertInertia(
+        fn (AssertableInertia $page) => $page->has('folders', 1)->where('folders.0.name', 'Child'),
+    );
+});


### PR DESCRIPTION
## The problem

`MyFilesController::index()` builds the portal's folder list in two branches.
At the root it narrows to what the client may see; one level in, it does not:

```php
if ($current === null) {
    $folders = Folder::query()
        ->whereIn('id', $visibleIds)
        ->where(fn ($q) => $q->whereNull('parent_id')->orWhereNotIn('parent_id', $visibleIds))
        ->orderBy('name');
} else {
    $folders = Folder::query()->where('parent_id', $current->id)->orderBy('name');
}
```

So browsing into a folder lists **every** direct child of it, whether or not
the client may see that child. Opening one is still refused — `$current` is
resolved through `Folder::query()->visibleToClient($client)` and 404s otherwise
— so what escapes is the folder's **name**, not its contents.

## Why this is the file's own rule

`$visibleIds` is computed once at the top of the method and used in three
places. Two of them narrow correctly; this is the third:

- the root branch, above;
- the breadcrumb — `$this->breadcrumbs->visible($current, $visibleIds)`, whose
  docblock says a client "has no business seeing the names of the folders above
  it";
- the nested branch, which ignored it.

And the class docblock states the guarantee outright:

> Group and internal folder names never leak: a file assigned directly inside an
> unshared folder appears loose.

That is the promise. The nested branch did not keep it.

## When it is reachable

Not on a shared subtree. `Folder::scopeVisibleToClient` matches anything under a
shared folder by path prefix, so inside a folder staff shared with the client,
every child is visible anyway and nothing leaks.

It needs a folder that is visible for the *other* reason — `created_by` — which
is what `POST /my-folders` produces for a client holding `create_own_folders`
and `upload`. That folder being theirs says nothing about a subfolder staff
later filed inside it. A client browsing their own upload folder would read the
name of anything staff put there, including a folder named for another
customer.

The harm is a name, which this codebase already treats as worth protecting;
`VisibleCommentScope` makes the same argument about the same kind of
disclosure — it is "what stops one customer learning that another exists".

It is also not only a disclosure. Folders and files share one 25-row page
window, and the listing is ordered by name, so the folders a client cannot open
compete with the ones they can. Measured on a client folder holding twenty of
their own subfolders and twenty staff ones they may not see:

| first page | folders listed | theirs | not theirs |
|---|---|---|---|
| before | 25 | 5 | 20 |
| after | 20 | 20 | 0 |

Fifteen of the client's own folders were pushed off the first page by folders
that answer 404. The fix also makes that page slightly cheaper — 38 queries
against 43 — because it stops assembling rows nobody may act on.

## The fix

The nested branch narrows to `$visibleIds`, like the other two uses:

```php
$folders = Folder::query()
    ->whereIn('id', $visibleIds)
    ->where('parent_id', $current->id)
    ->orderBy('name');
```

### Not changed (deliberate)

- **Files.** The nested branch's file query already starts from
  `File::query()->visibleToClient($client)`; only folders were unfiltered.
- **The breadcrumb.** Already trims to the first visible ancestor, and the
  portal already calls `visible()` rather than `for()`. Checked, not touched.
- **The flat branch** (search, category or owner filter). Already narrows both
  folders and files through `visibleToClient`.
- **The prop shape.** `folders` is the same list of the same objects; only which
  ones qualify changes, which is the behaviour being corrected. Themes reading
  the prop need no change. (The class docblock asks the reader to consult
  `docs/theming-files-checklist.md` first — worth knowing that file is not in
  the repo.)
- **Entering a folder.** Already refused; this changes what is listed, not what
  is reachable.

## Tests

Two cases in `tests/Feature/Files/ClientFoldersTest.php`: a staff subfolder
inside a client-created folder is neither listed nor enterable, and — the other
direction — a client browsing their own folder still sees the subfolders they
created there, so the narrowing does not swallow legitimate nesting.

Counter-check, stated plainly: **one of the two goes red** against the unfixed
code, listing the hidden folder where none should appear. The second passes
either way; it is a guard against over-filtering, not proof of the bug. The
twelve existing cases in that file pass in both directions.

Full suite passes (1837 passed / 2 skipped), PHPStan level 8 clean.