### PR TITLE
Keep comment moderation inside the moderator's own library

### DIFF
--- a/app/Modules/Comments/FileCommentPolicy.php
+++ b/app/Modules/Comments/FileCommentPolicy.php
@@ -7,6 +7,7 @@ namespace App\Modules\Comments;
 use App\Models\User;
 use App\Modules\Comments\Access\VisibleCommentScope;
 use App\Modules\Comments\Models\FileComment;
+use App\Modules\Files\Access\StaffLibraryScope;
 use Illuminate\Support\Facades\Gate;
 
 /**
@@ -20,6 +21,7 @@ class FileCommentPolicy
     public function __construct(
         private readonly VisibleCommentScope $scope,
         private readonly CommentingRules $rules,
+        private readonly StaffLibraryScope $library,
     ) {}
 
     public function view(User $user, FileComment $comment): bool
@@ -44,16 +46,38 @@ class FileCommentPolicy
 
     public function delete(User $user, FileComment $comment): bool
     {
-        if ($this->moderate($user)) {
+        if ($this->moderate($user, $comment)) {
             return true;
         }
 
         return $comment->author_id === $user->id && $this->withinEditWindow($comment);
     }
 
-    public function moderate(User $user): bool
+    /**
+     * Called both ways: with a comment, to decide about that one, and
+     * against the class, to ask whether this user moderates at all (the
+     * queue's own gate, and the affordances that offer it).
+     *
+     * The library boundary belongs here rather than in each caller. Named
+     * against the class it cannot be applied — there is no file to weigh —
+     * so that form answers the coarser question and every caller holding a
+     * comment should pass it.
+     */
+    public function moderate(User $user, ?FileComment $comment = null): bool
     {
-        return $user->isStaff() && $user->can('moderate_comments');
+        if (! $user->isStaff() || ! $user->can('moderate_comments')) {
+            return false;
+        }
+
+        if ($comment === null || ! $user->isClientScoped()) {
+            return true;
+        }
+
+        // By file id rather than through the relation: a file soft-deleted
+        // out from under its comments resolves to null there, and the
+        // answer for a scoped moderator is the same either way — it is not
+        // in their library. Unscoped staff never reach this line.
+        return $this->library->files($user)->whereKey($comment->file_id)->exists();
     }
 
     private function withinEditWindow(FileComment $comment): bool

--- a/app/Modules/Comments/Http/Controllers/Api/CommentModerationController.php
+++ b/app/Modules/Comments/Http/Controllers/Api/CommentModerationController.php
@@ -70,9 +70,9 @@ class CommentModerationController extends Controller
     {
         $viewer = $request->user();
         assert($viewer !== null);
-        Gate::forUser($viewer)->authorize('moderate', FileComment::class);
-        // Moderation rights are not a way around the library boundary.
-        abort_unless($this->library->allowsFile($viewer, $comment->file), 403);
+        // Moderation rights are not a way around the library boundary; the
+        // policy weighs the comment's file, so name the comment.
+        Gate::authorize('moderate', $comment);
 
         $this->comments->approve($comment, $viewer);
 

--- a/app/Modules/Comments/Http/Controllers/CommentsController.php
+++ b/app/Modules/Comments/Http/Controllers/CommentsController.php
@@ -11,7 +11,6 @@ use App\Modules\Comments\CommentPresenter;
 use App\Modules\Comments\CommentVisibility;
 use App\Modules\Comments\FileComments;
 use App\Modules\Comments\Models\FileComment;
-use App\Modules\Files\Access\StaffLibraryScope;
 use App\Modules\Platform\Localization\LocalDay;
 use App\Modules\Platform\Localization\TimezoneRegistry;
 use Carbon\Carbon;
@@ -44,7 +43,6 @@ class CommentsController extends Controller
 
     public function __construct(
         private readonly FileComments $comments,
-        private readonly StaffLibraryScope $library,
         private readonly CommentPresenter $presenter,
         private readonly VisibleCommentScope $scope,
         private readonly TimezoneRegistry $timezones,
@@ -95,9 +93,9 @@ class CommentsController extends Controller
     {
         $viewer = $request->user();
         assert($viewer !== null);
-        Gate::forUser($viewer)->authorize('moderate', FileComment::class);
-        // Moderation rights are not a way around the library boundary.
-        abort_unless($this->library->allowsFile($viewer, $comment->file), 403);
+        // Moderation rights are not a way around the library boundary; the
+        // policy weighs the comment's file, so name the comment.
+        Gate::forUser($viewer)->authorize('moderate', $comment);
 
         $this->comments->approve($comment, $viewer);
 
@@ -113,7 +111,6 @@ class CommentsController extends Controller
         $viewer = $request->user();
         assert($viewer !== null);
         Gate::forUser($viewer)->authorize('delete', $comment);
-        abort_unless($this->library->allowsFile($viewer, $comment->file), 403);
 
         $this->comments->remove($comment);
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1140,26 +1140,7 @@
                         }
                     },
                     "403": {
-                        "description": "An error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "message": {
-                                            "type": "string",
-                                            "description": "Error overview.",
-                                            "examples": [
-                                                ""
-                                            ]
-                                        }
-                                    },
-                                    "required": [
-                                        "message"
-                                    ]
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/AuthorizationException"
                     },
                     "404": {
                         "$ref": "#/components/responses/ModelNotFoundException"

--- a/tests/Feature/Comments/ModerationLibraryScopeTest.php
+++ b/tests/Feature/Comments/ModerationLibraryScopeTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Comments\Models\FileComment;
+use App\Modules\Files\Models\File;
+use App\Modules\Identity\Models\Role;
+use App\Modules\Identity\Models\RolePermission;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function () {
+    $this->admin = User::factory()->create();
+    $this->settings = app(Settings::class);
+
+    $this->settings->set(Setting::CommentsScope, 'all');
+    $this->settings->set(Setting::CommentsAuthors, 'everyone');
+    $this->settings->set(Setting::PublicCommentsEnabled, true);
+    $this->settings->set(Setting::CommentsGuestModeration, true);
+    $this->settings->set(Setting::CommentsEditWindowMinutes, 15);
+});
+
+/**
+ * A moderator who is scoped to their own clients — the role that holds
+ * moderate_comments without holding the whole library.
+ */
+function commentModeratorScopedTo(?User $client = null): User
+{
+    $role = Role::query()->create(['name' => 'Scoped moderator', 'client_scoped' => true]);
+    RolePermission::query()->insert([
+        ['role_id' => $role->id, 'permission' => 'moderate_comments'],
+        ['role_id' => $role->id, 'permission' => 'upload'],
+    ]);
+
+    $manager = User::factory()->create(['role_id' => $role->id]);
+    $manager->assignedClients()->attach(($client ?? User::factory()->client()->create())->id);
+
+    return $manager;
+}
+
+/**
+ * A commented-on file belonging to somebody else's client.
+ *
+ * @return array{0: File, 1: FileComment}
+ */
+function strangersCommentedFile(User $uploader): array
+{
+    $stranger = User::factory()->client()->create();
+    $file = File::factory()->public()->create(['uploaded_by' => $uploader->id]);
+    shareFileWith($file, $stranger);
+
+    return [$file, FileComment::factory()->for($file)->fromGuest()->pending()->create()];
+}
+
+test('a scoped moderator cannot delete a comment on a file outside their library', function () {
+    [, $comment] = strangersCommentedFile($this->admin);
+
+    // The per-file endpoint, not the moderation screen: the policy is the
+    // whole gate here, since the route carries no permission of its own.
+    $this->actingAs(commentModeratorScopedTo())
+        ->deleteJson("/comments/{$comment->id}")
+        ->assertForbidden();
+
+    expect(FileComment::query()->whereKey($comment->id)->exists())->toBeTrue();
+});
+
+test('a scoped moderator cannot delete an out-of-library comment through the API', function () {
+    [, $comment] = strangersCommentedFile($this->admin);
+
+    Sanctum::actingAs(commentModeratorScopedTo(), ['upload']);
+
+    $this->deleteJson("/api/v1/comments/{$comment->id}")->assertForbidden();
+
+    expect(FileComment::query()->whereKey($comment->id)->exists())->toBeTrue();
+});
+
+test('a scoped moderator cannot delete an out-of-library comment from the moderation screen', function () {
+    [, $comment] = strangersCommentedFile($this->admin);
+
+    $this->actingAs(commentModeratorScopedTo())
+        ->delete("/comments/{$comment->id}/moderate")
+        ->assertForbidden();
+
+    expect(FileComment::query()->whereKey($comment->id)->exists())->toBeTrue();
+});
+
+test('a scoped moderator cannot approve an out-of-library comment through the API', function () {
+    [, $comment] = strangersCommentedFile($this->admin);
+
+    Sanctum::actingAs(commentModeratorScopedTo(), ['moderate_comments']);
+
+    $this->postJson("/api/v1/comments/{$comment->id}/approve")->assertForbidden();
+
+    expect($comment->fresh()->isPending())->toBeTrue();
+});
+
+test('a scoped moderator still moderates the files that are theirs', function () {
+    $mine = User::factory()->client()->create();
+    $file = File::factory()->public()->create(['uploaded_by' => $this->admin->id]);
+    shareFileWith($file, $mine);
+    $comment = FileComment::factory()->for($file)->fromGuest()->pending()->create();
+
+    // Same role, same permission — the only difference is that this file
+    // belongs to a client they are assigned to.
+    $this->actingAs(commentModeratorScopedTo($mine))
+        ->deleteJson("/comments/{$comment->id}")
+        ->assertOk();
+
+    expect(FileComment::query()->whereKey($comment->id)->exists())->toBeFalse();
+});
+
+test('an unscoped moderator still reaches every comment', function () {
+    [, $comment] = strangersCommentedFile($this->admin);
+
+    $this->actingAs($this->admin)->deleteJson("/comments/{$comment->id}")->assertOk();
+
+    expect(FileComment::query()->whereKey($comment->id)->exists())->toBeFalse();
+});
+
+test('the library boundary does not follow an author onto their own comment', function () {
+    $client = User::factory()->client()->create();
+    $file = File::factory()->public()->create(['uploaded_by' => $this->admin->id]);
+    shareFileWith($file, $client);
+    $comment = FileComment::factory()->for($file)->inThreadOf($client)->create(['author_id' => $client->id]);
+
+    // Deleting your own words inside the edit window is not moderation, and
+    // the boundary the moderation branch now carries must not reach it.
+    $this->actingAs($client)->deleteJson("/comments/{$comment->id}")->assertOk();
+
+    expect(FileComment::query()->whereKey($comment->id)->exists())->toBeFalse();
+});


### PR DESCRIPTION
## The problem

`FileCommentPolicy::moderate()` asked two questions and stopped:

```php
public function moderate(User $user): bool
{
    return $user->isStaff() && $user->can('moderate_comments');
}
```

No file predicate. And `delete()` returns `true` the moment `moderate()` does:

```php
public function delete(User $user, FileComment $comment): bool
{
    if ($this->moderate($user)) {
        return true;
    }

    return $comment->author_id === $user->id && $this->withinEditWindow($comment);
}
```

So a **client-scoped** staff member holding `moderate_comments` could delete any
comment on the installation by naming its id — including conversations belonging
to clients they are not assigned to, on files they cannot open.

Three call sites already knew the boundary belonged there and wrote it out by
hand instead, each with its own guard after the gate:

```php
Gate::forUser($viewer)->authorize('moderate', FileComment::class);
// Moderation rights are not a way around the library boundary.
abort_unless($this->library->allowsFile($viewer, $comment->file), 403);
```

The two that did **not** are `FileCommentsController::destroy()`, web and API.
Both routes bind a comment directly — `DELETE /comments/{comment}` and
`DELETE /api/v1/comments/{comment}` — so unlike the per-file endpoints there is
no earlier `Gate::authorize('view', $file)` in the request to establish that the
viewer may see the file at all. The policy was the whole gate, and the policy
did not look.

## Why this is the codebase's own rule, not a new one

The intent is already written down in three places; it just was not enforced
where those places say it is:

- `StaffLibraryScope` — "Every staff listing goes through here, and **the
  policies consult allowsFile()/allowsFolder()** so direct access (download,
  details, edit…) respects the same boundary."
- `VisibleCommentScope::across()` — "**A moderation screen is not a way around
  the visibility model** — moderating means deciding about comments you can
  already see."
- `CommentsController::approve()` — "Moderation rights are not a way around the
  library boundary."

`FilePolicy` already ANDs `$this->scope->allowsFile(...)` into `view`, `update`
and `delete`. `FileCommentPolicy` was the one policy in the family that did not.

## Reachability

Not reachable with the shipped roles: only `SystemAdministrator` and
`AccountManager` carry `moderate_comments`, and neither is client-scoped. It
needs a custom client-scoped role that has been granted the permission — which
the roles screen offers, and which `CommentModerationTest` already builds a case
around for the queue.

## The fix

The boundary moves into the policy, and the three hand-written guards collapse
into it:

```php
public function moderate(User $user, ?FileComment $comment = null): bool
{
    if (! $user->isStaff() || ! $user->can('moderate_comments')) {
        return false;
    }

    if ($comment === null || ! $user->isClientScoped()) {
        return true;
    }

    return $this->library->files($user)->whereKey($comment->file_id)->exists();
}
```

Named against the class it still answers the coarser question — "does this user
moderate at all" — which is what the queue's own gate and the approve
affordance ask. Every caller holding a comment now passes it.

Membership is tested **by file id** rather than through `$comment->file`: `File`
is soft-deleted, so the relation resolves to `null` for a file deleted out from
under its comments, and for a scoped moderator the answer is the same either way
— it is not in their library.

### Not changed (deliberate)

- **The author branch of `delete()`.** Deleting your own words inside the edit
  window is not moderation, and a client is not client-scoped in
  `StaffLibraryScope`'s sense (`isClientScoped()` is `isStaff() && …`), so
  applying the boundary there would take away a client's ability to delete their
  own comment. A test pins this.
- **`update()`.** Already author-only; moderators are excluded by design, as its
  docblock explains.
- **`CommentPresenter`'s class-form check.** By the time a thread is presented,
  the viewer has passed `view` on the file, and `FilePolicy::view` already ANDs
  `allowsFile`.
- **`GET /comments/pending` and the `/comments` listing.** Both already narrow
  through `StaffLibraryScope::files()`; the finding was about direct access, not
  the lists.

### One documentation change falls out of this

Approving through the API derives its `403` from `Gate::authorize` now that the
`abort_unless` is gone. Scramble does not detect `Gate::forUser($viewer)->authorize(...)`,
so the committed document gains the shared `AuthorizationException` ref in place
of an inline `"description": "An error"` schema:

```diff
                     "403": {
-                        "description": "An error",
-                        "content": { ... "examples": [""] ... }
+                        "$ref": "#/components/responses/AuthorizationException"
                     },
```

That is the shape nine of the other twelve documented 403s already use.
Regenerated with `php artisan scramble:export`.

## What this costs, and the one line that removes it

Worth stating plainly rather than leaving to be discovered. Moving the boundary
into the policy means `can_delete` on the moderation screen now asks a question
that touches the database, once per row, for a **client-scoped** moderator.
Measured on `/comments` with 25 rows:

| viewer | before | after |
|---|---|---|
| unscoped staff | 19 queries | 19 queries |
| client-scoped, 1 assigned client | 29 | 129 |
| client-scoped, 5 assigned clients | 65 | 465 |

Unscoped staff — the ordinary case — pay nothing, because `moderate()` returns
before the boundary is consulted.

The cost is not really in this change. `StaffLibraryScope::files()` calls
`File::scopeVisibleToClient()` once per assigned client, and that scope runs
four immediate queries every time it is used to build a query — the client's
group ids (`File.php:306`), the same ids again inside
`Folder::sharedFolderIds()`, that method's own assignment lookup, and the
`->get()` of shared folders in `Folder::scopeVisibleToClient()`. None of them
depend on the query being built, and none are cached. This change simply calls
that helper more often. The same shape already exists on `main` elsewhere —
`FileVersions::sharedAudience()` runs it twice per candidate while resolving
notification recipients.

If the cost matters more to you than the argument above, one line removes it
entirely. Every row on this screen comes from `VisibleCommentScope::across()`,
which is already narrowed to the viewer's library, and the route itself demands
`moderate_comments` — so the answer here is a foregone yes:

```php
'can_delete' => true,
```

Measured, that returns the page to exactly the numbers in the "before" column.
It is deliberately **not** in this changeset, because this change argues that
authorization belongs in the policy and that callers restating it are how the
original bug happened — and a hardcoded flag is a caller restating it. It would
also offer a button that answers 403 if `across()` were ever widened. Both are
small prices; they are just not ours to pay on your behalf. Say the word and it
goes in.

## Tests

`tests/Feature/Comments/ModerationLibraryScopeTest.php`, seven cases: the two
holes, the three collapsed guards as regression, and both directions of "the fix
is not deny-everything" (a scoped moderator still moderates their own clients'
files; an unscoped one still reaches everything; an author still deletes their
own comment).

Counter-check, stated plainly: against the unfixed code **two of the seven go
red** — `DELETE /comments/{comment}` answers **200** and
`DELETE /api/v1/comments/{comment}` answers **204**, both having deleted a
comment on a file outside the moderator's library. The other five hold without
the fix; they are regression guards for the guards this collapses, not proof of
the bug.

Full suite passes (1854 passed / 2 skipped), PHPStan level 8 clean.