### PR TITLE
Nobody lifts a limit they are standing inside

### DIFF
--- a/app/Modules/Identity/Http/Controllers/RolesController.php
+++ b/app/Modules/Identity/Http/Controllers/RolesController.php
@@ -89,9 +89,12 @@ class RolesController extends Controller
 
         $this->guardGrantablePermissions($request, $validated['permissions'] ?? []);
 
+        $clientScoped = $request->boolean('client_scoped');
+        $this->guardScopeRemoval($request, removesScope: ! $clientScoped);
+
         $role = Role::query()->create([
             'name' => $validated['name'],
-            'client_scoped' => $validated['client_scoped'] ?? false,
+            'client_scoped' => $clientScoped,
         ]);
 
         $this->syncPermissions($role, $validated['permissions'] ?? []);
@@ -135,9 +138,12 @@ class RolesController extends Controller
         // Built-in roles have fixed names and a fixed scope flag; only their
         // permission set is editable. Custom roles can change name + scope.
         if (! $role->is_system) {
+            $clientScoped = $request->boolean('client_scoped');
+            $this->guardScopeRemoval($request, removesScope: $role->client_scoped && ! $clientScoped);
+
             $role->update([
                 'name' => $validated['name'],
-                'client_scoped' => $validated['client_scoped'] ?? false,
+                'client_scoped' => $clientScoped,
             ]);
         }
 
@@ -210,6 +216,46 @@ class RolesController extends Controller
                 ]),
             ]);
         }
+    }
+
+    /**
+     * The same rule for the other half of what a role carries.
+     *
+     * `client_scoped` decides how much of the library the role reaches,
+     * which makes it authority in exactly the sense the docblock above
+     * describes -- and the larger part of it, since it is what stands
+     * between a limited staff member and every file on the installation.
+     * Both writers of the flag went through nothing at all, so
+     * `manage_users` alone was enough to mint a role without the limit,
+     * or to lift it off the actor's own, and then to hold it.
+     *
+     * Phrased as "removes the limit" rather than "is not limited", so
+     * that only what this request actually changes is checked -- the same
+     * reasoning that has guardGrantablePermissions look at the diff.
+     * Editing an already-unlimited role's permissions is not this actor
+     * lifting a limit, and StaffAccounts::mayGrant is what stops them
+     * holding the result either way.
+     *
+     * Callers resolve the flag with Request::boolean() and hand the same
+     * value to this guard and to the write, deliberately. The `boolean`
+     * validation rule accepts "0" and 0 as well as false but does not
+     * cast, so reading the validated array and comparing it strictly
+     * would let a request through here that the model's `boolean` cast
+     * then stores as false anyway -- the guard and the write disagreeing
+     * about one value is exactly the shape this guard exists to prevent.
+     */
+    private function guardScopeRemoval(Request $request, bool $removesScope): void
+    {
+        $actor = $request->user();
+        assert($actor !== null);
+
+        if (! $removesScope || ! $actor->isClientScoped()) {
+            return;
+        }
+
+        throw ValidationException::withMessages([
+            'client_scoped' => __('Your own role is limited to the clients assigned to you, so a role you create or edit cannot drop that limit.'),
+        ]);
     }
 
     /**

--- a/app/Modules/Identity/StaffAccounts.php
+++ b/app/Modules/Identity/StaffAccounts.php
@@ -45,8 +45,17 @@ class StaffAccounts
      * permission into every permission and makes the rest of the matrix
      * decorative.
      *
-     * An administrator holds every permission by construction, so this is
-     * always true for them and the admin experience is unchanged.
+     * A role's `client_scoped` flag is part of that authority, and the
+     * larger part: a role without it reaches the whole library, while a
+     * client-scoped actor reaches only the clients assigned to them. So
+     * one may not hand out a role that is not client-scoped -- to a
+     * colleague, to a new account, or to themselves, which is the case
+     * that matters, since the role picker is how an account changes role
+     * and an account may edit its own.
+     *
+     * An administrator holds every permission by construction and is
+     * never client-scoped, so this is always true for them and the admin
+     * experience is unchanged.
      */
     public function mayGrant(User $actor, Role $role): bool
     {
@@ -55,6 +64,10 @@ class StaffAccounts
         }
 
         if ($role->is_administrator) {
+            return false;
+        }
+
+        if ($actor->isClientScoped() && ! $role->client_scoped) {
             return false;
         }
 

--- a/tests/Feature/Identity/RoleScopeAuthorityTest.php
+++ b/tests/Feature/Identity/RoleScopeAuthorityTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Files\Access\StaffLibraryScope;
+use App\Modules\Identity\Models\Role;
+use App\Modules\Identity\Models\RolePermission;
+use App\Modules\Identity\Permissions\Permission;
+use App\Modules\Identity\Permissions\SystemRole;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia;
+
+/**
+ * A role's client_scoped flag is the boundary a limited staff member
+ * works inside. StaffAccounts already refuses to let anybody grant
+ * permissions they do not hold; this is the same rule for the flag that
+ * decides how much of the library the role reaches.
+ */
+beforeEach(function () {
+    Storage::fake('files');
+    $this->admin = User::factory()->create();
+
+    $this->scopedRole = Role::query()->create(['name' => 'Reps '.Str::random(6), 'client_scoped' => true]);
+    foreach ([Permission::ManageUsers, Permission::EditUsers, Permission::CreateUsers] as $permission) {
+        RolePermission::query()->create(['role_id' => $this->scopedRole->id, 'permission' => $permission->value]);
+    }
+
+    $this->rep = User::factory()->create(['role_id' => $this->scopedRole->id]);
+    $this->mine = User::factory()->client()->create();
+    $this->rep->assignedClients()->sync([$this->mine->id]);
+
+    // Somebody else's file: the thing the boundary is holding back.
+    $this->secret = uploadNamedFile($this->admin, 'not-theirs');
+});
+
+function unscopedRoleWith(array $permissions): Role
+{
+    $role = Role::query()->create(['name' => 'Wide '.Str::random(6), 'client_scoped' => false]);
+    foreach ($permissions as $permission) {
+        RolePermission::query()->create(['role_id' => $role->id, 'permission' => $permission->value]);
+    }
+
+    return $role;
+}
+
+function stillScoped(User $rep): bool
+{
+    $rep->refresh()->unsetRelation('role');
+
+    return $rep->isClientScoped();
+}
+
+test('a scoped staff member cannot lift the limit off their own role', function () {
+    $this->actingAs($this->rep)->patch("/roles/{$this->scopedRole->id}", [
+        'name' => $this->scopedRole->name,
+        'client_scoped' => false,
+        'permissions' => [Permission::ManageUsers->value, Permission::EditUsers->value, Permission::CreateUsers->value],
+    ])->assertSessionHasErrors('client_scoped');
+
+    expect($this->scopedRole->fresh()->client_scoped)->toBeTrue()
+        ->and(stillScoped($this->rep))->toBeTrue()
+        ->and(app(StaffLibraryScope::class)->files($this->rep)->pluck('id')->all())
+        ->not->toContain($this->secret->id);
+});
+
+test('a scoped staff member cannot mint a role without the limit', function () {
+    $this->actingAs($this->rep)->post('/roles', [
+        'name' => 'Escape Hatch',
+        'client_scoped' => false,
+        'permissions' => [Permission::ManageUsers->value],
+    ])->assertSessionHasErrors('client_scoped');
+
+    expect(Role::query()->where('name', 'Escape Hatch')->exists())->toBeFalse();
+});
+
+/**
+ * The `boolean` validation rule accepts "0" and 0 as well as false, and
+ * validates without casting -- so a guard that compares the validated
+ * value strictly against false sees a string, waves the request through,
+ * and the model's own `boolean` cast then writes the flag as false. Both
+ * writers read the flag with Request::boolean() for that reason, and
+ * these two pin it: the same two requests as above, spelled the other
+ * way, have to be refused the same way.
+ */
+test('the limit cannot be dropped by spelling false as "0"', function () {
+    $this->actingAs($this->rep)->patch("/roles/{$this->scopedRole->id}", [
+        'name' => $this->scopedRole->name,
+        'client_scoped' => '0',
+        'permissions' => [Permission::ManageUsers->value, Permission::EditUsers->value, Permission::CreateUsers->value],
+    ])->assertSessionHasErrors('client_scoped');
+
+    expect($this->scopedRole->fresh()->client_scoped)->toBeTrue()
+        ->and(stillScoped($this->rep))->toBeTrue()
+        ->and(app(StaffLibraryScope::class)->files($this->rep)->pluck('id')->all())
+        ->not->toContain($this->secret->id);
+
+    // And through the JSON door, where it arrives as an integer.
+    $this->actingAs($this->rep)->patchJson("/roles/{$this->scopedRole->id}", [
+        'name' => $this->scopedRole->name,
+        'client_scoped' => 0,
+        'permissions' => [Permission::ManageUsers->value, Permission::EditUsers->value, Permission::CreateUsers->value],
+    ])->assertStatus(422);
+
+    expect($this->scopedRole->fresh()->client_scoped)->toBeTrue();
+});
+
+test('a role without the limit cannot be minted by spelling false as "0"', function () {
+    $this->actingAs($this->rep)->post('/roles', [
+        'name' => 'Escape Hatch Zero',
+        'client_scoped' => '0',
+        'permissions' => [Permission::ManageUsers->value],
+    ])->assertSessionHasErrors('client_scoped');
+
+    expect(Role::query()->where('name', 'Escape Hatch Zero')->exists())->toBeFalse();
+});
+
+test('a scoped staff member cannot move into an unscoped role that already exists', function () {
+    $wide = unscopedRoleWith([Permission::ManageUsers, Permission::EditUsers, Permission::CreateUsers]);
+
+    $this->actingAs($this->rep)->patch("/users/{$this->rep->id}", [
+        'name' => $this->rep->name,
+        'email' => $this->rep->email,
+        'role_id' => $wide->id,
+        'active' => true,
+    ])->assertSessionHasErrors('role_id');
+
+    expect(stillScoped($this->rep))->toBeTrue()
+        ->and(app(StaffLibraryScope::class)->files($this->rep)->pluck('id')->all())
+        ->not->toContain($this->secret->id);
+});
+
+test('a scoped staff member cannot hand an unscoped role to anybody else either', function () {
+    $wide = unscopedRoleWith([Permission::ManageUsers]);
+
+    $this->actingAs($this->rep)->post('/users', [
+        'name' => 'New Rep',
+        'email' => 'new-rep@example.test',
+        'role_id' => $wide->id,
+        'password' => 'a-strong-password-1',
+        'password_confirmation' => 'a-strong-password-1',
+    ])->assertSessionHasErrors('role_id');
+
+    expect(User::query()->where('email', 'new-rep@example.test')->exists())->toBeFalse();
+});
+
+test('the staff form stops offering a role the request behind it would refuse', function () {
+    $wide = unscopedRoleWith([Permission::ManageUsers]);
+
+    $this->actingAs($this->rep)->get('/users/create')->assertInertia(
+        fn (AssertableInertia $page) => $page->where('roles', function ($roles) use ($wide) {
+            $ids = collect($roles)->pluck('id')->all();
+
+            expect($ids)->toContain($this->scopedRole->id)->not->toContain($wide->id);
+
+            return true;
+        })
+    );
+});
+
+test('a scoped staff member has no business editing an unscoped colleague', function () {
+    $wide = unscopedRoleWith([Permission::ManageUsers]);
+    $colleague = User::factory()->create(['role_id' => $wide->id]);
+
+    $this->actingAs($this->rep)->patch("/users/{$colleague->id}", [
+        'name' => 'Renamed',
+        'email' => $colleague->email,
+        'role_id' => $wide->id,
+        'active' => true,
+    ])->assertForbidden();
+
+    expect($colleague->fresh()->name)->not->toBe('Renamed');
+});
+
+test('the API surface refuses the same move', function () {
+    $wide = unscopedRoleWith([Permission::ManageUsers, Permission::EditUsers, Permission::CreateUsers]);
+    $token = $this->rep->createToken('t', [Permission::ManageUsers->value, Permission::EditUsers->value])->plainTextToken;
+
+    $this->withToken($token)
+        ->patchJson("/api/v1/users/{$this->rep->id}", ['role_id' => $wide->id])
+        ->assertStatus(422);
+
+    expect(stillScoped($this->rep))->toBeTrue();
+});
+
+test('a scoped staff member may still create and edit a role inside their own limit', function () {
+    $this->actingAs($this->rep)->post('/roles', [
+        'name' => 'Junior Rep',
+        'client_scoped' => true,
+        'permissions' => [Permission::ManageUsers->value],
+    ])->assertSessionHasNoErrors();
+
+    $junior = Role::query()->where('name', 'Junior Rep')->firstOrFail();
+    expect($junior->client_scoped)->toBeTrue();
+
+    $this->actingAs($this->rep)->patch("/roles/{$junior->id}", [
+        'name' => 'Junior Rep',
+        'client_scoped' => true,
+        'permissions' => [Permission::ManageUsers->value, Permission::EditUsers->value],
+    ])->assertSessionHasNoErrors();
+
+    expect($junior->fresh()->permissions()->pluck('permission')->all())
+        ->toContain(Permission::EditUsers->value);
+});
+
+test('an unscoped staff member with the same permissions is unaffected', function () {
+    $wideRole = unscopedRoleWith([Permission::ManageUsers, Permission::EditUsers, Permission::CreateUsers]);
+    $manager = User::factory()->create(['role_id' => $wideRole->id]);
+
+    $this->actingAs($manager)->post('/roles', [
+        'name' => 'Another Wide One',
+        'client_scoped' => false,
+        'permissions' => [Permission::ManageUsers->value],
+    ])->assertSessionHasNoErrors();
+
+    expect(Role::query()->where('name', 'Another Wide One')->value('client_scoped'))->toBeFalse();
+
+    $this->actingAs($manager)->patch("/users/{$manager->id}", [
+        'name' => $manager->name,
+        'email' => $manager->email,
+        'role_id' => $wideRole->id,
+        'active' => true,
+    ])->assertSessionHasNoErrors();
+});
+
+test('an administrator is unaffected', function () {
+    $this->actingAs($this->admin)->patch("/roles/{$this->scopedRole->id}", [
+        'name' => $this->scopedRole->name,
+        'client_scoped' => false,
+        'permissions' => [Permission::ManageUsers->value],
+    ])->assertSessionHasNoErrors();
+
+    expect($this->scopedRole->fresh()->client_scoped)->toBeFalse();
+});
+
+test('the seeded Client Manager role keeps its flag, as it always did', function () {
+    $clientManager = Role::query()->where('name', SystemRole::ClientManager->value)->firstOrFail();
+
+    $this->actingAs($this->rep)->patch("/roles/{$clientManager->id}", [
+        'name' => $clientManager->name,
+        'client_scoped' => false,
+        'permissions' => [],
+    ]);
+
+    expect($clientManager->fresh()->client_scoped)->toBeTrue();
+});


### PR DESCRIPTION
## The rule this is missing

`StaffAccounts` opens by stating it (`:39-49`):

> Nobody hands out authority they do not hold. `manage_users` is a permission
> like any other, so without this a non-administrator holding it could mint an
> administrator — or build a custom role carrying `edit_settings`,
> `delete_others_files`, anything — and assign it, to a new account or to
> themselves. That turns one permission into every permission and makes the
> rest of the matrix decorative.

`RolesController::guardGrantablePermissions()` says the same thing from the
other side (`:186-195`):

> A role is a bundle of authority, so minting one is handing authority out —
> the same rule as assigning a role (`UsersController::mayGrant`). Without
> this, a non-administrator holding `manage_users` could create a role
> carrying permissions they lack and then hold it themselves.

Both weigh the role's **permissions**. A role carries one more thing:
`client_scoped` decides whether its holder reaches the clients assigned to
them or the whole library — the boundary `StaffLibraryScope`,
`ActivityLogScope` and every listing in the application are built around.
Nothing weighs it.

```php
// RolesController::store():94
$role = Role::query()->create([
    'name' => $validated['name'],
    'client_scoped' => $validated['client_scoped'] ?? false,
]);

// RolesController::update():140
$role->update([
    'name' => $validated['name'],
    'client_scoped' => $validated['client_scoped'] ?? false,
]);
```

```php
// StaffAccounts::mayGrant():51-65 — permissions, and nothing else
$held = $this->permissions->grantedKeys($actor);
$granting = $role->permissions()->pluck('permission')->all();

return array_diff($granting, $held) === [];
```

## What that gets you

`manage_users` on a client-scoped custom role is enough to stop being
client-scoped. Two ways, both measured, both a redirect and no error:

- `PATCH /roles/{their own role}` with `client_scoped: false` — the flag is
  written with no authority check at all. The next request reads the whole
  library.
- `POST /roles` with `client_scoped: false` and the actor's own permission set
  — which passes `guardGrantablePermissions()`, since nothing is being granted
  that the actor lacks — followed by `PATCH /users/{their own id}` moving into
  it, which passes `mayGrant()` for the same reason.

Either way the account is no longer client-scoped, and the `assigned_clients`
roster that #1697 protects stops meaning anything for it: the roster only
narrows a role that is client-scoped (`syncAssignedClients():333`).

### Reachability, stated honestly

No shipped role combines `client_scoped` with `manage_users`. `Client Manager`,
the only client-scoped role that ships, is file-focused — and `update()`
already refuses to move the flag on a system role, which is why the stock role
was never the way in. This needs a custom role, which the roles screen offers
and `ClientScopingTest:180` pins as supported. That lowers the severity; it
does not make the configuration strange, and it is the same configuration
#1697 addresses.

## The fix

The missing clause goes into both halves of the pair that already exists.

**`RolesController::guardScopeRemoval()`** refuses a client-scoped actor who
creates a role without the limit, or takes the limit off one that has it:

```php
private function guardScopeRemoval(Request $request, bool $removesScope): void
{
    $actor = $request->user();
    assert($actor !== null);

    if (! $removesScope || ! $actor->isClientScoped()) {
        return;
    }

    throw ValidationException::withMessages([
        'client_scoped' => __('Your own role is limited to the clients assigned to you, so a role you create or edit cannot drop that limit.'),
    ]);
}
```

Phrased as "removes the limit" rather than "is not limited", so only what this
request actually changes is weighed — the same reasoning
`guardGrantablePermissions()` gives for looking at the diff:

> Only what the actor is losing or gaining needs checking: a permission already
> on the role and left untouched is not being granted by this actor, so editing
> an unrelated field never requires holding the whole existing set.

Editing an already-unlimited role's permissions is not this actor lifting a
limit, and it stays possible.

Both writers resolve the flag with `$request->boolean('client_scoped')` and hand
that same value to the guard **and** to the write. The `boolean` validation rule
accepts `"0"` and `0` as well as `false` and validates without casting, so
reading the validated array and comparing it strictly would let a request
through the guard that the model's own `boolean` cast then stores as `false`
anyway — the guard and the write disagreeing about one value, which is precisely
what this guard exists to prevent. Two cases pin it.

**`StaffAccounts::mayGrant()`** gains the corresponding clause:

```php
if ($actor->isClientScoped() && ! $role->client_scoped) {
    return false;
}
```

which closes assigning an existing unscoped role, and reaches every surface at
once: `assignableRoleIds()` validates `role_id` on the web and API staff forms
and on the account converter, `assignableRoles()` fills the pickers, and
`guardTarget()` covers the account itself.

Administrators are unaffected — `mayGrant()` returns early for them, and an
administrator role is never client-scoped. Unscoped staff are unaffected: the
clause is conditioned on the actor's own scope, so a non-administrator with
`manage_users` and no limit creates, edits and grants exactly as before.

### Two changes a client-scoped holder of `manage_users` will see

Both follow from `mayGrant()`, and both are the rule being applied rather than
a new one:

- **the role picker** on the staff form and the account converter now offers
  only client-scoped roles, rather than offering one the request behind it
  would refuse — the reason `roleOptions()` is narrowed at all;
- **editing or deleting a staff account whose role is not client-scoped** now
  answers 403, through `guardTarget()`, on the rule that method already states:
  "if the actor could not grant the target's role, they have no business
  editing or deleting that account either."

### Not changed (deliberate)

- **The seeded roles.** `update()` already refuses to move `client_scoped` on a
  system role; a test pins that the stock Client Manager still keeps its flag.
- **Which permissions a scoped actor may put on a role.** That is
  `guardGrantablePermissions()`'s question and it was already being asked.
- **`syncAssignedClients()`.** Unchanged, as in #1697.

The roles API is read-only — `GET /roles` is the whole surface
(`routes/api.php:240`) — so that half has no API twin to mirror. The account
half does, and `mayGrant()` covers it; a test pins `PATCH /api/v1/users/{user}`
answering 422.

## Merge note

Clean against all eighteen open branches, checked pairwise with
`git merge-tree --write-tree`. This touches `StaffAccounts.php`, which #1697
and #1678 also touch, but in different regions — `mayGrant()`'s body versus a
new method after `assignableRoleIds()` (#1697) and the import/constructor block
(#1678) — and `git` merges all three without help. Verified by merging into a
branch carrying all eighteen: suite green, PHPStan clean.

## Tests

`tests/Feature/Identity/RoleScopeAuthorityTest.php`, thirteen cases: lifting the
limit off the actor's own role, minting a role without one, the same two
requests spelled with `"0"` and with `0` over JSON, moving into an existing
unscoped role, handing one to a new account, the picker no longer offering it,
`guardTarget()` on an unscoped colleague, the API twin, a scoped actor still
creating and editing a role inside their own limit, an unscoped actor with the
same permissions unaffected, an administrator unaffected, and the seeded Client
Manager keeping its flag.

Counter-check, stated plainly: against the unfixed code **nine of the thirteen
go red**. The other four hold without the fix — they are regression guards for
what must not change, not proof of the bug.

Full suite **1861 passed / 1 skipped** against `main` at `073101d1` (baseline
1848 / 1, same container image — exactly the thirteen new tests, nothing else
moved). PHPStan level 8 clean. `pint --test` clean on all three changed files.