### PR TITLE
Group membership is a library boundary, not just a list

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -145,10 +145,14 @@ class HandleInertiaRequests extends Middleware
         }
 
         if ($checker->allows($user, Permission::ApproveGroupsMembershipsRequests)) {
+            // Narrowed like the queue it badges, and by the same scope —
+            // a client-scoped staff member is not shown a number they
+            // cannot act on. Same rule the comments badge below states.
             $counts['membership_requests'] = MembershipRequest::query()
                 ->pending()
                 ->whereHas('user')
                 ->whereHas('group')
+                ->approvableBy($user)
                 ->count();
         }
 

--- a/app/Modules/Files/Access/StaffLibraryScope.php
+++ b/app/Modules/Files/Access/StaffLibraryScope.php
@@ -6,7 +6,9 @@ namespace App\Modules\Files\Access;
 
 use App\Models\User;
 use App\Modules\Files\Models\File;
+use App\Modules\Files\Models\FileAssignment;
 use App\Modules\Files\Models\Folder;
+use App\Modules\Files\Models\FolderAssignment;
 use App\Modules\Groups\Models\Group;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -144,5 +146,66 @@ class StaffLibraryScope
         $ids = $this->assignableGroupIds($user);
 
         return $ids === null || in_array($group->id, $ids, true);
+    }
+
+    /**
+     * Whether a staff member may put a client into a group, or take one
+     * out again.
+     *
+     * Not canAssignGroup(): that answers "may I share with this group",
+     * and it answers it *from* the membership — a group counts as the
+     * user's because one of their clients is in it. Deciding membership
+     * with a predicate derived from membership means whoever may edit
+     * the list also decides what the list entitles them to, which is not
+     * a boundary at all. It is also the wrong answer here in the other
+     * direction: a group nobody has joined yet belongs to nobody, so a
+     * scoped staff member could never put the first member into a group
+     * they had just created.
+     *
+     * The question membership actually asks is about reach. Joining a
+     * group hands the new member everything shared with it, and — when
+     * that member is one of the actor's own clients — hands the actor
+     * the same content back through File::scopeVisibleToClient, which is
+     * what StaffLibraryScope::files() is built on. So both sides have to
+     * hold: the client must be one this staff member holds, and the
+     * group must not already reach beyond their library. A group with
+     * nothing shared with it passes trivially, which is what keeps a
+     * newly created one usable.
+     *
+     * Unscoped staff are unaffected — both halves are true for them by
+     * construction.
+     */
+    public function allowsGroupMembership(User $user, Group $group, User $client): bool
+    {
+        return $this->canAssignClient($user, $client) && $this->groupReachesNoFurther($user, $group);
+    }
+
+    /**
+     * Whether everything shared with this group is already inside the
+     * user's library — files assigned to it, and the folders whose
+     * subtrees it can browse.
+     */
+    private function groupReachesNoFurther(User $user, Group $group): bool
+    {
+        if (! $user->isClientScoped()) {
+            return true;
+        }
+
+        $morph = $group->getMorphClass();
+
+        $fileIds = FileAssignment::query()
+            ->where('assignable_type', $morph)->where('assignable_id', $group->id)
+            ->pluck('file_id')->unique();
+
+        if ($fileIds->isNotEmpty() && $this->files($user)->whereIn('id', $fileIds)->count() !== $fileIds->count()) {
+            return false;
+        }
+
+        $folderIds = FolderAssignment::query()
+            ->where('assignable_type', $morph)->where('assignable_id', $group->id)
+            ->pluck('folder_id')->unique();
+
+        return $folderIds->isEmpty()
+            || $this->folders($user)->whereIn('id', $folderIds)->count() === $folderIds->count();
     }
 }

--- a/app/Modules/Groups/Http/Controllers/Api/GroupMembersController.php
+++ b/app/Modules/Groups/Http/Controllers/Api/GroupMembersController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLogger;
+use App\Modules\Files\Access\StaffLibraryScope;
 use App\Modules\Groups\Http\Resources\Api\GroupResource;
 use App\Modules\Groups\Models\Group;
 use Illuminate\Http\Request;
@@ -17,6 +18,7 @@ class GroupMembersController extends Controller
 {
     public function __construct(
         private readonly ActivityLogger $activity,
+        private readonly StaffLibraryScope $scope,
     ) {}
 
     public function store(Request $request, Group $group): GroupResource
@@ -37,6 +39,17 @@ class GroupMembersController extends Controller
             ]);
         }
 
+        $actor = $request->user();
+        assert($actor instanceof User);
+
+        // Membership is a library boundary, not just a list: joining a
+        // group hands the new member everything shared with it, and if
+        // that member is one of the actor's own clients,
+        // File::scopeVisibleToClient hands the same content back to the
+        // actor. `edit_groups` in front of the route is a permission,
+        // not a boundary. See StaffLibraryScope::allowsGroupMembership.
+        abort_unless($this->scope->allowsGroupMembership($actor, $group, $client), 403);
+
         // syncWithoutDetaching, so adding an existing member is a no-op and
         // a retried request is safe.
         $group->members()->syncWithoutDetaching([$client->id]);
@@ -46,8 +59,15 @@ class GroupMembersController extends Controller
         return new GroupResource($group->loadCount('members')->load('members'));
     }
 
-    public function destroy(Group $group, User $member): GroupResource
+    public function destroy(Request $request, Group $group, User $member): GroupResource
     {
+        $actor = $request->user();
+        assert($actor instanceof User);
+
+        // The same boundary as store(): taking somebody out of a group
+        // is a decision about their access, and about a group.
+        abort_unless($this->scope->allowsGroupMembership($actor, $group, $member), 403);
+
         $group->members()->detach($member->id);
 
         $this->activity->log(Action::GroupMemberRemoved, subject: $group, context: ['member' => $member->name]);

--- a/app/Modules/Groups/Http/Controllers/GroupMembersController.php
+++ b/app/Modules/Groups/Http/Controllers/GroupMembersController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLogger;
+use App\Modules\Files\Access\StaffLibraryScope;
 use App\Modules\Groups\Models\Group;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -17,6 +18,7 @@ class GroupMembersController extends Controller
 {
     public function __construct(
         private readonly ActivityLogger $activity,
+        private readonly StaffLibraryScope $scope,
     ) {}
 
     public function store(Request $request, Group $group): RedirectResponse
@@ -35,6 +37,17 @@ class GroupMembersController extends Controller
             ]);
         }
 
+        $actor = $request->user();
+        assert($actor instanceof User);
+
+        // Membership is a library boundary, not just a list: joining a
+        // group hands the new member everything shared with it, and if
+        // that member is one of the actor's own clients,
+        // File::scopeVisibleToClient hands the same content back to the
+        // actor. `edit_groups` in front of the route is a permission,
+        // not a boundary. See StaffLibraryScope::allowsGroupMembership.
+        abort_unless($this->scope->allowsGroupMembership($actor, $group, $client), 403);
+
         $group->members()->syncWithoutDetaching([$client->id]);
 
         $this->activity->log(Action::GroupMemberAdded, subject: $group, context: ['member' => $client->name]);
@@ -42,8 +55,15 @@ class GroupMembersController extends Controller
         return back();
     }
 
-    public function destroy(Group $group, User $member): RedirectResponse
+    public function destroy(Request $request, Group $group, User $member): RedirectResponse
     {
+        $actor = $request->user();
+        assert($actor instanceof User);
+
+        // The same boundary as store(): taking somebody out of a group
+        // is a decision about their access, and about a group.
+        abort_unless($this->scope->allowsGroupMembership($actor, $group, $member), 403);
+
         $group->members()->detach($member->id);
 
         $this->activity->log(Action::GroupMemberRemoved, subject: $group, context: ['member' => $member->name]);

--- a/app/Modules/Groups/Http/Controllers/MembershipRequestsController.php
+++ b/app/Modules/Groups/Http/Controllers/MembershipRequestsController.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace App\Modules\Groups\Http\Controllers;
 
 use App\Http\Controllers\Controller;
+use App\Models\User;
 use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLogger;
+use App\Modules\Files\Access\StaffLibraryScope;
+use App\Modules\Groups\Models\Group;
 use App\Modules\Groups\Models\MembershipRequest;
 use App\Modules\Groups\Notifications\GroupMembershipDeniedNotification;
 use App\Modules\Notifications\Notifier;
@@ -30,6 +33,7 @@ class MembershipRequestsController extends Controller
         private readonly ActivityLogger $activity,
         private readonly Settings $settings,
         private readonly Notifier $notifier,
+        private readonly StaffLibraryScope $scope,
     ) {}
 
     public function index(Request $request): Response
@@ -40,12 +44,19 @@ class MembershipRequestsController extends Controller
 
         $filters = ['search' => $validated['search'] ?? null];
 
+        $viewer = $request->user();
+        assert($viewer !== null);
+
         $requests = MembershipRequest::query()
             ->pending()
             // A request whose client or group vanished is dead weight; excluding
             // it in SQL (not after fetching) keeps pagination counts honest.
             ->whereHas('user')
             ->whereHas('group')
+            // Narrowed the way the buttons on each row now are — see
+            // MembershipRequest::scopeApprovableBy, which the sidebar badge
+            // reads too so the number and this screen agree.
+            ->approvableBy($viewer)
             ->with(['group', 'user'])
             ->when($filters['search'], fn (Builder $query, string $search) => $query->where(fn (Builder $q) => $q
                 ->whereHas('user', fn (Builder $u) => $u->where('name', 'like', "%{$search}%")->orWhere('email', 'like', "%{$search}%"))
@@ -68,12 +79,14 @@ class MembershipRequestsController extends Controller
         ]);
     }
 
-    public function approve(MembershipRequest $membershipRequest): RedirectResponse
+    public function approve(Request $request, MembershipRequest $membershipRequest): RedirectResponse
     {
         $group = $membershipRequest->group;
         $client = $membershipRequest->user;
 
         abort_unless($group !== null && $client !== null && $membershipRequest->status === MembershipRequest::STATUS_PENDING, 404);
+
+        $this->guardRequest($request, $group, $client);
 
         $group->members()->syncWithoutDetaching([$client->id]);
         $membershipRequest->delete();
@@ -85,10 +98,14 @@ class MembershipRequestsController extends Controller
         return back()->with('success', __('Membership request approved.'));
     }
 
-    public function deny(MembershipRequest $membershipRequest): RedirectResponse
+    public function deny(Request $request, MembershipRequest $membershipRequest): RedirectResponse
     {
         $group = $membershipRequest->group;
         $client = $membershipRequest->user;
+
+        if ($group !== null && $client !== null) {
+            $this->guardRequest($request, $group, $client);
+        }
 
         // The denied row persists: the client sees the outcome, and it
         // enforces the re-request cooldown.
@@ -106,5 +123,26 @@ class MembershipRequestsController extends Controller
         }
 
         return back()->with('success', __('Membership request denied.'));
+    }
+
+    /**
+     * Approving a request is GroupMembersController::store by another
+     * door: it joins a client to a group, with the same consequence for
+     * what that client -- and any staff member holding them -- can reach
+     * afterwards. Denying one is a decision about somebody's client, and
+     * emails them about it. Both belong inside the same boundary, and
+     * `approve_groups_memberships_requests` in front of the route is a
+     * permission, not one.
+     *
+     * 404 rather than 403, matching the guard immediately above it in
+     * approve(): a request this staff member may not act on should not
+     * be distinguishable from one that is not there.
+     */
+    private function guardRequest(Request $request, Group $group, User $client): void
+    {
+        $viewer = $request->user();
+        assert($viewer !== null);
+
+        abort_unless($this->scope->allowsGroupMembership($viewer, $group, $client), 404);
     }
 }

--- a/app/Modules/Groups/Models/MembershipRequest.php
+++ b/app/Modules/Groups/Models/MembershipRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Modules\Groups\Models;
 
 use App\Models\User;
+use App\Modules\Files\Access\StaffLibraryScope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -42,6 +43,37 @@ class MembershipRequest extends Model
     public function scopePending(Builder $query): Builder
     {
         return $query->where('status', self::STATUS_PENDING);
+    }
+
+    /**
+     * The requests a staff member may actually act on.
+     *
+     * MembershipRequestsController guards approve() and deny() with
+     * StaffLibraryScope::allowsGroupMembership, because joining a client
+     * to a group decides what that client -- and any staff member
+     * holding them -- can reach. This is the listing half of the same
+     * rule, and both the queue and the sidebar badge read it, so the
+     * number and the screen behind it cannot drift apart. That is why it
+     * lives here rather than in either caller, the same reasoning
+     * VisibleCommentScope::pendingTotal() gives for owning the comment
+     * badge instead of leaving the middleware to count for itself.
+     *
+     * Narrowed on the client only. Whether the *group* is reachable is
+     * the other half of allowsGroupMembership, and it depends on what is
+     * shared with that group -- not a question to ask row by row in a
+     * listing. So a scoped viewer may still be shown a request they
+     * would be refused on; it will be one of their own clients asking to
+     * join a group out of their reach, rather than a client they were
+     * never meant to hear about. The names are the part that leaks.
+     *
+     * @param  Builder<MembershipRequest>  $query
+     * @return Builder<MembershipRequest>
+     */
+    public function scopeApprovableBy(Builder $query, User $viewer): Builder
+    {
+        $clientIds = app(StaffLibraryScope::class)->assignableClientIds($viewer);
+
+        return $clientIds === null ? $query : $query->whereIn('user_id', $clientIds);
     }
 
     /**

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2327,6 +2327,28 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "An error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "description": "Error overview.",
+                                            "examples": [
+                                                ""
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "message"
+                                    ]
+                                }
+                            }
+                        }
+                    },
                     "422": {
                         "$ref": "#/components/responses/ValidationException"
                     },
@@ -2390,6 +2412,28 @@
                                     },
                                     "required": [
                                         "data"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "An error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "description": "Error overview.",
+                                            "examples": [
+                                                ""
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "message"
                                     ]
                                 }
                             }

--- a/tests/Feature/Groups/GroupMembershipScopeTest.php
+++ b/tests/Feature/Groups/GroupMembershipScopeTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Files\Access\StaffLibraryScope;
+use App\Modules\Files\Folders\FolderService;
+use App\Modules\Files\Models\FolderAssignment;
+use App\Modules\Groups\Models\Group;
+use App\Modules\Groups\Models\MembershipRequest;
+use App\Modules\Identity\Models\Role;
+use App\Modules\Identity\Models\RolePermission;
+use App\Modules\Identity\Permissions\Permission;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia;
+
+/**
+ * Group membership decides what a client can reach, and through
+ * File::scopeVisibleToClient it decides what the staff member holding
+ * that client can reach too. The routes that edit it were gated on
+ * edit_groups and nothing else.
+ */
+beforeEach(function () {
+    Storage::fake('files');
+    $this->admin = User::factory()->create();
+
+    $role = Role::query()->create(['name' => 'Reps '.Str::random(6), 'client_scoped' => true]);
+    foreach ([Permission::EditGroups, Permission::CreateGroups, Permission::Upload, Permission::EditFiles] as $permission) {
+        RolePermission::query()->create(['role_id' => $role->id, 'permission' => $permission->value]);
+    }
+
+    $this->rep = User::factory()->create(['role_id' => $role->id]);
+    $this->mine = User::factory()->client()->create(['name' => 'Mine']);
+    $this->rep->assignedClients()->sync([$this->mine->id]);
+
+    $this->stranger = User::factory()->client()->create(['name' => 'Not Mine']);
+
+    $this->strangerGroup = Group::query()->create(['name' => 'Theirs', 'slug' => 'theirs', 'public' => false]);
+    $this->strangerGroup->members()->syncWithoutDetaching([$this->stranger->id]);
+
+    $this->secret = uploadNamedFile($this->admin, 'stranger-secret');
+    shareFileWithGroup($this->secret, $this->strangerGroup);
+});
+
+function libraryHolds(User $rep, int $fileId): bool
+{
+    return in_array($fileId, app(StaffLibraryScope::class)->files($rep)->pluck('id')->all(), true);
+}
+
+test('a scoped staff member cannot widen their own library through a group', function () {
+    expect(libraryHolds($this->rep, $this->secret->id))->toBeFalse();
+    $this->actingAs($this->rep)->get("/files/{$this->secret->id}/download")->assertForbidden();
+
+    $this->actingAs($this->rep)
+        ->post("/groups/{$this->strangerGroup->id}/members", ['user_id' => $this->mine->id])
+        ->assertForbidden();
+
+    expect($this->strangerGroup->members()->count())->toBe(1)
+        ->and(libraryHolds($this->rep, $this->secret->id))->toBeFalse();
+
+    $this->actingAs($this->rep)->get("/files/{$this->secret->id}/download")->assertForbidden();
+});
+
+test('the API twin refuses it too', function () {
+    $token = $this->rep->createToken('t', [Permission::EditGroups->value])->plainTextToken;
+
+    $this->withToken($token)
+        ->postJson("/api/v1/groups/{$this->strangerGroup->id}/members", ['user_id' => $this->mine->id])
+        ->assertForbidden();
+
+    expect($this->strangerGroup->members()->count())->toBe(1);
+});
+
+test('a scoped staff member cannot hand somebody else client the files of their own', function () {
+    $ours = Group::query()->create(['name' => 'Ours', 'slug' => 'ours', 'public' => false]);
+    $ours->members()->syncWithoutDetaching([$this->mine->id]);
+
+    $this->actingAs($this->rep)
+        ->post("/groups/{$ours->id}/members", ['user_id' => $this->stranger->id])
+        ->assertForbidden();
+
+    expect($ours->members()->pluck('users.id')->all())->toBe([$this->mine->id]);
+});
+
+test('a scoped staff member cannot pull somebody else client out of a group', function () {
+    $this->actingAs($this->rep)
+        ->delete("/groups/{$this->strangerGroup->id}/members/{$this->stranger->id}")
+        ->assertForbidden();
+
+    $token = $this->rep->createToken('t', [Permission::EditGroups->value])->plainTextToken;
+    $this->withToken($token)
+        ->deleteJson("/api/v1/groups/{$this->strangerGroup->id}/members/{$this->stranger->id}")
+        ->assertForbidden();
+
+    expect($this->strangerGroup->members()->count())->toBe(1);
+});
+
+test('approving a membership request is held to the same boundary', function () {
+    $role = $this->rep->role;
+    RolePermission::query()->create([
+        'role_id' => $role->id,
+        'permission' => Permission::ApproveGroupsMembershipsRequests->value,
+    ]);
+
+    $request = MembershipRequest::query()->create([
+        'group_id' => $this->strangerGroup->id,
+        'user_id' => $this->mine->id,
+        'status' => MembershipRequest::STATUS_PENDING,
+    ]);
+
+    $this->actingAs($this->rep)->post("/membership-requests/{$request->id}/approve")->assertNotFound();
+
+    expect($this->strangerGroup->members()->count())->toBe(1)
+        ->and(libraryHolds($this->rep, $this->secret->id))->toBeFalse();
+});
+
+test('denying somebody else client request is held to the same boundary', function () {
+    RolePermission::query()->create([
+        'role_id' => $this->rep->role_id,
+        'permission' => Permission::ApproveGroupsMembershipsRequests->value,
+    ]);
+
+    $request = MembershipRequest::query()->create([
+        'group_id' => $this->strangerGroup->id,
+        'user_id' => $this->stranger->id,
+        'status' => MembershipRequest::STATUS_PENDING,
+    ]);
+
+    $this->actingAs($this->rep)->delete("/membership-requests/{$request->id}")->assertNotFound();
+
+    expect($request->fresh()->status)->toBe(MembershipRequest::STATUS_PENDING);
+});
+
+test('the queue stops naming clients this viewer has no business hearing about', function () {
+    RolePermission::query()->create([
+        'role_id' => $this->rep->role_id,
+        'permission' => Permission::ApproveGroupsMembershipsRequests->value,
+    ]);
+
+    $ours = Group::query()->create(['name' => 'Ours', 'slug' => 'ours', 'public' => true]);
+    MembershipRequest::query()->create(['group_id' => $ours->id, 'user_id' => $this->mine->id, 'status' => MembershipRequest::STATUS_PENDING]);
+    MembershipRequest::query()->create(['group_id' => $ours->id, 'user_id' => $this->stranger->id, 'status' => MembershipRequest::STATUS_PENDING]);
+
+    $body = $this->actingAs($this->rep)->get('/membership-requests')->getContent();
+
+    // The row carries client_name and client_email, so an unnarrowed
+    // queue hands over both for a client outside the roster.
+    expect(str_contains($body, 'Not Mine'))->toBeFalse()
+        ->and(str_contains($body, $this->stranger->email))->toBeFalse()
+        ->and(str_contains($body, 'Mine'))->toBeTrue();
+});
+
+test('the sidebar badge counts what the queue lists', function () {
+    RolePermission::query()->create([
+        'role_id' => $this->rep->role_id,
+        'permission' => Permission::ApproveGroupsMembershipsRequests->value,
+    ]);
+
+    $ours = Group::query()->create(['name' => 'Ours', 'slug' => 'ours', 'public' => true]);
+    MembershipRequest::query()->create(['group_id' => $ours->id, 'user_id' => $this->mine->id, 'status' => MembershipRequest::STATUS_PENDING]);
+    MembershipRequest::query()->create(['group_id' => $ours->id, 'user_id' => $this->stranger->id, 'status' => MembershipRequest::STATUS_PENDING]);
+
+    $this->actingAs($this->rep)->get('/dashboard')->assertInertia(
+        fn (AssertableInertia $page) => $page->where('pending.membership_requests', 1),
+    );
+
+    // Unscoped staff are told about both, and see both.
+    $wide = Role::query()->create(['name' => 'Wide '.Str::random(6), 'client_scoped' => false]);
+    RolePermission::query()->create(['role_id' => $wide->id, 'permission' => Permission::ApproveGroupsMembershipsRequests->value]);
+    $manager = User::factory()->create(['role_id' => $wide->id]);
+
+    $this->actingAs($manager)->get('/dashboard')->assertInertia(
+        fn (AssertableInertia $page) => $page->where('pending.membership_requests', 2),
+    );
+});
+
+test('a group nobody has shared anything with can still be populated', function () {
+    $fresh = Group::query()->create(['name' => 'Brand New', 'slug' => 'brand-new', 'public' => false]);
+
+    $this->actingAs($this->rep)
+        ->post("/groups/{$fresh->id}/members", ['user_id' => $this->mine->id])
+        ->assertRedirect();
+
+    expect($fresh->members()->pluck('users.id')->all())->toBe([$this->mine->id]);
+});
+
+test('a group already holding the actor own client stays editable', function () {
+    $ours = Group::query()->create(['name' => 'Ours', 'slug' => 'ours', 'public' => false]);
+    $ours->members()->syncWithoutDetaching([$this->mine->id]);
+
+    $ourFile = uploadNamedFile($this->admin, 'our-brochure');
+    shareFileWithGroup($ourFile, $ours);
+
+    $second = User::factory()->client()->create(['name' => 'Also Mine']);
+    $this->rep->assignedClients()->sync([$this->mine->id, $second->id]);
+
+    $this->actingAs($this->rep)
+        ->post("/groups/{$ours->id}/members", ['user_id' => $second->id])
+        ->assertRedirect();
+
+    $this->actingAs($this->rep)
+        ->delete("/groups/{$ours->id}/members/{$second->id}")
+        ->assertRedirect();
+
+    expect($ours->members()->pluck('users.id')->all())->toBe([$this->mine->id]);
+});
+
+test('unscoped staff manage membership exactly as before', function () {
+    $role = Role::query()->create(['name' => 'Wide '.Str::random(6), 'client_scoped' => false]);
+    RolePermission::query()->create(['role_id' => $role->id, 'permission' => Permission::EditGroups->value]);
+    $manager = User::factory()->create(['role_id' => $role->id]);
+
+    $this->actingAs($manager)
+        ->post("/groups/{$this->strangerGroup->id}/members", ['user_id' => $this->mine->id])
+        ->assertRedirect();
+
+    expect($this->strangerGroup->members()->count())->toBe(2);
+
+    $this->actingAs($manager)
+        ->delete("/groups/{$this->strangerGroup->id}/members/{$this->stranger->id}")
+        ->assertRedirect();
+
+    expect($this->strangerGroup->members()->pluck('users.id')->all())->toBe([$this->mine->id]);
+});
+
+test('a folder shared with a group counts as reach too', function () {
+    $folder = app(FolderService::class)->create('Their Folder', null);
+    FolderAssignment::query()->create([
+        'folder_id' => $folder->id,
+        'assignable_type' => $this->strangerGroup->getMorphClass(),
+        'assignable_id' => $this->strangerGroup->id,
+    ]);
+
+    $bare = Group::query()->create(['name' => 'Folder Only', 'slug' => 'folder-only', 'public' => false]);
+    FolderAssignment::query()->create([
+        'folder_id' => $folder->id,
+        'assignable_type' => $bare->getMorphClass(),
+        'assignable_id' => $bare->id,
+    ]);
+
+    $this->actingAs($this->rep)
+        ->post("/groups/{$bare->id}/members", ['user_id' => $this->mine->id])
+        ->assertForbidden();
+
+    expect($bare->members()->count())->toBe(0);
+});


### PR DESCRIPTION
## What these routes check

Nothing. `GroupMembersController::store()`/`destroy()` and their API twins
contain no authorization call of any kind — `can:edit_groups` in front of the
route is the whole of it:

```php
public function store(Request $request, Group $group): RedirectResponse
{
    $validated = $request->validate([
        'user_id' => ['required', 'integer', 'exists:users,id'],
    ]);

    $client = User::query()->findOrFail((int) $validated['user_id']);

    if (! $client->isClient()) { … }        // a type check

    $group->members()->syncWithoutDetaching([$client->id]);
    …
```

A permission is not a boundary. `ResolvesShareTargets::guardAssignable():104`
draws one on the sharing path:

> A client-scoped staff member may only share with their own clients (or a
> group one of them belongs to). Applied when revoking too, so that reaching a
> subject through one of your own clients does not let you revoke somebody
> else's access to it.

Nobody draws it on the membership path.

## Why "groups are installation-wide" does not settle it

It is a fair description of the object: `GroupsController::index:42` lists every
group with an unfiltered `Group::query()`, so the listing and single-object
access agree and there is no listing/direct-access mismatch to fix. This change
does not touch that, and staff still see every group.

The question it does not answer is what a *write* to one does.

Joining a group hands the new member everything shared with it. When that
member is one of a client-scoped staff member's own clients,
`File::scopeVisibleToClient` hands the same content straight back to that staff
member — that scope is what `StaffLibraryScope::files()` is built out of:

```php
foreach ($user->assignedClients as $client) {
    $outer->orWhere(fn (Builder $scoped) => $scoped->visibleToClient($client));
}
```

So one membership write moves a file from "403" to "in my library". Measured:

| | |
|---|---|
| `GET /files/{id}/download` before | **403** |
| `POST /groups/{someone else's group}/members` with the actor's own client | **302** (API: **200**) |
| the file in `StaffLibraryScope::files($actor)` after | **yes** |
| `GET /files/{id}/download` after | **200** |

`canAssignGroup()` — the predicate the sharing path uses — cannot be the guard
here, and not only because nobody applied it. It is *derived from membership*:

```php
public function assignableGroupIds(User $user): ?array
{
    …
    return Group::query()
        ->whereHas('members', fn (Builder $members) => $members->whereIn('users.id', $clientIds))
        …
```

Whoever may edit the list also decides what the list entitles them to. It is
also wrong in the other direction: a group nobody has joined yet belongs to
nobody, so using it would leave a scoped staff member unable to put the first
client into a group they had just created.

### Reachability, stated honestly

`Client Manager`, the only client-scoped role that ships, holds no group
permissions at all. This needs a custom role combining `client_scoped` with
`edit_groups`, which the roles screen offers. That lowers the severity; it does
not make the configuration strange.

## The fix

`StaffLibraryScope::allowsGroupMembership()` asks about reach directly, which
is what membership is about:

```php
public function allowsGroupMembership(User $user, Group $group, User $client): bool
{
    return $this->canAssignClient($user, $client) && $this->groupReachesNoFurther($user, $group);
}
```

Both halves have to hold: the client must be one this staff member holds, and
the group must not already reach past their library — no file assigned to it,
and no folder shared with it, outside `StaffLibraryScope`. A group with nothing
shared with it passes trivially, which is what keeps a newly created one usable,
and a group already holding one of the actor's own clients passes by
construction, since everything shared with it is already in their library.
Unscoped staff pass both halves by construction.

Four call sites take it, at 403.

### What this is a check on, and what it is not

It asks about the group as it stands. A group with nothing shared with it passes,
and if somebody with the authority to share then shares a stranger file with that
group, the member joined earlier reaches it — and so does the staff member holding
that member. Measured: join an empty group (302), have an unscoped colleague share
a file with it afterwards, and the file is in the joiner's holder's library and
downloads 200.

That is group sharing working as designed — the second step is a deliberate act by
somebody allowed to make it, sharing with a group whose membership is visible on
the group screen — but it is worth saying out loud that a scoped staff member can
prepare for it by putting their own client into every empty group first. Closing
that would mean deciding membership from something other than what the group holds
right now: either freezing which groups a scoped member may ever join, or checking
reach again on the sharing side, where `canAssignGroup()` already asks a different
and correct question. Both are larger changes than this one, and both are about
sharing rather than about membership. What this fix removes is the part that took
one request and no waiting.

### The same write has a second door

`MembershipRequestsController::approve()` joins a client to a group with
identical consequences, under `approve_groups_memberships_requests`, and
`deny()` decides about somebody else's client and emails them about it. Both go
through the same predicate, answering **404** to match the guard already sitting
above `approve()`:

```php
abort_unless($group !== null && $client !== null && $membershipRequest->status === MembershipRequest::STATUS_PENDING, 404);
```

### The queue and its badge

Each row of that queue carries the client's **name and email**:

```php
'client_name' => $membershipRequest->user?->name,
'client_email' => $membershipRequest->user?->email,
```

so an unnarrowed queue hands both over for clients outside the viewer's roster —
the same thing `ActivityLogScope`'s docblock is about, one surface further along.
Both the queue and the sidebar badge now read one scope on the model:

```php
public function scopeApprovableBy(Builder $query, User $viewer): Builder
{
    $clientIds = app(StaffLibraryScope::class)->assignableClientIds($viewer);

    return $clientIds === null ? $query : $query->whereIn('user_id', $clientIds);
}
```

It lives on the model rather than in either caller for the reason
`VisibleCommentScope::pendingTotal()` gives for owning the comment badge instead
of leaving `HandleInertiaRequests` to count for itself — and that middleware
already states the rule in the branch immediately below the one this changes:

> Library-scoped, like the screen it badges: a client-scoped staff member is not
> shown a number they cannot act on.

Unscoped staff still see every pending request and the full count.

**Narrowed on the client, not on the group** — worth stating, because it makes
this less than "the queue lists only what you can act on". Whether a group is
reachable is the other half of `allowsGroupMembership()` and it depends on what
is shared with that group, which is not a question to ask row by row in a
listing. A scoped viewer may therefore still be shown a request whose approve
button answers 404: one of their own clients asking to join a group out of their
reach. The names were the part that leaked.

### Not changed (deliberate)

- **`GroupsController::index`, `edit`, `update`, `destroy`.** Managing the group
  object stays installation-wide, exactly as the sweep of that decision
  concluded. This is about membership.
- **`canAssignGroup()` and the sharing path.** Untouched. It answers "may I
  share with this group" and it answers it correctly; it is simply not the
  question membership asks.
- **`MyGroupsController`.** A client requesting or leaving their own membership
  is a different actor and a different rule.

## One documentation change falls out of this

The published API document gains a `403` on `POST /groups/{group}/members` and
`DELETE /groups/{group}/members/{member}`. Regenerated with
`php artisan scramble:export`.

Worth recording for whoever writes the next guard here: Scramble reads
`abort_unless` out of a controller method's body but **not** out of a private
helper it calls. Sharing the four call sites through one private
`guardMembership()` produced identical, and therefore silently incomplete,
output — the guard was there and the documented contract said nothing about it.
Writing it out at each call site is why the 403 appears.

## Merge note

Clean against all eighteen open branches, checked pairwise with
`git merge-tree --write-tree`, including the three that also touch
`docs/api/openapi.json`. Verified by merging into a branch carrying all
eighteen: suite green (`OpenApiContractTest` included, so the merged document
matches the merged code) and PHPStan clean.

## Tests

`tests/Feature/Groups/GroupMembershipScopeTest.php`, twelve cases: the
403-to-200 sequence through a stranger group, the API twin, handing a stranger
client the actor's own group, pulling a stranger client out of one, the same
boundary through `approve`, through `deny`, the queue no longer naming a
stranger client or their email, the badge agreeing with the queue for a scoped
viewer and still counting everything for an unscoped one, a folder shared with a
group counting as reach, a group with nothing shared with it still being
populatable, a group already holding the actor's own client staying editable,
and unscoped staff managing membership exactly as before.

Counter-check, stated plainly: against the unfixed code **nine of the twelve go
red**. The other three hold without the fix — they are regression guards for
what must not change, not proof of the bug.

Full suite **1860 passed / 1 skipped** against `main` at `073101d1` (baseline
1848 / 1, same container image — exactly the twelve new tests, nothing else
moved). PHPStan level 8 clean. `pint --test` clean on all seven changed files.