### PR TITLE
Hold the folder an upload names to the same library boundary as everything else

### DIFF
--- a/app/Modules/Files/Http/Controllers/FilesController.php
+++ b/app/Modules/Files/Http/Controllers/FilesController.php
@@ -93,6 +93,17 @@ class FilesController extends Controller
         $user = $request->user();
         assert($user !== null);
 
+        // The check the other two upload paths make and this one did not:
+        // a folder outside the uploader's library is not a place to put a
+        // file. Without it this route reached any folder on the
+        // installation, and File::scopeVisibleToClient then hands the file
+        // to whoever that folder's subtree is shared with.
+        $folder = isset($validated['folder_id'])
+            ? Folder::query()->whereKey($validated['folder_id'])->first()
+            : null;
+
+        abort_unless(Folder::uploadableBy($user, $folder), 403);
+
         if (! app(UploadExtensionPolicy::class)->isAllowed($user, $upload->getClientOriginalName())) {
             throw ValidationException::withMessages([
                 'file' => __('This file type is not allowed for upload.'),
@@ -197,7 +208,11 @@ class FilesController extends Controller
                     'url' => route('files.edit', $member, false),
                     'is_current' => $member->id === $file->id,
                 ])->values(),
-            'folder_options' => Folder::query()->orderBy('path')->orderBy('name')->get()
+            // Narrowed like every other folder listing: an unscoped staff
+            // member gets the whole tree, a client-scoped one only their
+            // own. Unfiltered this handed a scoped staffer every folder
+            // name and id on the installation.
+            'folder_options' => $this->scope->folders($viewer)->orderBy('path')->orderBy('name')->get()
                 ->map(fn (Folder $folder): array => ['id' => $folder->id, 'name' => $folder->name])->all(),
             'categories' => Category::query()->orderBy('name')->get(['id', 'name', 'color'])
                 ->map(fn (Category $category): array => ['id' => $category->id, 'name' => $category->name, 'color' => $category->color])->all(),

--- a/app/Modules/Files/Http/Controllers/FoldersController.php
+++ b/app/Modules/Files/Http/Controllers/FoldersController.php
@@ -186,7 +186,11 @@ class FoldersController extends Controller
             'expired' => $expired,
             'categories' => Category::query()->orderBy('name')->get(['id', 'name', 'color'])
                 ->map(fn (Category $category): array => ['id' => $category->id, 'name' => $category->name, 'color' => $category->color])->all(),
-            'folder_options' => Folder::query()->orderBy('path')->orderBy('name')->get()
+            // Narrowed like every other folder listing on this screen: an
+            // unscoped staff member gets the whole tree, a client-scoped
+            // one only their own. Unfiltered this handed a scoped staffer
+            // every folder name and id on the installation.
+            'folder_options' => $this->scope->folders($user)->orderBy('path')->orderBy('name')->get()
                 ->map(fn (Folder $folder): array => ['id' => $folder->id, 'name' => $folder->name])->all(),
             'can_create_folders' => $user->can('create_own_folders'),
             'can_upload' => $user->can('upload'),

--- a/app/Modules/Files/Models/Folder.php
+++ b/app/Modules/Files/Models/Folder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Modules\Files\Models;
 
 use App\Models\User;
+use App\Modules\Files\Access\StaffLibraryScope;
 use App\Modules\Groups\Models\Group;
 use App\Support\Concerns\HasUniqueSlug;
 use Illuminate\Database\Eloquent\Builder;
@@ -152,11 +153,19 @@ class Folder extends Model
 
     /**
      * Whether $user may upload a new file directly into $folder (null =
-     * loose at the root, always allowed). Staff already validate folder_id
-     * through FilesController's own flow — this is the client-facing
-     * check, used by ChunkedUploadsController: the client owns the
-     * folder, or it's a public folder that opts into client uploads and
-     * the client's role permits uploading into public folders at all.
+     * loose at the root, always allowed).
+     *
+     * Staff are held to the library boundary they are held to everywhere
+     * else: an unscoped staff member may use any folder, a client-scoped
+     * one only the folders StaffLibraryScope already shows them. This is
+     * the only place that decides it: every upload path — the web form,
+     * the API and the chunked flow the browser actually posts to — comes
+     * through here rather than checking folder_id for itself.
+     *
+     * For a client this is unchanged, and is still the whole of the
+     * check: they own the folder, or it is a public folder that opts into
+     * client uploads and their role permits uploading into public folders
+     * at all.
      */
     public static function uploadableBy(User $user, ?self $folder): bool
     {
@@ -165,7 +174,7 @@ class Folder extends Model
         }
 
         if ($user->isStaff()) {
-            return true;
+            return app(StaffLibraryScope::class)->allowsFolder($user, $folder);
         }
 
         return $folder->isOwnedBy($user)

--- a/tests/Feature/Files/UploadFolderScopeTest.php
+++ b/tests/Feature/Files/UploadFolderScopeTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Files\Folders\FolderService;
+use App\Modules\Files\Models\File;
+use App\Modules\Files\Models\Folder;
+use App\Modules\Identity\Permissions\Permission;
+use App\Modules\Identity\Permissions\SystemRole;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Testing\AssertableInertia;
+
+beforeEach(function () {
+    Storage::fake('files');
+    $this->admin = User::factory()->create();
+
+    // A folder shared with a client the manager below is not assigned to:
+    // in their library it does not exist, and everything in its subtree
+    // belongs to that other client.
+    $this->stranger = User::factory()->client()->create(['name' => 'Not Mine']);
+    $this->strangersFolder = makeFolder('Strangers');
+    $this->actingAs($this->admin)
+        ->post("/folders/{$this->strangersFolder->id}/assignments", ['type' => 'client', 'id' => $this->stranger->id]);
+
+    $this->mine = User::factory()->client()->create(['name' => 'Mine']);
+    $this->manager = User::factory()->role(SystemRole::ClientManager)->create();
+    $this->manager->assignedClients()->sync([$this->mine->id]);
+
+    $this->myFolder = makeFolder('Mine');
+    $this->actingAs($this->admin)
+        ->post("/folders/{$this->myFolder->id}/assignments", ['type' => 'client', 'id' => $this->mine->id]);
+});
+
+/** The opening request of the resumable flow, which is where the folder is named. */
+function beginChunkedUpload(int $folderId): array
+{
+    return ['filename' => 'resumable.pdf', 'size' => 2048, 'type' => 'application/pdf', 'folder_id' => $folderId];
+}
+
+/** @return list<string> */
+function folderOptionNames(mixed $options): array
+{
+    return collect($options)->pluck('name')->all();
+}
+
+test('a scoped manager cannot upload into a folder outside their library over the web route', function () {
+    $this->actingAs($this->manager)->post('/files', [
+        'file' => UploadedFile::fake()->create('smuggled.pdf', 12, 'application/pdf'),
+        'name' => 'Smuggled',
+        'description' => '',
+        'folder_id' => $this->strangersFolder->id,
+    ])->assertForbidden();
+
+    expect(File::query()->where('name', 'Smuggled')->exists())->toBeFalse();
+});
+
+test('a scoped manager cannot upload into a folder outside their library over the API', function () {
+    $token = $this->manager->createToken('t', [Permission::Upload->value])->plainTextToken;
+
+    $this->withToken($token)->post('/api/v1/files', [
+        'file' => UploadedFile::fake()->create('smuggled.pdf', 12, 'application/pdf'),
+        'name' => 'Smuggled',
+        'folder_id' => $this->strangersFolder->id,
+    ], ['Accept' => 'application/json'])->assertForbidden();
+
+    expect(File::query()->where('name', 'Smuggled')->exists())->toBeFalse();
+});
+
+test('a scoped manager cannot open a chunked upload into a folder outside their library', function () {
+    // The production path for both surfaces: files/create.tsx posts here,
+    // not to files.store.
+    $this->actingAs($this->manager)
+        ->postJson('/uploads', beginChunkedUpload($this->strangersFolder->id))
+        ->assertForbidden();
+
+    $token = $this->manager->createToken('t', [Permission::Upload->value])->plainTextToken;
+
+    $this->withToken($token)
+        ->postJson('/api/v1/uploads', beginChunkedUpload($this->strangersFolder->id))
+        ->assertForbidden();
+});
+
+test('a file landing in that folder would be the stranger content, which is why the folder is the check', function () {
+    // The stranger is never assigned anything here. Landing a file inside
+    // a folder shared with them is the whole of it: File::scopeVisibleToClient
+    // reads the folder subtree, so the file is theirs the moment it is
+    // written, without an assignment row ever being touched. This is the
+    // outcome the three refusals above prevent.
+    $planted = uploadNamedFile($this->admin, 'planted', $this->strangersFolder->id);
+
+    expect(File::query()->whereKey($planted->id)->visibleToClient($this->stranger)->exists())->toBeTrue();
+});
+
+test('a scoped manager still uploads into a folder of their own client, on every path', function () {
+    $this->actingAs($this->manager)->post('/files', [
+        'file' => UploadedFile::fake()->create('ok.pdf', 12, 'application/pdf'),
+        'name' => 'Allowed',
+        'description' => '',
+        'folder_id' => $this->myFolder->id,
+    ])->assertRedirect();
+
+    expect(File::query()->where('name', 'Allowed')->value('folder_id'))->toBe($this->myFolder->id);
+
+    $this->actingAs($this->manager)->postJson('/uploads', beginChunkedUpload($this->myFolder->id))->assertOk();
+
+    // And their own folder, which is theirs by creation rather than
+    // through any client assignment.
+    $this->actingAs($this->manager);
+    $ownFolder = app(FolderService::class)->create('My Own', null);
+
+    $this->actingAs($this->manager)->postJson('/uploads', beginChunkedUpload($ownFolder->id))->assertOk();
+
+    // Token last: a bearer request swaps the default guard for the rest of
+    // the test, which a following session request cannot recover from.
+    $token = $this->manager->createToken('t', [Permission::Upload->value])->plainTextToken;
+
+    $this->withToken($token)->post('/api/v1/files', [
+        'file' => UploadedFile::fake()->create('ok.pdf', 12, 'application/pdf'),
+        'name' => 'Allowed via API',
+        'folder_id' => $this->myFolder->id,
+    ], ['Accept' => 'application/json'])->assertStatus(201);
+});
+
+test('an unscoped staff member reaches every folder exactly as before', function () {
+    $this->actingAs($this->admin)->post('/files', [
+        'file' => UploadedFile::fake()->create('ok.pdf', 12, 'application/pdf'),
+        'name' => 'Admin Upload',
+        'description' => '',
+        'folder_id' => $this->strangersFolder->id,
+    ])->assertRedirect();
+
+    expect(File::query()->where('name', 'Admin Upload')->value('folder_id'))->toBe($this->strangersFolder->id);
+
+    $this->actingAs($this->admin)->postJson('/uploads', beginChunkedUpload($this->strangersFolder->id))->assertOk();
+});
+
+test('the client side of uploadableBy is untouched', function () {
+    // The same helper answers for clients, whose branch is a different
+    // rule entirely: ownership, or a public folder opting into client
+    // uploads. A client is never client-scoped, so nothing the staff
+    // branch now asks can reach them. Both directions pinned.
+    $client = User::factory()->client()->create();
+
+    $this->actingAs($client);
+    $ownFolder = app(FolderService::class)->create('Client Folder', null);
+
+    expect(Folder::uploadableBy($client, $ownFolder))->toBeTrue()
+        ->and(Folder::uploadableBy($client, $this->strangersFolder))->toBeFalse();
+
+    $this->actingAs($client)->postJson('/uploads', beginChunkedUpload($ownFolder->id))->assertOk();
+    $this->actingAs($client)->postJson('/uploads', beginChunkedUpload($this->strangersFolder->id))->assertForbidden();
+});
+
+test('the folder pickers offer a scoped manager only their own folders', function () {
+    $this->actingAs($this->manager)->get('/files')->assertInertia(
+        fn (AssertableInertia $page) => $page->where(
+            'folder_options',
+            fn ($options) => in_array('Mine', folderOptionNames($options), true)
+                && ! in_array('Strangers', folderOptionNames($options), true),
+        ),
+    );
+
+    $file = uploadNamedFile($this->manager, 'mine-to-edit');
+
+    $this->actingAs($this->manager)->get("/files/{$file->id}")->assertInertia(
+        fn (AssertableInertia $page) => $page->where(
+            'folder_options',
+            fn ($options) => in_array('Mine', folderOptionNames($options), true)
+                && ! in_array('Strangers', folderOptionNames($options), true),
+        ),
+    );
+});
+
+test('an unscoped staff member still sees the whole tree in both pickers', function () {
+    $this->actingAs($this->admin)->get('/files')->assertInertia(
+        fn (AssertableInertia $page) => $page->where(
+            'folder_options',
+            fn ($options) => in_array('Mine', folderOptionNames($options), true)
+                && in_array('Strangers', folderOptionNames($options), true),
+        ),
+    );
+
+    $file = uploadNamedFile($this->admin, 'admins');
+
+    $this->actingAs($this->admin)->get("/files/{$file->id}")->assertInertia(
+        fn (AssertableInertia $page) => $page->where(
+            'folder_options',
+            fn ($options) => in_array('Mine', folderOptionNames($options), true)
+                && in_array('Strangers', folderOptionNames($options), true),
+        ),
+    );
+});


### PR DESCRIPTION
## The problem

`Folder::uploadableBy()` (`app/Modules/Files/Models/Folder.php:161`) answers
"may this user put a file in this folder". For staff it answered yes without
looking:

```php
public static function uploadableBy(User $user, ?self $folder): bool
{
    if ($folder === null) {
        return true;
    }

    if ($user->isStaff()) {
        return true;
    }

    return $folder->isOwnedBy($user)
        || ($folder->public && $folder->allow_client_uploads && $user->can('upload_to_public_folders'));
}
```

Its docblock said why that was thought to be safe:

> Staff already validate folder_id through FilesController's own flow — this
> is the client-facing check…

No upload path did. There are three, and between them they cover both
surfaces:

| path | what it checks | how `folder_id` is validated |
|---|---|---|
| `FilesController::store()` — `POST /files` | **nothing at all** | `['nullable','integer','exists:folders,id']` |
| `Api\FilesController::store()` — `:196` | `uploadableBy()`, i.e. yes | same |
| `ChunkedUploadsController::store()` — `:90` | `uploadableBy()`, i.e. yes | same |

The third is the one that matters most in practice. `routes/web.php:109-113`
says so itself: "No page posts here anymore — files/create.tsx uses the
chunked uploads.\* endpoints below", and those endpoints are shared by the
browser, the client portal and the API. `complete()` does not re-check the
folder either; it takes `$session->folder_id` as given.

`POST /files` still exists on every installation whatever the UI posts to,
which is why "no page posts here anymore" is not the same as "nothing posts
here anymore".

## What that gets you

A client-scoped staff member — the shipped **Client Manager** role, which is
`client_scoped` and carries `upload` — names any folder id and the file lands
inside a subtree shared with somebody else's client.

No assignment row is ever touched. `File::scopeVisibleToClient()`
(`File.php:320`) reads the folder subtree:

```php
->orWhereIn('folder_id', $visibleFolders)
```

so the file belongs to that client from the moment it is written. The
uploader keeps `edit_files` on their own upload, so they can rename it,
set an expiry, make it public — everything except see whose library they
put it in.

This is the boundary `StaffLibraryScope` states at the top of its own class:

> Every staff listing goes through here, and the policies consult
> `allowsFile()`/`allowsFolder()` so direct access (download, details, edit…)
> respects the same boundary.

and the one `ClientScopingTest:129` — *"a scoped manager can only share with
their assigned clients"* — exists to hold. Sharing is refused there and the
picker is filtered; uploading reached the same result without asking.

### Related to #1681, and not covered by it

#1681 closes the same class of hole in `update()`, web and API. These are
different call sites: `store()` on three paths, plus the picker below. If
#1681 lands, this one is still open — and vice versa. The two do not
conflict (`git merge-tree` is clean; #1681 touches `update()`, this touches
`store()` and `edit()`).

## The fix

The staff branch asks the question the rest of the library asks:

```php
if ($user->isStaff()) {
    return app(StaffLibraryScope::class)->allowsFolder($user, $folder);
}
```

`allowsFolder()` returns `true` for anyone who is not client-scoped, so for
an ordinary staff account nothing changes at all — not a query, not a
response. Fixing the helper rather than its callers is deliberate: the
helper *is* the guard on two of the three paths, and a guard that cannot say
no is how this happened. The third path gets the call it never had:

```php
$folder = isset($validated['folder_id'])
    ? Folder::query()->whereKey($validated['folder_id'])->first()
    : null;

abort_unless(Folder::uploadableBy($user, $folder), 403);
```

The alternative was to resolve the folder at each call site through
`$this->scope->folders($user)->findOrFail($folderId)`, the way `move():338`
and `bulkUpdate():401` do. That is the right shape for *those* two — they
already hold a `$user` and a folder id and nothing else — but here it would
leave `uploadableBy()` still returning an unconditional yes for staff, and
the next upload path added would inherit it. This way the rule is in one
place and every current and future caller gets it.

### Not changed (deliberate)

- **The client branch.** It is a different rule — ownership, or a public
  folder that opts into client uploads — and `MyFilesController:261,283`
  depends on it. A client is never `isClientScoped()` (that is
  `isStaff() && …`), so nothing the staff branch now asks can reach them.
  Both directions are pinned by a test.
- **403 rather than 404.** `move()` answers 404 because it resolves through
  the scoped query; these three answer 403 because that is what
  `uploadableBy()`'s existing call sites answer, and matching the two
  surviving guards mattered more than matching a different route.
- **`complete()`.** It uses the `folder_id` stored on the session, which
  `store()` now validates before the session exists. Re-checking there would
  be a second statement of the same rule.
- **`upload_to_public_folders` for staff.** Out of scope: this changes which
  folders a staff member may reach, not which permissions govern them.

## The picker that fed it the ids

`FoldersController:189` and `FilesController:200`, identical, both:

```php
'folder_options' => Folder::query()->orderBy('path')->orderBy('name')->get()
    ->map(fn (Folder $folder): array => ['id' => $folder->id, 'name' => $folder->name])->all(),
```

An unfiltered `Folder::query()` on two screens whose every other listing goes
through `$this->scope->folders($user)` — `FoldersController:100` for the tree
itself, `:124` for the current folder, `:424` for a new folder's parent. A
client-scoped staff member was handed every folder name and id on the
installation in the page props.

That is a disclosure on its own, and it is also what made the ids above
convenient rather than guessed. Both now read `$this->scope->folders($user)`,
which for unscoped staff is `Folder::query()` unchanged.

## Tests

`tests/Feature/Files/UploadFolderScopeTest.php`, nine cases: the three upload
paths refused, the same three still working for the manager's own client and
their own folder, unscoped staff untouched, the client branch pinned in both
directions, and both pickers narrowed and not narrowed for the two kinds of
staff. One more asserts the outcome the refusals prevent — that a file
planted in that folder really is visible to the other client.

Counter-check, stated plainly: against the unfixed code **four of the nine go
red** — `POST /files` answers **302** (uploaded), `POST /api/v1/files`
answers **201**, `POST /uploads` answers **200**, and the folder picker
contains the other client's folder. The other five hold without the fix; they
are regression guards for the behaviour that must not change, not proof of
the bug.

Full suite passes (1856 passed / 2 skipped), PHPStan level 8 clean.