### PR TITLE
Nobody hands out reach they do not hold either

### DIFF
--- a/app/Modules/Identity/Http/Controllers/AccountConversionController.php
+++ b/app/Modules/Identity/Http/Controllers/AccountConversionController.php
@@ -120,7 +120,9 @@ class AccountConversionController extends Controller
                     'is_system' => $role->is_system,
                     'client_scoped' => $role->client_scoped,
                 ])->all(),
-            'clients' => User::query()->where('type', UserType::Client)->orderBy('name')->get()
+            // Narrowed like `roles` beside it: the picker offers what this
+            // actor may hand out, which is what store() will accept.
+            'clients' => User::query()->whereIn('id', $this->accounts->assignableClientIds($actor))->orderBy('name')->get()
                 ->map(fn (User $client): array => ['id' => $client->id, 'name' => $client->name])
                 ->values()->all(),
         ]);
@@ -152,7 +154,8 @@ class AccountConversionController extends Controller
             'assigned_clients' => ['array'],
             'assigned_clients.*' => [
                 'integer',
-                Rule::exists('users', 'id')->where('type', UserType::Client->value),
+                // Reach, not a label: see StaffAccounts::assignableClientIds.
+                Rule::in($this->accounts->assignableClientIds($actor)),
                 Rule::notIn([$user->id]),
             ],
             // Required only for an account whose credential lives in the

--- a/app/Modules/Identity/Http/Controllers/Api/UsersController.php
+++ b/app/Modules/Identity/Http/Controllers/Api/UsersController.php
@@ -125,7 +125,11 @@ class UsersController extends Controller
             // to mistype. Password::defaults() still applies.
             'password' => ['required', Password::defaults()],
             'assigned_clients' => ['array'],
-            'assigned_clients.*' => ['integer', Rule::exists('users', 'id')->where('type', UserType::Client->value)],
+            // Only clients you can reach yourself: an unrestricted account may
+            // assign any client, a client-scoped one only the clients already
+            // assigned to it. Assigning a client hands over everything that
+            // client can see, so it follows the same rule as role_id above.
+            'assigned_clients.*' => ['integer', Rule::in($this->accounts->assignableClientIds($actor))],
         ]);
 
         $user = $this->accounts->create([
@@ -163,7 +167,11 @@ class UsersController extends Controller
             'active' => ['sometimes', 'boolean'],
             'password' => ['sometimes', 'nullable', Password::defaults()],
             'assigned_clients' => ['sometimes', 'array'],
-            'assigned_clients.*' => ['integer', Rule::exists('users', 'id')->where('type', UserType::Client->value)],
+            // Only clients you can reach yourself: an unrestricted account may
+            // assign any client, a client-scoped one only the clients already
+            // assigned to it. Assigning a client hands over everything that
+            // client can see, so it follows the same rule as role_id above.
+            'assigned_clients.*' => ['integer', Rule::in($this->accounts->assignableClientIds($actor))],
         ]);
 
         // The same refusal the web screen makes, and for the same reason:

--- a/app/Modules/Identity/Http/Controllers/UsersController.php
+++ b/app/Modules/Identity/Http/Controllers/UsersController.php
@@ -116,7 +116,10 @@ class UsersController extends Controller
             'role_id' => ['required', 'integer', Rule::in($this->accounts->assignableRoleIds($this->actor()))],
             'password' => ['required', 'confirmed', Password::defaults()],
             'assigned_clients' => ['array'],
-            'assigned_clients.*' => ['integer', Rule::exists('users', 'id')->where('type', UserType::Client->value)],
+            // Reach, not a label: see StaffAccounts::assignableClientIds.
+            // The list is client-typed already, so this is one rule where
+            // an exists() plus a type filter used to be two.
+            'assigned_clients.*' => ['integer', Rule::in($this->accounts->assignableClientIds($this->actor()))],
         ]);
 
         $user = $this->accounts->create([
@@ -171,7 +174,10 @@ class UsersController extends Controller
             'active' => ['required', 'boolean'],
             'password' => ['nullable', 'confirmed', Password::defaults()],
             'assigned_clients' => ['array'],
-            'assigned_clients.*' => ['integer', Rule::exists('users', 'id')->where('type', UserType::Client->value)],
+            // Reach, not a label: see StaffAccounts::assignableClientIds.
+            // The list is client-typed already, so this is one rule where
+            // an exists() plus a type filter used to be two.
+            'assigned_clients.*' => ['integer', Rule::in($this->accounts->assignableClientIds($this->actor()))],
         ]);
 
         // Deactivating yourself is refused here rather than in StaffAccounts
@@ -259,13 +265,15 @@ class UsersController extends Controller
     }
 
     /**
-     * The client roster, for the assigned-clients picker.
+     * The client roster, for the assigned-clients picker — narrowed to
+     * what this actor may actually hand out, the same way roleOptions()
+     * is narrowed to the roles they may grant.
      *
      * @return array<int, array{id: int, name: string}>
      */
     private function clientOptions(): array
     {
-        return User::query()->where('type', UserType::Client)->orderBy('name')->get()
+        return User::query()->whereIn('id', $this->accounts->assignableClientIds($this->actor()))->orderBy('name')->get()
             ->map(fn (User $client): array => ['id' => $client->id, 'name' => $client->name])
             ->values()->all();
     }

--- a/app/Modules/Identity/StaffAccounts.php
+++ b/app/Modules/Identity/StaffAccounts.php
@@ -7,6 +7,7 @@ namespace App\Modules\Identity;
 use App\Models\User;
 use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLogger;
+use App\Modules\Files\Access\StaffLibraryScope;
 use App\Modules\Identity\Models\Role;
 use App\Modules\Identity\Permissions\PermissionChecker;
 use App\Modules\Identity\Permissions\SystemRole;
@@ -34,6 +35,7 @@ class StaffAccounts
     public function __construct(
         private readonly ActivityLogger $activity,
         private readonly PermissionChecker $permissions,
+        private readonly StaffLibraryScope $library,
     ) {}
 
     /**
@@ -88,6 +90,39 @@ class StaffAccounts
     public function assignableRoleIds(User $actor): array
     {
         return array_values($this->assignableRoles($actor)->map(fn (Role $role): int => $role->id)->all());
+    }
+
+    /**
+     * Client ids this actor may put on a staff account's roster — the same
+     * rule as mayGrant(), applied to reach instead of to authority.
+     *
+     * An assigned client is not a label: it is everything that client can
+     * see, handed to whoever holds it. So a client-scoped actor may hand
+     * out the clients they hold and no others — including to themselves,
+     * which is the case that matters, since guardTarget() lets anybody
+     * edit their own account and `assigned_clients` was never checked
+     * against the actor at all. Without this a scoped staff member with
+     * `edit_users` could PATCH their own id with every client id on the
+     * installation and read the whole library from then on.
+     *
+     * An unrestricted actor gets the full roster back rather than null, so
+     * every caller can validate against one list instead of composing a
+     * conditional rule. That list is already client-typed, which is why it
+     * replaces the `exists:users,id where type = client` rule rather than
+     * joining it.
+     *
+     * @return list<int>
+     */
+    public function assignableClientIds(User $actor): array
+    {
+        $ids = $this->library->assignableClientIds($actor);
+
+        if ($ids !== null) {
+            return $ids;
+        }
+
+        return array_values(User::query()->where('type', UserType::Client)
+            ->pluck('id')->map(fn ($id): int => (int) $id)->all());
     }
 
     /**

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3215,7 +3215,8 @@
                                     "assigned_clients": {
                                         "type": "array",
                                         "items": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Only clients you can reach yourself: an unrestricted account may\nassign any client, a client-scoped one only the clients already\nassigned to it. Assigning a client hands over everything that\nclient can see, so it follows the same rule as role_id above."
                                         }
                                     }
                                 },
@@ -3351,7 +3352,8 @@
                                     "assigned_clients": {
                                         "type": "array",
                                         "items": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Only clients you can reach yourself: an unrestricted account may\nassign any client, a client-scoped one only the clients already\nassigned to it. Assigning a client hands over everything that\nclient can see, so it follows the same rule as role_id above."
                                         }
                                     }
                                 }

--- a/tests/Feature/Identity/AssignedClientsAuthorityTest.php
+++ b/tests/Feature/Identity/AssignedClientsAuthorityTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Identity\Models\Role;
+use App\Modules\Identity\Models\RolePermission;
+use App\Modules\Identity\Permissions\Permission;
+use App\Modules\Identity\Permissions\SystemRole;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia;
+
+/**
+ * Assigning a client to a staff account hands over everything that client
+ * can see. StaffAccounts already refuses to let anybody grant a role they
+ * do not hold; this is the same rule for the client roster.
+ */
+beforeEach(function () {
+    $this->admin = User::factory()->create();
+
+    $this->mine = User::factory()->client()->create(['name' => 'Mine']);
+    $this->stranger = User::factory()->client()->create(['name' => 'Not Mine']);
+
+    // A client-scoped role that manages staff accounts. Nothing shipped
+    // combines the two; the roles screen offers every combination, and
+    // ClientScopingTest pins that a custom role can be made scoped.
+    $this->role = Role::query()->create(['name' => 'Reps '.Str::random(6), 'client_scoped' => true]);
+    foreach ([Permission::ManageUsers, Permission::EditUsers, Permission::CreateUsers, Permission::EditClients] as $permission) {
+        RolePermission::query()->create(['role_id' => $this->role->id, 'permission' => $permission->value]);
+    }
+
+    $this->rep = User::factory()->create(['role_id' => $this->role->id]);
+    $this->rep->assignedClients()->sync([$this->mine->id]);
+});
+
+test('a scoped staff member cannot widen their own reach', function () {
+    // guardTarget() returns immediately for your own account — editing
+    // your own name and email is not a question of authority — so this
+    // payload had nothing standing in front of it at all.
+    $this->actingAs($this->rep)->patch("/users/{$this->rep->id}", [
+        'name' => $this->rep->name,
+        'email' => $this->rep->email,
+        'role_id' => $this->role->id,
+        'active' => true,
+        'assigned_clients' => [$this->mine->id, $this->stranger->id],
+    ])->assertSessionHasErrors('assigned_clients.1');
+
+    expect($this->rep->assignedClients()->pluck('users.id')->all())->toBe([$this->mine->id]);
+});
+
+test('a scoped staff member cannot hand a stranger client to somebody else either', function () {
+    $colleague = User::factory()->create(['role_id' => $this->role->id]);
+
+    $this->actingAs($this->rep)->patch("/users/{$colleague->id}", [
+        'name' => $colleague->name,
+        'email' => $colleague->email,
+        'role_id' => $this->role->id,
+        'active' => true,
+        'assigned_clients' => [$this->stranger->id],
+    ])->assertSessionHasErrors('assigned_clients.0');
+
+    expect($colleague->assignedClients()->count())->toBe(0);
+});
+
+test('a scoped staff member cannot mint a new account holding clients they do not', function () {
+    $this->actingAs($this->rep)->post('/users', [
+        'name' => 'New Rep',
+        'email' => 'new-rep@example.test',
+        'role_id' => $this->role->id,
+        'password' => 'a-strong-password-1',
+        'password_confirmation' => 'a-strong-password-1',
+        'assigned_clients' => [$this->stranger->id],
+    ])->assertSessionHasErrors('assigned_clients.0');
+
+    expect(User::query()->where('email', 'new-rep@example.test')->exists())->toBeFalse();
+});
+
+test('their own clients still pass, on create and on edit', function () {
+    // Not deny-everything: handing on what you hold is the point of the
+    // roster, and the rule only says you cannot hand on what you do not.
+    $this->actingAs($this->rep)->post('/users', [
+        'name' => 'New Rep',
+        'email' => 'new-rep@example.test',
+        'role_id' => $this->role->id,
+        'password' => 'a-strong-password-1',
+        'password_confirmation' => 'a-strong-password-1',
+        'assigned_clients' => [$this->mine->id],
+    ])->assertSessionHasNoErrors();
+
+    $created = User::query()->where('email', 'new-rep@example.test')->sole();
+
+    expect($created->assignedClients()->pluck('users.id')->all())->toBe([$this->mine->id]);
+});
+
+test('an administrator still assigns any client at all', function () {
+    $rep = User::factory()->create(['role_id' => $this->role->id]);
+
+    $this->actingAs($this->admin)->patch("/users/{$rep->id}", [
+        'name' => $rep->name,
+        'email' => $rep->email,
+        'role_id' => $this->role->id,
+        'active' => true,
+        'assigned_clients' => [$this->mine->id, $this->stranger->id],
+    ])->assertSessionHasNoErrors();
+
+    expect($rep->assignedClients()->count())->toBe(2);
+});
+
+test('a staff account is still not assignable as a client', function () {
+    // The type filter the old exists() rule carried is inside the list
+    // this now validates against, so it did not go anywhere.
+    $staff = User::factory()->create();
+
+    $this->actingAs($this->admin)->patch("/users/{$this->rep->id}", [
+        'name' => $this->rep->name,
+        'email' => $this->rep->email,
+        'role_id' => $this->role->id,
+        'active' => true,
+        'assigned_clients' => [$staff->id],
+    ])->assertSessionHasErrors('assigned_clients.0');
+
+    $this->actingAs($this->admin)->patch("/users/{$this->rep->id}", [
+        'name' => $this->rep->name,
+        'email' => $this->rep->email,
+        'role_id' => $this->role->id,
+        'active' => true,
+        'assigned_clients' => [999999],
+    ])->assertSessionHasErrors('assigned_clients.0');
+});
+
+test('the API answers the same on both verbs', function () {
+    $token = $this->rep->createToken('t', [
+        Permission::ManageUsers->value,
+        Permission::EditUsers->value,
+        Permission::CreateUsers->value,
+    ])->plainTextToken;
+
+    $this->withToken($token)->patchJson("/api/v1/users/{$this->rep->id}", [
+        'assigned_clients' => [$this->mine->id, $this->stranger->id],
+    ])->assertJsonValidationErrors('assigned_clients.1');
+
+    $this->withToken($token)->postJson('/api/v1/users', [
+        'name' => 'New Rep',
+        'email' => 'new-rep@example.test',
+        'role_id' => $this->role->id,
+        'password' => 'a-strong-password-1',
+        'assigned_clients' => [$this->stranger->id],
+    ])->assertJsonValidationErrors('assigned_clients.0');
+
+    expect($this->rep->assignedClients()->pluck('users.id')->all())->toBe([$this->mine->id]);
+
+    // Their own client still goes through the same endpoint.
+    $this->withToken($token)->patchJson("/api/v1/users/{$this->rep->id}", [
+        'assigned_clients' => [$this->mine->id],
+    ])->assertOk();
+});
+
+test('converting an account to staff cannot hand out clients either', function () {
+    $target = User::factory()->client()->create();
+
+    $this->actingAs($this->rep)->post("/users/convert/{$target->id}", [
+        'direction' => 'to_staff',
+        'role_id' => $this->role->id,
+        'assigned_clients' => [$this->stranger->id],
+        'password' => 'a-strong-password-1',
+    ])->assertSessionHasErrors('assigned_clients.0');
+
+    expect($target->refresh()->isClient())->toBeTrue();
+});
+
+test('the picker offers what the rule accepts', function () {
+    // A form that offers a client the server will refuse is a form that
+    // teaches people the boundary by hitting it — roleOptions() is
+    // narrowed for exactly this reason, and now so is this.
+    $names = fn ($clients) => collect($clients)->pluck('name')->all();
+
+    $this->actingAs($this->rep)->get('/users/create')->assertInertia(
+        fn (AssertableInertia $page) => $page->where(
+            'clients',
+            fn ($clients) => $names($clients) === ['Mine'],
+        ),
+    );
+
+    $this->actingAs($this->admin)->get('/users/create')->assertInertia(
+        fn (AssertableInertia $page) => $page->where(
+            'clients',
+            fn ($clients) => in_array('Not Mine', $names($clients), true),
+        ),
+    );
+});
+
+test('an unscoped role clears the roster as before', function () {
+    // syncAssignedClients still decides that, and it is untouched: this
+    // change is about which ids may be offered, not about when they stick.
+    $plain = Role::query()->where('name', SystemRole::AccountManager->value)->sole();
+
+    $this->actingAs($this->admin)->patch("/users/{$this->rep->id}", [
+        'name' => $this->rep->name,
+        'email' => $this->rep->email,
+        'role_id' => $plain->id,
+        'active' => true,
+        'assigned_clients' => [$this->mine->id],
+    ])->assertSessionHasNoErrors();
+
+    expect($this->rep->refresh()->assignedClients()->count())->toBe(0);
+});


### PR DESCRIPTION
## The rule this is missing

`StaffAccounts` opens by stating it (`:39-49`):

> Nobody hands out authority they do not hold. `manage_users` is a permission
> like any other, so without this a non-administrator holding it could mint an
> administrator — or build a custom role carrying `edit_settings`,
> `delete_others_files`, anything — and assign it, to a new account or to
> themselves. That turns one permission into every permission and makes the
> rest of the matrix decorative.

`mayGrant()` enforces it for roles, `assignableRoleIds()` narrows the picker
to it, and `guardTarget()` applies the same test to an existing account.

`assigned_clients` — the other thing a staff account carries — got none of
that. It is validated as a type check and passed straight through:

```php
'assigned_clients' => ['array'],
'assigned_clients.*' => ['integer', Rule::exists('users', 'id')->where('type', UserType::Client->value)],
```

```php
$user->assignedClients()->sync($scoped ? $clientIds : []);
```

Nothing between the two asks whether the actor holds the clients they are
handing out. Assigning a client is not a label: `StaffLibraryScope::files()`
unions `File::scopeVisibleToClient()` over every assigned client, so an
assignment *is* that client's whole library, given to whoever is on the other
end of it.

## What that gets you

The case that matters is the actor's own account. `guardTarget()` returns
immediately when the target is the actor (`:101-105`):

```php
public function guardTarget(User $actor, User $target): void
{
    if ($target->is($actor)) {
        return;
    }
    …
}
```

which is right for what it was written for — editing your own name or email
is not a question of authority. But it means a client-scoped staff member
holding `manage_users` and `edit_users` could send
`PATCH /users/{their own id}` with `assigned_clients: [every client id]` and
read the entire installation's library from then on. Their own role, their own
account, no guard on the path.

(The `/users` screens sit behind `capability:users.manage`, so this is a
community-edition path; a managed installation does not register these routes
at all.)

Reaching the ids costs nothing: the assigned-clients picker on that very
screen was served the whole roster.

Five places accept the field — `UsersController::store()`/`update()`,
`Api\UsersController::store()`/`update()`, and
`AccountConversionController::store()`.

### Reachability, stated honestly

No shipped role combines `client_scoped` with `manage_users`/`edit_users`:
`Client Manager`, the only client-scoped role that ships, is file-focused.
This needs a custom role, which the roles screen allows and
`ClientScopingTest:180` pins as supported. That lowers the severity; it does
not make the configuration strange.

## The fix

The roster gets the counterpart `mayGrant()` already is for roles:

```php
public function assignableClientIds(User $actor): array
{
    $ids = $this->library->assignableClientIds($actor);

    if ($ids !== null) {
        return $ids;
    }

    return array_values(User::query()->where('type', UserType::Client)
        ->pluck('id')->map(fn ($id): int => (int) $id)->all());
}
```

and the five call sites validate against it, exactly as `role_id` already
validates against `assignableRoleIds()`:

```php
'assigned_clients.*' => ['integer', Rule::in($this->accounts->assignableClientIds($this->actor()))],
```

Returning the whole roster for an unrestricted actor rather than `null` is
deliberate: every caller gets one list to validate against instead of
composing a conditional rule, and an administrator's behaviour is unchanged
by construction. The list is already client-typed, which is why one rule
replaces the `exists()` and the type filter together rather than joining
them — a staff id and an id that does not exist are both still rejected, by
the same rule, and a test pins both.

The two pickers that offer the roster (`UsersController::clientOptions()` and
the conversion screen's `clients` prop) are narrowed to the same list, the way
`roleOptions()` next to them already is. A form that offers a client the
request behind it will refuse is a form that teaches people the boundary by
running into it.

### Not changed (deliberate)

- **`guardTarget()`'s self-exemption.** It is correct for what it guards: you
  may edit your own account. What was missing is not an exception to that but
  a check on `assigned_clients` that never existed for *any* target, self or
  otherwise. Tightening the exemption would break editing your own profile
  and still leave the field unchecked for colleagues.
- **`syncAssignedClients()`.** Which ids stick to which role is its decision,
  and it was never the problem — it already clears the roster when the role
  is not client-scoped. A test pins that this still happens.
- **Sharing.** `StaffLibraryScope::assignableClientIds()` already bounds who a
  scoped staff member may share *with*; this reuses it rather than
  introducing a second notion of "clients you may act on".
- **`AccountConversionController`'s `Rule::notIn([$user->id])`.** Kept as is:
  it stops an account being assigned to itself during conversion, which is a
  different question from whose clients they are.

## One documentation change falls out of this

Scramble publishes comments above validation rules as the API reference, so
the note on `assigned_clients.*` in `Api\UsersController` becomes a
description on `POST /users` and `PATCH /users/{user}`. It is written as
documentation rather than as an implementation note for that reason:

> Only clients you can reach yourself: an unrestricted account may assign any
> client, a client-scoped one only the clients already assigned to it.
> Assigning a client hands over everything that client can see, so it follows
> the same rule as role_id above.

Regenerated with `php artisan scramble:export`.

## Merge note

This touches `StaffAccounts.php`, which #1678 also touches. The two conflict
textually in exactly two places — both add an import and a constructor
property in the same spot — and both sides are wanted, so resolving is keeping
each. Nothing else in the file differs, and #1678 itself is clean against
`main`, so whoever merges second resolves those two hunks and is done.

Clean against every other open branch, including #1684 and #1688, which share
these controllers but in `store()` and `destroy()`.

## Tests

`tests/Feature/Identity/AssignedClientsAuthorityTest.php`, ten cases: the
self-widening PATCH, the same payload aimed at a colleague, the same on
create, the API twin of both, the account conversion, an administrator still
assigning anything, a scoped actor's own clients still passing, a staff id and
a non-existent id both still rejected, the picker narrowed, and the
role-change clearing still working.

Counter-check, stated plainly: against the unfixed code **six of the ten go
red** — the self-widening PATCH, the colleague PATCH, the create, the API
PATCH, the conversion and the picker all go through. The other four hold
without the fix; they are regression guards for what must not change, not
proof of the bug.

Full suite passes (1857 passed / 2 skipped), PHPStan level 8 clean.