### PR TITLE
Scope the dashboard's staff widgets, as the pages they summarise already are

### DIFF
--- a/app/Modules/Audit/Http/Controllers/DashboardController.php
+++ b/app/Modules/Audit/Http/Controllers/DashboardController.php
@@ -9,8 +9,10 @@ use App\Models\User;
 use App\Modules\Api\ApiUsage;
 use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLog;
+use App\Modules\Audit\ActivityLogScope;
 use App\Modules\Audit\DashboardWidgetPreferences;
 use App\Modules\Clients\ClientStorageUsage;
+use App\Modules\Files\Access\StaffLibraryScope;
 use App\Modules\Files\Models\File;
 use App\Modules\Groups\Models\Group;
 use App\Modules\Identity\UserType;
@@ -50,6 +52,8 @@ class DashboardController extends Controller
         private readonly Installation $installation,
         private readonly TimezoneRegistry $timezones,
         private readonly SystemEnvironment $environment,
+        private readonly StaffLibraryScope $library,
+        private readonly ActivityLogScope $activityScope,
     ) {}
 
     public function __invoke(Request $request): Response
@@ -81,10 +85,10 @@ class DashboardController extends Controller
                 ? ['preset' => $preset, 'from' => $from->toDateString(), 'to' => $to->toDateString()]
                 : null,
             'top_clients_by_storage' => $canStatistics && $prefs->isEnabled($user, 'top_clients_by_storage')
-                ? $this->topClientsByStorage()
+                ? $this->topClientsByStorage($user)
                 : null,
             'largest_files' => $canStatistics && $prefs->isEnabled($user, 'largest_files') ? $this->largestFiles($user) : null,
-            'recent' => $canActionsLog && $prefs->isEnabled($user, 'recent') ? $this->recentActivity() : null,
+            'recent' => $canActionsLog && $prefs->isEnabled($user, 'recent') ? $this->recentActivity($user) : null,
             'system' => $canSystem && $prefs->isEnabled($user, 'system') ? $this->systemInfo() : null,
             // Both editions — informational content, not an update action,
             // so no Capability check alongside the permission (unlike
@@ -274,13 +278,26 @@ class DashboardController extends Controller
      * ClientStorageUsage::quotaMb()) so the widget reads the same way
      * the client-facing usage box does.
      *
+     * "Clients" means the viewer's own, for a client-scoped one: the
+     * roster assigned to them, which is the same set ActivityLogScope
+     * lets them read log entries about. Unscoped staff get every client,
+     * as before.
+     *
      * @return list<array{id: int, name: string, used_bytes: int, quota_mb: int}>
      */
-    private function topClientsByStorage(): array
+    private function topClientsByStorage(User $viewer): array
     {
-        $rows = File::query()
+        $clientIds = $this->library->assignableClientIds($viewer);
+
+        $query = File::query()
             ->select('uploaded_by', DB::raw('SUM(size) as total_bytes'))
-            ->whereHas('uploader', fn ($query) => $query->where('type', UserType::Client))
+            ->whereHas('uploader', fn ($query) => $query->where('type', UserType::Client));
+
+        if ($clientIds !== null) {
+            $query->whereIn('uploaded_by', $clientIds);
+        }
+
+        $rows = $query
             ->groupBy('uploaded_by')
             ->orderByDesc('total_bytes')
             ->limit(5)
@@ -313,16 +330,21 @@ class DashboardController extends Controller
     }
 
     /**
-     * The 10 largest individual files on the installation, regardless of
+     * The 10 largest files in the viewer's library, regardless of
      * uploader — catches a single space hog that per-client aggregates
      * (topClientsByStorage()) can't surface on their own.
      *
-     * Edit/download/uploader links are coarse-gated on the viewer's own
-     * permissions only (same level of precision ActivityLogController's
-     * own link resolver uses) — not a per-file StaffLibraryScope check,
-     * so a client-scoped staff member could still see a link here that
-     * 403s if clicked. Accepted, matching existing precedent, rather
-     * than adding per-row scope checks to a 10-row dashboard widget.
+     * "Their library" is StaffLibraryScope, the same set the file
+     * listings show them: the whole installation for unscoped staff, own
+     * uploads plus assigned clients' content for a client-scoped one. A
+     * widget is a listing like any other, and this one named files by
+     * name and size.
+     *
+     * Edit/download/uploader links stay coarse-gated on the viewer's own
+     * permissions (same level of precision ActivityLogController's own
+     * link resolver uses). With the rows scoped, the links can no longer
+     * point at a file the viewer would get a 403 on — only at one they
+     * lack the permission for.
      *
      * @return list<array{id: int, name: string, size: int, uploader_name: ?string, created_at: string, edit_url: ?string, download_url: ?string, uploader_edit_url: ?string}>
      */
@@ -338,7 +360,7 @@ class DashboardController extends Controller
         $staffModule = $this->capabilities->has(Capability::UsersManage) && $viewer->can('manage_users');
         $canStaffUsers = $staffModule && $viewer->can('edit_users');
 
-        return array_values(File::query()
+        return array_values($this->library->files($viewer)
             ->with('uploader:id,name,type')
             ->orderByDesc('size')
             ->limit(10)
@@ -376,9 +398,16 @@ class DashboardController extends Controller
         // Same coarse gate largestFiles() uses for its edit links.
         $canFiles = $viewer->can('upload') || $viewer->can('edit_files') || $viewer->can('edit_others_files');
 
+        // Built once and cloned per use. StaffLibraryScope::files() runs a
+        // handful of queries per assigned client while it assembles, so the
+        // count and the rows are worth sharing one build; and cloning both
+        // sides rather than reusing one keeps the source query unmutated, so
+        // the order the array happens to be evaluated in cannot matter.
+        $expired = $this->library->files($viewer)->expired();
+
         return [
-            'count' => File::query()->expired()->count(),
-            'files' => array_values(File::query()->expired()->orderBy('expires_at')->limit(10)
+            'count' => (clone $expired)->count(),
+            'files' => array_values((clone $expired)->orderBy('expires_at')->limit(10)
                 ->get(['id', 'name', 'expires_at'])
                 ->map(fn (File $file): array => [
                     'id' => $file->id,
@@ -394,11 +423,21 @@ class DashboardController extends Controller
     }
 
     /**
+     * The viewer's eight most recent readable log entries.
+     *
+     * Through ActivityLogScope, like the activity page, the CSV export,
+     * the downloads report and the API — this was the fifth reader and
+     * the only one that skipped it. An entry carries the subject's name,
+     * so an unscoped one here handed a client-scoped viewer the names of
+     * files and accounts the rest of the application answers 403 or 404
+     * about; that scope's own docblock spells out why, and names the
+     * Client Manager system role as the configuration it applies to.
+     *
      * @return array<int, array<string, mixed>>
      */
-    private function recentActivity(): array
+    private function recentActivity(User $viewer): array
     {
-        return ActivityLog::query()
+        return $this->activityScope->apply(ActivityLog::query(), $viewer)
             ->orderByDesc('created_at')
             ->orderByDesc('id')
             ->limit(8)

--- a/tests/Feature/Audit/DashboardWidgetScopeTest.php
+++ b/tests/Feature/Audit/DashboardWidgetScopeTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Files\Models\File;
+use App\Modules\Identity\Permissions\SystemRole;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Testing\AssertableInertia;
+
+/**
+ * The dashboard's staff widgets against the two boundaries the rest of
+ * the application applies: ActivityLogScope for the log, and
+ * StaffLibraryScope for files and clients.
+ *
+ * The viewer throughout is a stock Client Manager — the seeded role that
+ * ships with view_actions_log and view_statistics and is client-scoped,
+ * so none of this needs a custom role to reproduce.
+ */
+beforeEach(function () {
+    Storage::fake('files');
+    $this->admin = User::factory()->create();
+
+    $this->manager = User::factory()->role(SystemRole::ClientManager)->create();
+    $this->mine = User::factory()->client()->create(['name' => 'My Own Client']);
+    $this->manager->assignedClients()->sync([$this->mine->id]);
+
+    $this->stranger = User::factory()->client()->create(['name' => 'Stranger Client Ltd']);
+});
+
+/** @return array<string, mixed> */
+function dashboardProps(User $viewer): array
+{
+    $props = [];
+
+    test()->actingAs($viewer)->get('/dashboard')->assertInertia(function (AssertableInertia $page) use (&$props) {
+        $props = $page->toArray()['props'];
+    });
+
+    return $props;
+}
+
+/** @return list<string> */
+function activityNames(array $entries): array
+{
+    return collect($entries)->flatMap(fn (array $entry): array => array_values($entry['replacements'] ?? []))->all();
+}
+
+it('keeps the recent activity widget inside the same scope as the activity page', function () {
+    $secret = uploadNamedFile($this->admin, 'Q4-payroll-secret');
+    shareFileWith($secret, $this->stranger);
+    $this->actingAs($this->stranger)->get("/files/{$secret->id}/download")->assertOk();
+
+    $ours = uploadNamedFile($this->admin, 'brochure');
+    shareFileWith($ours, $this->mine);
+
+    // The premise: the file itself is out of reach.
+    $this->actingAs($this->manager)->get("/files/{$secret->id}/download")->assertForbidden();
+
+    $names = activityNames(dashboardProps($this->manager)['recent'] ?? []);
+
+    expect($names)->not->toContain('Q4-payroll-secret')
+        ->and($names)->not->toContain('Stranger Client Ltd')
+        ->and($names)->toContain('brochure');
+});
+
+it('keeps the largest files widget inside the viewer library', function () {
+    $secret = uploadNamedFile($this->admin, 'Q4-payroll-secret');
+    $secret->forceFill(['size' => 999_999_999])->save();
+
+    $ours = uploadNamedFile($this->admin, 'brochure');
+    shareFileWith($ours, $this->mine);
+
+    $names = collect(dashboardProps($this->manager)['largest_files'] ?? [])->pluck('name')->all();
+
+    expect($names)->not->toContain('Q4-payroll-secret')
+        ->and($names)->toContain('brochure');
+});
+
+it('keeps the expired files widget, and its count, inside the viewer library', function () {
+    $secret = uploadNamedFile($this->admin, 'expired-merger-plan');
+    $secret->forceFill(['expires_at' => now()->subDay()])->save();
+
+    $ours = uploadNamedFile($this->manager, 'expired-brochure');
+    $ours->forceFill(['expires_at' => now()->subDay()])->save();
+
+    $widget = dashboardProps($this->manager)['expired_files'] ?? [];
+    $names = collect($widget['files'] ?? [])->pluck('name')->all();
+
+    expect($names)->not->toContain('expired-merger-plan')
+        ->and($names)->toContain('expired-brochure')
+        ->and($widget['count'] ?? null)->toBe(1);
+});
+
+/**
+ * StaffLibraryScope reaches an assigned client's content through
+ * File::scopeVisibleToClient, which ends in notExpired() — so an expired
+ * file belonging to an assigned client is not in a scoped viewer's
+ * library, and the file listing does not show it either. The widget now
+ * agrees with the listing instead of being the one place that didn't.
+ */
+it('agrees with the file listing about an assigned client expired file', function () {
+    $theirs = uploadNamedFile($this->admin, 'expired-client-file');
+    shareFileWith($theirs, $this->mine);
+    $theirs->forceFill(['expires_at' => now()->subDay()])->save();
+
+    $listing = $this->actingAs($this->manager)->get('/files');
+    $widget = dashboardProps($this->manager)['expired_files'] ?? [];
+
+    expect(str_contains($listing->getContent(), 'expired-client-file'))->toBeFalse()
+        ->and(collect($widget['files'] ?? [])->pluck('name')->all())->not->toContain('expired-client-file')
+        ->and($widget['count'] ?? null)->toBe(0);
+});
+
+it('names only the viewer own clients in the storage widget', function () {
+    foreach ([[$this->mine, 'mine'], [$this->stranger, 'theirs']] as [$client, $label]) {
+        $file = uploadNamedFile($this->admin, "upload-{$label}");
+        $file->forceFill(['uploaded_by' => $client->id, 'size' => 5_000_000])->save();
+    }
+
+    $names = collect(dashboardProps($this->manager)['top_clients_by_storage'] ?? [])->pluck('name')->all();
+
+    expect($names)->not->toContain('Stranger Client Ltd')
+        ->and($names)->toContain('My Own Client');
+});
+
+it('leaves an unscoped staff dashboard installation-wide', function () {
+    $staff = User::factory()->role(SystemRole::AccountManager)->create();
+
+    $secret = uploadNamedFile($this->admin, 'Q4-payroll-secret');
+    $secret->forceFill(['size' => 999_999_999, 'expires_at' => now()->subDay()])->save();
+    $secret->forceFill(['uploaded_by' => $this->stranger->id])->save();
+
+    expect($staff->isClientScoped())->toBeFalse();
+
+    $props = dashboardProps($staff);
+
+    expect(activityNames($props['recent'] ?? []))->toContain('Q4-payroll-secret')
+        ->and(collect($props['largest_files'] ?? [])->pluck('name')->all())->toContain('Q4-payroll-secret')
+        ->and(collect($props['expired_files']['files'] ?? [])->pluck('name')->all())->toContain('Q4-payroll-secret')
+        ->and(collect($props['top_clients_by_storage'] ?? [])->pluck('name')->all())->toContain('Stranger Client Ltd');
+});
+
+it('still shows a scoped viewer their own actions', function () {
+    $own = uploadNamedFile($this->manager, 'my-own-upload');
+
+    expect(activityNames(dashboardProps($this->manager)['recent'] ?? []))->toContain('my-own-upload')
+        ->and(collect(dashboardProps($this->manager)['largest_files'] ?? [])->pluck('name')->all())
+        ->toContain('my-own-upload')
+        ->and($own->uploaded_by)->toBe($this->manager->id);
+});


### PR DESCRIPTION
## The rule this is missing

`ActivityLogScope` opens by stating it (`app/Modules/Audit/ActivityLogScope.php:14-37`):

> `view_actions_log` alone is not the whole answer for a client-scoped staff
> member (see `User::isClientScoped`). Scoping restricts which library content
> they can reach, but an activity row carries the subject's *name* — and, for
> downloads, who fetched it and from which IP — so an unscoped log hands over
> exactly the information the scope exists to withhold: a Client Manager could
> read the names of every file in the installation and who touched them, while
> getting a 403 on the files themselves. **The Client Manager system role ships
> with `view_actions_log`, so this is the default configuration, not an exotic
> one.**

Four things read the activity log and apply it: `ActivityLogController::index`,
its CSV export, `Api\ActivityController:64`, and `DownloadsController:101`. The
dashboard's Recent activity widget is the fifth and does not:

```php
private function recentActivity(): array
{
    return ActivityLog::query()
        ->orderByDesc('created_at')
        …
```

The three `view_statistics` widgets have the same shape against
`StaffLibraryScope`:

```php
'largest_files' => …,        // File::query()->orderByDesc('size')->limit(10)
'expired_files' => …,        // File::query()->expired(), plus an installation-wide count
'top_clients_by_storage' =>  // File::query()->…->whereHas('uploader', client)
```

`SystemRole::ClientManager` ships with `ViewActionsLog` **and** `ViewStatistics`
(`app/Modules/Identity/Permissions/SystemRole.php:107-120`) and is the one
seeded role for which `isClientScoped()` is true. One stock role, no custom
configuration, sees all four.

## What that gets you

Measured on a stock `Client Manager` with one assigned client, against a file
belonging to a client that is not theirs:

| | |
|---|---|
| `GET /files/{id}/download` | **403** |
| `/activity` | does **not** name the file |
| `/dashboard` → `recent` | **names it** |
| `/dashboard` → `largest_files` | **names it**, with its size |
| `/dashboard` → `expired_files` | **names it**, and counts installation-wide |
| `/dashboard` → `top_clients_by_storage` | **names clients** off the whole roster |

The activity page is narrowed and the widget that summarises it is not, on the
same screen, for the same viewer, in the same session.

## The fix

Each widget asks the boundary its own page asks.

```php
private function recentActivity(User $viewer): array
{
    return $this->activityScope->apply(ActivityLog::query(), $viewer)
        ->orderByDesc('created_at')
        …
```

`largestFiles()` and `expiredFiles()` read `StaffLibraryScope::files($viewer)`
— the set the file listings show — including the count beside the expired list,
so the number and the rows cannot disagree. `topClientsByStorage()` narrows to
`assignableClientIds($viewer)`, the same roster `ActivityLogScope` allows log
entries about.

Unscoped staff are unaffected everywhere: both scopes return the unmodified
query for them, and `assignableClientIds()` returns `null`.

### Three consequences, named rather than left to be found

**`largest_files` links.** Its docblock accepted that a scoped viewer could see
an edit or download link that 403s if clicked, "matching existing precedent,
rather than adding per-row scope checks to a 10-row dashboard widget". With the
rows scoped that can no longer happen. The links keep their coarse permission
gate, so a viewer can still see a link they lack the *permission* for — which is
the precedent that was actually being appealed to.

**`expired_files` for a scoped viewer** now holds their own expiring uploads and
not an assigned client's. `StaffLibraryScope` reaches a client's content through
`File::scopeVisibleToClient`, which ends in `notExpired()`, so an expired file of
theirs is not in that library — and `GET /files` does not list it either. The
widget was the one place it appeared. A Client Manager uploading on a client's
behalf owns those rows (`uploaded_by`) and still sees them; a test pins the
listing and the widget now agreeing.

**What it costs.** `StaffLibraryScope::files()` builds its per-client branch by
walking `$user->assignedClients` and adding a `File::scopeVisibleToClient` clause
for each, and that scope runs four immediate queries every time it is used to
build one — the same property **#1698** sets out at length, since applying the
boundary in one more place is what both changes do. That is why the file
listings are priced the way they are, and the dashboard now pays the same way.
Measured on a client-scoped viewer, whole dashboard render:

| assigned clients | before | after |
|---|---|---|
| 5 | 24 queries | 82 |
| 25 | 24 queries | 300 |

An unscoped viewer is unchanged at 27, since both scopes return early. For
reference, `GET /files` for that same 25-client viewer costs 143 today, and a
single `files()` assembly costs 78 — so the dashboard, which was cheaper than
any file page, is now dearer than one. It builds the library query twice: once
for `largest_files`, once for `expiredFiles()`.

`expiredFiles()` builds it once and clones it for the count and for the rows,
rather than building it twice two lines apart. Cloning both sides rather than
reusing one keeps the source query unmutated, so the order the array happens to
be evaluated in cannot matter; `Eloquent\Builder::__clone()` clones the
underlying query builder, so the `orderBy`/`limit` on the rows does not reach
the count. Verified past the ten-row cap: with thirteen expired files the count
is thirteen and the list is ten, exactly as before.

That is as far as this change goes. Folding `largestFiles()` in as well would
bring 25 clients to 225, but it means threading the builder through
`__invoke()` and annotating it — a shape change to the controller inside a fix
that is about a boundary. The rest of the cost is `StaffLibraryScope::files()`
itself, which is one question worth answering once, on its own, rather than
piecemeal inside fixes that are about something else.

### Not changed (deliberate)

- **Counters and Transfers.** Both are aggregates that name nothing. Counters is
  gated on `view_dashboard_counters`, which Client Manager does not hold;
  Transfers is a per-day count of uploads and downloads. Narrowing a figure is a
  decision about what the figure means — a product question, not a boundary
  being restored.
- **The `api` widget.** Already scoped to the viewer's own tokens.
- **`ActivityLogScope` and `StaffLibraryScope` themselves.** Unchanged; this is
  four call sites that were not using them.

## Merge note

**Both this and #1685 merge into `main` on their own** — the two only collide
with each other, so whichever you take first goes in untouched and I will push
the resolution onto the other. Nothing needs doing to #1685; rebasing it onto
this would only break it against `main`. The detail is below so the second merge
holds no surprises.

This touches `recentActivity()`, which **#1685** also touches — it routes the
same method through `ActivityPresenter`. `git merge-tree` reports three
conflicts in `DashboardController.php`, all mechanical, and both sides are
wanted in each:

1. the import block — keep both `ActivityLogScope` and `ActivityPresenter`;
2. the constructor — keep all three new promoted properties;
3. `recentActivity()`'s first statement — keep #1685's comment above it, and
   `$this->activityScope->apply(ActivityLog::query(), $viewer)` as the
   expression. #1685's `->map(fn (ActivityLog $entry): array => $this->presenter->present($entry))`
   is below the conflict and survives untouched.

Resolved that way and re-measured, in both directions: full suite
**1856 passed / 1 skipped**, PHPStan clean.

Clean against every other open branch.

## Tests

`tests/Feature/Audit/DashboardWidgetScopeTest.php`, seven cases: the recent
widget against the activity page, largest files, expired files with its count,
the listing and the expired widget agreeing about an assigned client's expired
file, the storage widget's client names, an unscoped viewer's dashboard still
installation-wide, and a scoped viewer still seeing their own uploads and their
own actions.

Counter-check, stated plainly: against the unfixed code **five of the seven go
red**. The other two hold without the fix — they are regression guards for what
must not change (unscoped staff unaffected; a scoped viewer keeps their own
content), not proof of the bug.

Full suite **1855 passed / 1 skipped** against `main` at `073101d1` (baseline
1848 / 1, same container image — exactly the seven new tests, nothing else
moved). PHPStan level 8 clean. `pint --test` clean on both changed files.