### PR TITLE
Delete a file's bytes when its transaction commits, not before

### DIFF
--- a/app/Modules/Files/Models/File.php
+++ b/app/Modules/Files/Models/File.php
@@ -105,7 +105,20 @@ class File extends Model
             // because it needs the row's own pointers intact.
             app(FileVersions::class)->detachOnDelete($file);
 
-            app(FileDiskCleanup::class)->delete($file);
+            // The bytes go once the transaction holding this row commits,
+            // not alongside the row itself. A cascade — a folder subtree,
+            // an account's content — deletes many rows in one transaction,
+            // and anything that rolls it back afterwards puts every row
+            // back while the bytes are already gone: a loss nothing can
+            // undo. Deferred, the worst case is bytes left on disk with no
+            // row, which OrphanFileScanner already finds and reports.
+            //
+            // Outside a transaction the callback runs immediately, so
+            // deleting one file is unchanged. Nested transactions only fire
+            // it at the outermost commit, which is the case this is for.
+            $file->getConnection()->afterCommit(
+                fn () => app(FileDiskCleanup::class)->delete($file)
+            );
         });
     }
 

--- a/tests/Feature/Files/FileDiskCleanupTest.php
+++ b/tests/Feature/Files/FileDiskCleanupTest.php
@@ -7,6 +7,7 @@ use App\Modules\Files\Models\File;
 use App\Modules\Files\Thumbnails\ImageAudience;
 use App\Modules\Files\Thumbnails\ImageRendition;
 use App\Modules\Files\Thumbnails\ThumbnailGenerator;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
@@ -82,6 +83,48 @@ test('a file stored on the external disk is deleted from that disk, not the loca
     $this->actingAs($this->admin)->delete("/files/{$file->id}")->assertRedirect();
 
     Storage::disk('files_external')->assertMissing($file->path);
+});
+
+// The row comes back on a rollback; the bytes have to still be under it.
+// Nothing restores them, so this is the one failure in the whole cleanup
+// path that cannot be repaired afterwards.
+test('a transaction that rolls back leaves the bytes where they were', function () {
+    $file = makeStoredFile();
+
+    try {
+        DB::transaction(function () use ($file): void {
+            $file->delete();
+
+            throw new RuntimeException('something later in the transaction failed');
+        });
+    } catch (RuntimeException) {
+        // The point of the test is what survives it.
+    }
+
+    expect(File::query()->find($file->id))->not->toBeNull();
+    Storage::disk('files')->assertExists($file->path);
+});
+
+// The shape an account deletion has: content disposal runs in its own
+// transaction, nested as a savepoint inside the caller's, and the write
+// that fails afterwards belongs to the caller.
+test('an outer rollback leaves the bytes even after the inner transaction committed', function () {
+    $file = makeStoredFile();
+
+    try {
+        DB::transaction(function () use ($file): void {
+            DB::transaction(function () use ($file): void {
+                $file->delete();
+            });
+
+            throw new RuntimeException('the account write after it failed');
+        });
+    } catch (RuntimeException) {
+        // Same.
+    }
+
+    expect(File::query()->find($file->id))->not->toBeNull();
+    Storage::disk('files')->assertExists($file->path);
 });
 
 test('a storage failure while cleaning up disk bytes never blocks the file from being deleted', function () {


### PR DESCRIPTION
## The problem

`File::booted()` cleans up the disk the moment a row is deleted:

```php
static::deleted(function (File $file): void {
    app(FileVersions::class)->detachOnDelete($file);

    app(FileDiskCleanup::class)->delete($file);
});
```

For a single file that is exactly right. But two paths delete files **inside a
transaction**, and both of them delete many:

```php
// FolderService::delete() — the folder, its whole subtree, and every file in it
DB::transaction(function () use ($folder): void {
    $subtreeIds = /* … */;
    File::query()->whereIn('folder_id', $subtreeIds)->get()->each->delete();
    Folder::query()->whereIn('id', $subtreeIds)->get()->each->delete();
});

// DeletedAccountContent::cascadeDelete() — everything an account uploaded
DB::transaction(function () use ($user): array {
    $files = File::query()->where('uploaded_by', $user->id)->get();
    $files->each->delete();
    /* … folders, deepest-first … */
});
```

Anything that rolls either transaction back puts every row back — and the bytes
are already gone. A transaction exists to make a set of writes undoable;
removing the bytes was the one write in that set that nothing can undo.

Both are reachable as they stand, and the trigger does not have to be exotic.
The `deleted` hook runs per file, and it does database work — `detachOnDelete()`
repairs the version chain, which means freeing this row's claim on
`previous_file_id`'s **unique** slot before the successor takes it. So a cascade
interleaves:

```
file 1:  detach (writes) → bytes deleted
file 2:  detach (writes) → bytes deleted
…
file 50: detach throws   → the whole transaction rolls back
```

Rows 1 to 49 come back. Their bytes do not. A unique-constraint violation on an
unexpected chain state is enough, and so is a deadlock or a lock-wait timeout,
which a cascade over a large subtree is a good way to earn. Nothing outside
these two methods has to go wrong.

## Which direction is safe

The two failure modes are not equal:

- bytes deleted, rows restored — the rows now point at nothing, every download
  404s, and no amount of retrying brings the file back;
- rows deleted, bytes left — orphaned bytes on disk, which `OrphanFileScanner`
  already exists to find and report.

One is recoverable and already has a tool pointed at it. The other is not
recoverable at all.

## The fix

```php
$file->getConnection()->afterCommit(
    fn () => app(FileDiskCleanup::class)->delete($file)
);
```

Three properties worth stating, because the fix would be wrong without any of
them:

- **Outside a transaction nothing changes.** `DatabaseTransactionsManager::addCallback()`
  invokes the callback immediately when no transaction is pending, so deleting
  one file still removes its bytes in the same request, synchronously.
- **Nested transactions only fire at the outermost commit.** `commit()` returns
  early unless the new transaction level is `0`, so a savepoint committing
  inside a larger transaction does not release the bytes. These paths already
  nest — `detachOnDelete()` opens its own transaction inside the cascade's — so
  this matters today, not only if the account-deletion PR lands and adds a
  third level.
- **The connection is the row's own**, not whichever one happens to be default.

### Not changed (deliberate)

- **`detachOnDelete` stays inside the transaction.** It repairs the version
  chain's `previous_file_id` pointers — database work that must roll back with
  everything else, and must still run before the row's own pointers change.
- **`FileDiskCleanup`'s tolerance of storage failures.** It still swallows and
  logs, for the reason its docblock gives: a rotated external disk must not turn
  a delete into a 500. Deferring it does not change that, and an existing test
  pins it.
- **Notifications dispatched inside a transaction.** `FileVersions::link()`
  reaches `FileSharing::assign()` through `moveAssignmentsToRoot()` while its
  transaction is open, so a rollback there — and `link()` catches
  `UniqueConstraintViolationException` explicitly, so that rollback is a
  documented path — leaves "file shared" mail already sent. Same shape as this,
  different blast radius and different tests; deliberately not bundled in.
- **Queued work.** Nothing here moves onto the queue; the callback runs in the
  same request, just after the commit.

## Merge note

Independent of #1688 (the account-deletion one), and deliberately not stacked on
it: this changes `File` and its own test, that one changes the four `destroy()`
controllers, and the bug fixed here is reachable on `main` as it stands through
each path's own transaction.

They do meet, though. That PR wraps each `destroy()` in one transaction, which
nests `cascadeDelete()`'s transaction inside a larger one and so widens the
window this closes — its description names this as the separate change to make.
If both land, either order works; this one landing first simply means the other
never opens the window in the first place.

## Tests

Two cases in `tests/Feature/Files/FileDiskCleanupTest.php`: a transaction that
rolls back after deleting a file leaves the bytes in place, and the same with
the delete nested in an inner transaction that committed before the outer one
failed — the account-deletion shape.

Counter-check: **both go red** against the unfixed model, with the bytes gone
where the row had come back.

The five existing cases in that file are the other half of the argument and pass
unchanged — in particular "deleting a folder cascades disk cleanup to every file
inside it", which goes through `FolderService::delete()`'s transaction and shows
the deferred cleanup still runs on commit.

Full suite passes (1837 passed / 2 skipped), PHPStan level 8 clean.