### PR TITLE
Hand over a public download from the disk the file is on

### DIFF
--- a/app/Modules/Groups/Http/Controllers/PublicGroupsController.php
+++ b/app/Modules/Groups/Http/Controllers/PublicGroupsController.php
@@ -326,7 +326,7 @@ class PublicGroupsController extends Controller
         return route('public.preview', [$publicSlug, $file->slug]);
     }
 
-    public function download(string $publicSlug, File $file): Response
+    public function download(string $publicSlug, File $file): Response|RedirectResponse
     {
         $this->guardSlug($publicSlug);
 
@@ -340,11 +340,6 @@ class PublicGroupsController extends Controller
 
         $this->activity->log(Action::PublicFileDownloaded, subject: $file);
 
-        return response('', 200, [
-            'X-Accel-Redirect' => '/protected-files/'.$file->path,
-            'Content-Type' => $file->mime_type,
-            'Content-Disposition' => ContentDisposition::attachment($file->original_name),
-            'Content-Length' => (string) $file->size,
-        ]);
+        return $this->bytes->attachment($file);
     }
 }

--- a/tests/Feature/Groups/PublicGroupsTest.php
+++ b/tests/Feature/Groups/PublicGroupsTest.php
@@ -191,13 +191,49 @@ test('download serves a public file and 404s a non-public one regardless of grou
     $notPublic = publicListingFile(['name' => 'Not Downloadable', 'public' => false]);
     $this->actingAs($staff)->post("/files/{$notPublic->id}/assignments", ['type' => 'group', 'id' => $group->id]);
 
+    // The whole header set, not only the path: local delivery is what this
+    // route used to build by hand, and moving it behind StoredFileResponse
+    // has to leave a local install's response exactly as it was.
     $this->get("/public/files/{$public->slug}/download")
         ->assertOk()
-        ->assertHeader('X-Accel-Redirect', '/protected-files/'.$public->path);
+        ->assertHeader('X-Accel-Redirect', '/protected-files/'.$public->path)
+        ->assertHeader('Content-Type', 'application/pdf')
+        ->assertHeader('Content-Disposition', 'attachment; filename="report.pdf"')
+        ->assertHeader('Content-Length', (string) $public->size);
 
     expect(ActivityLog::query()->where('action', Action::PublicFileDownloaded)->where('subject_name', 'Downloadable')->exists())->toBeTrue();
 
     $this->get("/public/files/{$notPublic->slug}/download")->assertNotFound();
+});
+
+test('a public download of an externally stored file hands out a presigned url, not an nginx path', function () {
+    // The bug this covers: this route answered every download with
+    // X-Accel-Redirect regardless of the file's disk, so a public download
+    // of an externally stored file pointed nginx at a path nothing ever
+    // wrote. Its two neighbours on this same controller, thumbnail() and
+    // preview(), were moved onto the shared delivery object; download()
+    // was left building the response itself.
+    Storage::fake('files_external');
+    Storage::disk('files_external')->buildTemporaryUrlsUsing(
+        fn (string $path, $expiration, array $options) => 'https://storage.example.test/'.$path.'?disposition='.urlencode($options['ResponseContentDisposition'] ?? '')
+    );
+
+    $file = publicListingFile(['name' => 'Externally Stored', 'disk' => 'files_external']);
+
+    $response = $this->get(route('public.download', ['public', $file->slug]));
+
+    $response->assertRedirect();
+    $response->assertHeaderMissing('X-Accel-Redirect');
+
+    $target = $response->headers->get('Location');
+    expect($target)->toStartWith('https://storage.example.test/'.$file->path)
+        // The filename has to survive into the signed URL, or the download
+        // arrives named after the storage key.
+        ->and(urldecode((string) $target))->toContain('attachment; filename="report.pdf"');
+
+    // Delivery moved; the checks in front of it did not. The download is
+    // still logged, which is also what the download limit counts.
+    expect(ActivityLog::query()->where('action', Action::PublicFileDownloaded)->where('subject_name', 'Externally Stored')->exists())->toBeTrue();
 });
 
 test('an expired public file 404s on its detail, thumbnail, and download routes, and drops out of the standalone listing', function () {


### PR DESCRIPTION
## The problem

`PublicGroupsController::download()` builds its response by hand and hardcodes
the local disk's nginx location
(`app/Modules/Groups/Http/Controllers/PublicGroupsController.php:343-348`):

```php
return response('', 200, [
    'X-Accel-Redirect' => '/protected-files/'.$file->path,
    'Content-Type' => $file->mime_type,
    'Content-Disposition' => ContentDisposition::attachment($file->original_name),
    'Content-Length' => (string) $file->size,
]);
```

`/protected-files/` is nginx's `internal` location for the local `files` disk.
`$file->disk` is never read. On an install with external storage switched on,
this hands nginx a path nothing ever wrote and the download fails — while the
same file downloads correctly from the file manager, downloads correctly from a
share link, and previews correctly from this very page, because all three go
through the object that knows the rule.

One method sits behind two surfaces. `public.download` is what
`InteractsWithPublicListing::fileProps()` puts in every listing row's
`download_url` (`:56`), and `PublicFoldersController` uses that trait (`:38`),
so a public folder page reaches the same method as a public group page.

## Not a new rule — this file's own rule

`5754016` ("Read a file from the disk it is actually on, everywhere") moved this
controller's `thumbnail()` and `preview()` onto `StoredFileResponse` and left
`download()`, the last method in the same class, building its own response. The
object is already injected here:

```php
// PublicGroupsController.php:85
private readonly StoredFileResponse $bytes,
```

and `preview()`, two methods above, already uses it:

```php
// PublicGroupsController.php:303
return $this->bytes->inline($file);
```

That commit's own message names exactly this shape:

> Neither is a new rule. FileDownloadController and FileThumbnailController
> already did it right, which is the actual finding: the knowledge was sitting in
> a private method on one class and inline in another, so the next caller could
> not inherit it and did not.

The knowledge is an object now. This is the one call site that was not moved onto
it, and it sits forty lines below one that was.

## The fix

```diff
-    public function download(string $publicSlug, File $file): Response
+    public function download(string $publicSlug, File $file): Response|RedirectResponse
     {
         …
-        return response('', 200, [
-            'X-Accel-Redirect' => '/protected-files/'.$file->path,
-            'Content-Type' => $file->mime_type,
-            'Content-Disposition' => ContentDisposition::attachment($file->original_name),
-            'Content-Length' => (string) $file->size,
-        ]);
+        return $this->bytes->attachment($file);
     }
```

`attachment()` is the method `FileDownloadController:45` and
`PublicShareController:105` already call.

**Nothing changes for a local install.** `StoredFileResponse::make()` emits the
same four headers, with the same values, through the same
`ContentDisposition::attachment()` call:

```php
// StoredFileResponse.php:63-68
return response('', 200, [
    'X-Accel-Redirect' => '/protected-files/'.$file->path,
    'Content-Type' => $file->mime_type,
    'Content-Disposition' => $disposition,
    'Content-Length' => (string) $file->size,
]);
```

The return type widens to `Response|RedirectResponse` because a non-local disk
answers with a redirect to a short-lived presigned URL carrying the disposition —
the signature `preview()` next door already declares.

### Not changed (deliberate)

- **The guards in front of delivery.** `guardSlug()`, the
  `isEffectivelyPublic()`/`isExpired()` 404, the `DownloadAllowance` 403 and the
  `PublicFileDownloaded` log all stay exactly where they were. Only the last line
  moved, and the log matters: `DownloadAllowance`'s counting comes from the
  activity log via `File::downloads()`, so a download that stopped being logged
  would stop counting against a limit.
- **`thumbnail()`'s own `X-Accel-Redirect` (`:271`).** That path is the *cached
  rendition*, which is written to the local `files` disk regardless of where the
  source lives — the distinction `5754016` drew when it fixed the source lookup
  on the line above. Same for `FileThumbnailController::serve():225`.
- **`ZipDownloadsController::download():147`.** A built archive is always written
  to the local disk (`BuildZipDownloadJob:96-97`), so its X-Accel path is not a
  disk assumption about a stored file.
- **`LocalSourceFile:38` and `BuildZipDownloadJob::localPathFor():216`.** These
  are the only other places that resolve a stored file's bytes to a local path,
  and both already branch on `$file->disk === 'files'`.

## Tests

In `tests/Feature/Groups/PublicGroupsTest.php`:

- **New:** a public download of a file on `files_external` redirects to the
  presigned URL, sends no `X-Accel-Redirect`, carries the filename through into
  the signed URL's disposition, and is still logged. Same `Storage::fake()` +
  `buildTemporaryUrlsUsing()` shape as the share-link case added in `5754016`.
- **Extended:** the existing local-disk case now asserts `Content-Type`,
  `Content-Disposition` and `Content-Length` alongside the `X-Accel-Redirect` path
  it already checked.

Counter-check: the new case **goes red** against the unfixed controller (`200`
with an `X-Accel-Redirect` where a redirect was expected), and the extended
local-disk case **passes both before and after**, so "unchanged for a local
install" is pinned in both directions rather than argued.

Full suite passes (1848 passed / 2 skipped), PHPStan level 8 clean.