### PR TITLE
Managing a client account is inside the same boundary as everything else about them

### DIFF
--- a/app/Modules/Clients/Http/Controllers/Api/ClientsController.php
+++ b/app/Modules/Clients/Http/Controllers/Api/ClientsController.php
@@ -16,6 +16,7 @@ use App\Modules\Clients\Models\ClientCustomField;
 use App\Modules\Clients\Models\ClientCustomFieldValue;
 use App\Modules\Clients\Notifications\ClientAccountEditedNotification;
 use App\Modules\Clients\Notifications\ClientWelcomeNotification;
+use App\Modules\Files\Access\StaffLibraryScope;
 use App\Modules\Files\DeletedAccountContent;
 use App\Modules\Identity\AccountContentDeletion;
 use App\Modules\Identity\Models\Role;
@@ -36,10 +37,10 @@ use Illuminate\Validation\Rules\Password;
  * Client accounts over the API.
  *
  * Clients are `users` rows with type = client, so every response here goes
- * through ClientResource's allowlist rather than the model. `abort_unless
- * ($client->isClient(), 404)` on each single-client route mirrors the web
- * controller: a staff account is not addressable through this surface even
- * by id.
+ * through ClientResource's allowlist rather than the model. guardTarget()
+ * on each single-client route mirrors the web controller: a staff account
+ * is not addressable through this surface even by id, and a client outside
+ * the caller's own reach is not either.
  *
  * Validation rules, custom-field handling and the deletion flow are the
  * web controller's, reused or mirrored field for field — a client created
@@ -54,6 +55,7 @@ class ClientsController extends Controller
         private readonly ClientStorageUsage $storageUsage,
         private readonly DeletedAccountContent $accountContent,
         private readonly AccountContentDeletion $accountDeletion,
+        private readonly StaffLibraryScope $scope,
     ) {}
 
     public function index(Request $request): AnonymousResourceCollection
@@ -79,9 +81,9 @@ class ClientsController extends Controller
         return ClientResource::collection($this->polling->paginate($request, $query, 'users'));
     }
 
-    public function show(User $client): ClientResource
+    public function show(Request $request, User $client): ClientResource
     {
-        abort_unless($client->isClient(), 404);
+        $this->guardTarget($request, $client);
 
         return $this->resourceFor($client);
     }
@@ -133,7 +135,7 @@ class ClientsController extends Controller
 
     public function update(Request $request, User $client): ClientResource
     {
-        abort_unless($client->isClient(), 404);
+        $this->guardTarget($request, $client);
 
         $validated = $request->validate([
             'name' => ['sometimes', 'string', 'max:255'],
@@ -203,9 +205,9 @@ class ClientsController extends Controller
      * in the activity log against the caller. Answers 204 whether or not a
      * second factor was actually in force.
      */
-    public function destroyTwoFactor(User $client, TwoFactorAdministration $twoFactor): JsonResponse
+    public function destroyTwoFactor(Request $request, User $client, TwoFactorAdministration $twoFactor): JsonResponse
     {
-        abort_unless($client->isClient(), 404);
+        $this->guardTarget($request, $client);
 
         $twoFactor->reset($client);
 
@@ -230,7 +232,7 @@ class ClientsController extends Controller
      */
     public function destroy(Request $request, User $client): JsonResponse
     {
-        abort_unless($client->isClient(), 404);
+        $this->guardTarget($request, $client);
 
         $validated = $this->accountDeletion->validate($request, $client);
 
@@ -242,6 +244,26 @@ class ClientsController extends Controller
         $this->accountDeletion->apply($validated, $client, $name);
 
         return response()->json(status: 204);
+    }
+
+    /**
+     * The API twin of the web controller's guard, and for the same reason:
+     * `edit_clients` is a permission, not a boundary. A token acts as its
+     * owner, so a client-scoped staff member's token reaches exactly the
+     * clients they do — the clients assigned to them — and no others.
+     *
+     * 404 rather than 403, like the isClient() check it absorbs: a client
+     * outside this token owner's reach should not be distinguishable from
+     * one that is not there.
+     */
+    private function guardTarget(Request $request, User $client): void
+    {
+        abort_unless($client->isClient(), 404);
+
+        $actor = $request->user();
+        assert($actor instanceof User);
+
+        abort_unless($this->scope->canAssignClient($actor, $client), 404);
     }
 
     private function resourceFor(User $client): ClientResource

--- a/app/Modules/Clients/Http/Controllers/ClientsController.php
+++ b/app/Modules/Clients/Http/Controllers/ClientsController.php
@@ -14,6 +14,7 @@ use App\Modules\Clients\Models\ClientCustomField;
 use App\Modules\Clients\Models\ClientCustomFieldValue;
 use App\Modules\Clients\Notifications\ClientAccountEditedNotification;
 use App\Modules\Clients\Notifications\ClientWelcomeNotification;
+use App\Modules\Files\Access\StaffLibraryScope;
 use App\Modules\Files\DeletedAccountContent;
 use App\Modules\Identity\AccountContentDeletion;
 use App\Modules\Identity\Models\Role;
@@ -44,6 +45,7 @@ class ClientsController extends Controller
         private readonly ClientStorageUsage $storageUsage,
         private readonly DeletedAccountContent $accountContent,
         private readonly AccountContentDeletion $accountDeletion,
+        private readonly StaffLibraryScope $scope,
     ) {}
 
     public function index(Request $request): Response
@@ -135,7 +137,7 @@ class ClientsController extends Controller
 
     public function edit(User $client): Response
     {
-        abort_unless($client->isClient(), 404);
+        $this->guardTarget($client);
 
         return Inertia::render('clients/edit', [
             'client' => [
@@ -160,7 +162,7 @@ class ClientsController extends Controller
 
     public function update(Request $request, User $client): RedirectResponse
     {
-        abort_unless($client->isClient(), 404);
+        $this->guardTarget($client);
 
         $validated = $request->validate(array_merge([
             'name' => ['required', 'string', 'max:255'],
@@ -221,7 +223,7 @@ class ClientsController extends Controller
      */
     public function destroyTwoFactor(User $client, TwoFactorAdministration $twoFactor): RedirectResponse
     {
-        abort_unless($client->isClient(), 404);
+        $this->guardTarget($client);
 
         $twoFactor->reset($client);
 
@@ -230,7 +232,7 @@ class ClientsController extends Controller
 
     public function destroy(Request $request, User $client): RedirectResponse
     {
-        abort_unless($client->isClient(), 404);
+        $this->guardTarget($client);
 
         $validated = $this->accountDeletion->validate($request, $client);
 
@@ -242,6 +244,37 @@ class ClientsController extends Controller
         $this->accountDeletion->apply($validated, $client, $name);
 
         return redirect()->route('clients.index')->with('success', __('Client deleted.'));
+    }
+
+    /**
+     * Every route that binds a client keeps `can:edit_clients` (or
+     * `can:delete_clients`) in front of it, and a permission is not a
+     * boundary: a client-scoped staff member holds it for the clients
+     * assigned to them and it used to let them through for anybody's.
+     *
+     * clients/{client}/files says the rule out loud one line away in
+     * routes/web.php, on the same bound object under the same permission
+     * — "a client-scoped staff member may only browse this for clients
+     * assigned to them" — and the staff-account routes apply their own
+     * version through StaffAccounts::guardTarget. These did neither, and
+     * update() sets email, password and active.
+     *
+     * 404 rather than 403, like the isClient() check it absorbs and like
+     * clients/{client}/files: a client outside this staff member's reach
+     * should not be distinguishable from one that is not there.
+     */
+    private function guardTarget(User $client): void
+    {
+        abort_unless($client->isClient(), 404);
+        abort_unless($this->scope->canAssignClient($this->actor(), $client), 404);
+    }
+
+    private function actor(): User
+    {
+        $actor = auth()->user();
+        assert($actor instanceof User);
+
+        return $actor;
     }
 
     /**

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -975,11 +975,11 @@
                             }
                         }
                     },
-                    "404": {
-                        "$ref": "#/components/responses/ModelNotFoundException"
-                    },
                     "422": {
                         "$ref": "#/components/responses/ValidationException"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
                     },
                     "401": {
                         "$ref": "#/components/responses/AuthenticationException"

--- a/tests/Feature/Clients/ClientAccountScopeTest.php
+++ b/tests/Feature/Clients/ClientAccountScopeTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Identity\Models\Role;
+use App\Modules\Identity\Models\RolePermission;
+use App\Modules\Identity\Permissions\Permission;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+/**
+ * Managing a client account is inside the same library boundary as
+ * everything else about that client — the one clients/{client}/files
+ * already applies under the very same permission.
+ */
+beforeEach(function () {
+    Storage::fake('files');
+
+    // A client-scoped role that manages clients. Nothing shipped combines
+    // the two, but the roles screen offers every combination and
+    // ClientScopingTest pins that a custom role can be made scoped.
+    $role = Role::query()->create(['name' => 'Reps '.Str::random(6), 'client_scoped' => true]);
+    foreach ([Permission::ManageClients, Permission::EditClients, Permission::DeleteClients] as $permission) {
+        RolePermission::query()->create(['role_id' => $role->id, 'permission' => $permission->value]);
+    }
+
+    $this->mine = User::factory()->client()->create(['name' => 'Mine']);
+    $this->stranger = User::factory()->client()->create(['name' => 'Not Mine', 'email' => 'stranger@example.test']);
+
+    $this->rep = User::factory()->create(['role_id' => $role->id]);
+    $this->rep->assignedClients()->sync([$this->mine->id]);
+
+    $this->token = $this->rep->createToken('t', [
+        Permission::ManageClients->value,
+        Permission::EditClients->value,
+        Permission::DeleteClients->value,
+    ])->plainTextToken;
+});
+
+test('the neighbouring route already draws this line', function () {
+    // clients/{client}/files, same permission, same bound object. The
+    // routes below used to answer where this one refuses.
+    $this->actingAs($this->rep)->get("/clients/{$this->mine->id}/files")->assertOk();
+    $this->actingAs($this->rep)->get("/clients/{$this->stranger->id}/files")->assertNotFound();
+});
+
+test('a scoped rep cannot open or edit a client that is not theirs', function () {
+    $this->actingAs($this->rep)->get("/clients/{$this->stranger->id}")->assertNotFound();
+
+    $this->actingAs($this->rep)->patch("/clients/{$this->stranger->id}", [
+        'name' => 'Taken Over',
+        'email' => 'attacker@example.test',
+        'active' => true,
+        'password' => 'a-new-password-123',
+        'password_confirmation' => 'a-new-password-123',
+    ])->assertNotFound();
+
+    $this->stranger->refresh();
+
+    // The takeover this closes: email and password are editable here, so
+    // reaching a client outside the boundary means signing in as them and
+    // reading their whole library.
+    expect($this->stranger->email)->toBe('stranger@example.test')
+        ->and($this->stranger->name)->toBe('Not Mine');
+});
+
+test('a scoped rep cannot delete a client that is not theirs, or reset their second factor', function () {
+    $this->actingAs($this->rep)->delete("/clients/{$this->stranger->id}", ['content_action' => 'keep'])
+        ->assertNotFound();
+
+    expect(User::query()->whereKey($this->stranger->id)->exists())->toBeTrue();
+
+    enableTwoFactor($this->stranger);
+    forgetRequestState();
+    confirmPassword($this->rep);
+
+    $this->actingAs($this->rep)->delete("/clients/{$this->stranger->id}/two-factor")->assertNotFound();
+
+    expect($this->stranger->refresh()->hasTwoFactorEnabled())->toBeTrue();
+});
+
+test('their own clients are still entirely theirs to manage', function () {
+    // Not deny-everything: the whole point of the role is that these work.
+    $this->actingAs($this->rep)->get("/clients/{$this->mine->id}")->assertOk();
+
+    $this->actingAs($this->rep)->patch("/clients/{$this->mine->id}", [
+        'name' => 'Renamed',
+        'email' => $this->mine->email,
+        'active' => true,
+    ])->assertRedirect();
+
+    expect($this->mine->refresh()->name)->toBe('Renamed');
+});
+
+test('an unscoped staff member reaches every client exactly as before', function () {
+    $admin = User::factory()->create();
+
+    $this->actingAs($admin)->get("/clients/{$this->stranger->id}")->assertOk();
+
+    $this->actingAs($admin)->patch("/clients/{$this->stranger->id}", [
+        'name' => 'Renamed By Admin',
+        'email' => $this->stranger->email,
+        'active' => true,
+    ])->assertRedirect();
+
+    expect($this->stranger->refresh()->name)->toBe('Renamed By Admin');
+});
+
+test('a staff account still 404s on these routes, scoped or not', function () {
+    // The type filter the scope check absorbed still filters.
+    $staff = User::factory()->create();
+
+    $this->actingAs($this->rep)->get("/clients/{$staff->id}")->assertNotFound();
+    $this->actingAs(User::factory()->create())->get("/clients/{$staff->id}")->assertNotFound();
+});
+
+test('a scoped token reaches exactly the clients its owner does', function () {
+    $this->withToken($this->token)->getJson("/api/v1/clients/{$this->stranger->id}")->assertNotFound();
+
+    $this->withToken($this->token)->patchJson("/api/v1/clients/{$this->stranger->id}", [
+        'email' => 'attacker@example.test',
+        'password' => 'a-new-password-123',
+    ])->assertNotFound();
+
+    $this->withToken($this->token)->deleteJson("/api/v1/clients/{$this->stranger->id}", ['content_action' => 'keep'])
+        ->assertNotFound();
+
+    expect($this->stranger->refresh()->email)->toBe('stranger@example.test');
+
+    // And their own client, over the same token, still answers.
+    $this->withToken($this->token)->getJson("/api/v1/clients/{$this->mine->id}")->assertOk();
+});
+
+test('a scoped token cannot reset an out-of-reach client two-factor secret', function () {
+    enableTwoFactor($this->stranger);
+    forgetRequestState();
+
+    $this->withToken($this->token)
+        ->deleteJson("/api/v1/clients/{$this->stranger->id}/two-factor")
+        ->assertNotFound();
+
+    expect($this->stranger->refresh()->hasTwoFactorEnabled())->toBeTrue();
+});
+
+test('the roster listing is deliberately left alone', function () {
+    // manage_clients, not edit_clients: the list is the one client
+    // surface this change does not narrow, because nothing in the code
+    // claims it is narrowed — see the note in the pull request.
+    $names = collect($this->withToken($this->token)->getJson('/api/v1/clients')->assertOk()->json('data'))
+        ->pluck('name');
+
+    expect($names)->toContain('Mine', 'Not Mine');
+});


### PR DESCRIPTION
## The problem

Eight routes bind a client account directly — the edit screen, the update,
the delete and the second-factor reset, on the web and over the API. Every
one of them asked the same single question about the object it had been
handed:

```php
abort_unless($client->isClient(), 404);
```

`ClientsController.php:138, 163, 224, 233` and
`Api\ClientsController.php:84, 136, 208, 233`. That is a type filter. It
keeps a staff account from being addressed through a client route, and it is
the whole of what those methods check — so the route's `can:edit_clients`
(or `can:delete_clients`) is the entire gate.

A permission is not a boundary. `Client Manager` is client-scoped by design,
and a custom role that is client-scoped *and* carries `edit_clients` is one
the roles screen offers; `ClientScopingTest:180` pins that a custom role can
be made scoped.

## The rule is already written down, one line away

`routes/web.php:258-259`:

```php
Route::get('clients/{client}/files', [ClientFilesController::class, 'index'])->middleware(['staff', 'can:edit_clients'])->name('clients.files');
Route::get('clients/{client}', [ClientsController::class, 'edit'])->middleware(['staff', 'can:edit_clients'])->name('clients.edit');
```

Same permission. Same bound object. The first one says it out loud
(`ClientFilesController:39-42`):

```php
// A client-scoped staff member may only browse this for clients
// assigned to them — the same boundary StaffLibraryScope enforces
// everywhere else in the library.
abort_unless(! $viewer->isClientScoped() || $this->scope->canAssignClient($viewer, $client), 404);
```

The second one did not. And the staff-account routes next door apply their
own version of the same idea at every single-object route through
`StaffAccounts::guardTarget()`. Client accounts had no equivalent anywhere.

## What that gets you

`ClientsController::update()` accepts `email`, `password` and `active`
(`:167-169`). So a client-scoped staff member holding `edit_clients` could
set new credentials on a client they are not assigned to, sign in as that
client, and read their entire library — which is `StaffLibraryScope`
bypassed completely rather than bent. With `delete_clients`, a `DELETE` with
`content_action=cascade_delete` destroys that client's content instead.

Reaching the id costs nothing: the roster listing runs under
`manage_clients` and shows every client on the installation.

## The fix

One guard per controller, absorbing the type check that was already there:

```php
private function guardTarget(User $client): void
{
    abort_unless($client->isClient(), 404);
    abort_unless($this->scope->canAssignClient($this->actor(), $client), 404);
}
```

`canAssignClient()` already exists and already returns `true` for anyone who
is not client-scoped (`assignableClientIds()` gives them `null`, meaning
unrestricted), so an ordinary staff account sees no change at all. The eight
call sites become eight calls to it.

404 rather than 403, matching both the check it replaces and
`clients/{client}/files`: a client this staff member may not manage should
not be distinguishable from one that is not there.

### Not changed (deliberate)

- **The roster listing** — `GET /clients` and `GET /api/v1/clients`. It runs
  under `manage_clients`, not `edit_clients`, and nothing in the code claims
  it is narrowed: `UsersController::clientOptions()` and the account
  conversion screen show the whole roster too. Narrowing who appears in a
  client list is a product decision about what "manage clients" means, and it
  is not what this fix is about. A test pins the current behaviour so the
  choice is visible rather than accidental.
- **`store()`** — creating a client. A client-scoped staff member who creates
  one is not reaching past a boundary; whether a new client should be
  auto-assigned to its creator is a separate question, and answering it here
  would change behaviour nobody asked about.
- **`canAssignClient()` itself.** It is the existing predicate for "may this
  staff member act on this client", already used for sharing and by
  `ClientFilesController`. This adds callers, not a second rule.

## One documentation change falls out of this

Scramble reads the guard through the helper now, so on
`PATCH /api/v1/clients/{client}` the `422` is registered before the `404`
instead of after. The committed document is otherwise identical:

```diff
-                    "404": {
-                        "$ref": "#/components/responses/ModelNotFoundException"
-                    },
                     "422": {
                         "$ref": "#/components/responses/ValidationException"
                     },
+                    "404": {
+                        "$ref": "#/components/responses/ModelNotFoundException"
+                    },
```

Both responses are still documented, with the same refs. Regenerated with
`php artisan scramble:export`.

## Merge note

Both controllers here are also touched by #1678, which adds an `ErasureSchedule`
alongside the deletion flow. The two conflict textually in one place per file —
both add a constructor property in the same spot — and both sides are wanted,
so resolving is keeping each. Nothing else in either file differs, and #1678 is
clean against `main`, so whoever merges second resolves those two lines and is
done.

Clean against every other open branch, including #1688, which wraps the same
`destroy()` in a transaction without touching the guard above it.

## Tests

`tests/Feature/Clients/ClientAccountScopeTest.php`, nine cases. The first
asserts the contrast the fix is built on — `clients/{client}/files` already
refuses where `clients/{client}` answered. Then: edit, update, delete and
two-factor reset refused for a client that is not theirs, on the web and
through a token; their own client still fully manageable; an unscoped staff
member unchanged; a staff account still 404ing; and the roster listing
deliberately still complete.

Counter-check, stated plainly: against the unfixed code **four of the nine go
red** — `GET /clients/{id}` answers **200**, the web `DELETE` answers **302**
to `/clients` with the account gone (checked directly, not inferred),
`GET /api/v1/clients/{id}` answers **200**, and the API two-factor reset
answers **204** with the stranger's second factor removed. The other five hold
without the fix; they are regression guards, not proof of the bug.

Full suite passes (1856 passed / 2 skipped), PHPStan level 8 clean.