### PR TITLE
Promoting a client is still binding a client account

### DIFF
--- a/app/Modules/Identity/AccountConversion.php
+++ b/app/Modules/Identity/AccountConversion.php
@@ -7,6 +7,7 @@ namespace App\Modules\Identity;
 use App\Models\User;
 use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLogger;
+use App\Modules\Files\Access\StaffLibraryScope;
 use App\Modules\Identity\Models\Role;
 use App\Modules\Identity\Permissions\SystemRole;
 use Illuminate\Support\Facades\DB;
@@ -36,6 +37,7 @@ class AccountConversion
     public function __construct(
         private readonly StaffAccounts $accounts,
         private readonly ActivityLogger $activity,
+        private readonly StaffLibraryScope $library,
     ) {}
 
     /**
@@ -84,11 +86,25 @@ class AccountConversion
     {
         $this->guardSelf($actor, $target);
 
-        // No guardTarget here — see guardToClient(). What actually limits
-        // a promotion is the role being granted, and that is enforced by
-        // the caller validating role_id against
-        // StaffAccounts::assignableRoleIds(): nobody hands out authority
-        // they do not hold.
+        // No guardTarget here — see guardToClient(). It asks "could the
+        // actor have granted the target's role", which is meaningless of
+        // a client; what limits a promotion is the role being *granted*,
+        // and the caller enforces that by validating role_id against
+        // StaffAccounts::assignableRoleIds().
+        //
+        // That answers the question about the role. It does not answer
+        // the one about the target, and the target here is a client
+        // account: the same object every other route that binds one
+        // holds to the actor's own roster. A promotion is the most
+        // far-reaching thing that can be done to a client — it takes
+        // their portal access away, makes their assignments inert, and
+        // leaves them holding staff permissions the actor chose — so
+        // reaching one outside that roster through this door and no
+        // other is not a rule, it is a gap. 404 rather than 403, like
+        // the clients routes and like the isClient() check the caller
+        // makes on the way in: a client this staff member may not manage
+        // should not be distinguishable from one that is not there.
+        abort_unless($this->library->canAssignClient($actor, $target), 404);
 
         // An account request is not an account yet. Approving one is a
         // deliberate decision with its own screen and its own audit entry;

--- a/tests/Feature/Identity/AccountConversionScopeTest.php
+++ b/tests/Feature/Identity/AccountConversionScopeTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Audit\Action;
+use App\Modules\Audit\ActivityLog;
+use App\Modules\Groups\Models\Group;
+use App\Modules\Identity\Models\Role;
+use App\Modules\Identity\Models\RolePermission;
+use App\Modules\Identity\Permissions\Permission;
+use App\Modules\Identity\UserType;
+use Illuminate\Support\Str;
+
+/**
+ * Promoting a client to staff binds a client account, so it is inside
+ * the same boundary as every other route that binds one: the clients
+ * assigned to this staff member. guardToStaff() deliberately skips
+ * StaffAccounts::guardTarget, and the reason it gives is about the role
+ * being granted -- which leaves the target unasked about.
+ */
+beforeEach(function () {
+    $this->admin = User::factory()->create();
+
+    $this->role = Role::query()->create(['name' => 'Reps '.Str::random(6), 'client_scoped' => true]);
+    foreach ([Permission::ManageUsers, Permission::EditUsers, Permission::EditClients, Permission::CreateUsers] as $permission) {
+        RolePermission::query()->create(['role_id' => $this->role->id, 'permission' => $permission->value]);
+    }
+
+    $this->rep = User::factory()->create(['role_id' => $this->role->id]);
+    $this->mine = User::factory()->client()->create(['name' => 'Mine']);
+    $this->rep->assignedClients()->sync([$this->mine->id]);
+
+    $this->stranger = User::factory()->client()->create(['name' => 'Not Mine']);
+});
+
+test('a scoped staff member cannot promote a client outside their roster', function () {
+    $this->actingAs($this->rep)->post("/users/convert/{$this->stranger->id}", [
+        'direction' => 'to_staff',
+        'role_id' => $this->role->id,
+        'assigned_clients' => [],
+    ])->assertNotFound();
+
+    $after = $this->stranger->fresh();
+
+    expect($after->type)->toBe(UserType::Client)
+        ->and($after->role_id)->not->toBe($this->role->id);
+});
+
+test('everything a promotion would have done to a stranger client is left alone', function () {
+    $colleague = User::factory()->create(['role_id' => $this->role->id]);
+    $colleague->assignedClients()->sync([$this->stranger->id]);
+
+    $group = Group::query()->create(['name' => 'Theirs', 'slug' => 'theirs', 'public' => false]);
+    $group->members()->syncWithoutDetaching([$this->stranger->id]);
+
+    $this->actingAs($this->rep)->post("/users/convert/{$this->stranger->id}", [
+        'direction' => 'to_staff',
+        'role_id' => $this->role->id,
+        'assigned_clients' => [],
+    ])->assertNotFound();
+
+    // A promotion clears every roster row pointing at the account and
+    // leaves its group memberships inert. Neither happened, and nothing
+    // was written to the log.
+    expect($colleague->assignedClients()->pluck('users.id')->all())->toBe([$this->stranger->id])
+        ->and($group->members()->pluck('users.id')->all())->toBe([$this->stranger->id])
+        ->and(ActivityLog::query()->where('action', Action::AccountConvertedToStaff->value)->count())->toBe(0);
+});
+
+test('the refusal does not distinguish a stranger client from one that is not there', function () {
+    $this->actingAs($this->rep)->post('/users/convert/999999', [
+        'direction' => 'to_staff',
+        'role_id' => $this->role->id,
+    ])->assertNotFound();
+});
+
+test('a scoped staff member may still promote a client of their own', function () {
+    $this->actingAs($this->rep)->post("/users/convert/{$this->mine->id}", [
+        'direction' => 'to_staff',
+        'role_id' => $this->role->id,
+        'assigned_clients' => [],
+    ])->assertSessionHasNoErrors();
+
+    $after = $this->mine->fresh();
+
+    expect($after->type)->toBe(UserType::Staff)
+        ->and($after->role_id)->toBe($this->role->id);
+});
+
+test('unscoped staff promote any client, as before', function () {
+    $this->actingAs($this->admin)->post("/users/convert/{$this->stranger->id}", [
+        'direction' => 'to_staff',
+        'role_id' => $this->role->id,
+        'assigned_clients' => [],
+    ])->assertSessionHasNoErrors();
+
+    expect($this->stranger->fresh()->type)->toBe(UserType::Staff);
+});
+
+test('the demotion direction keeps answering through guardTarget', function () {
+    $colleague = User::factory()->create();
+
+    $this->actingAs($this->rep)->post("/users/convert/{$colleague->id}", [
+        'direction' => 'to_client',
+    ])->assertForbidden();
+
+    expect($colleague->fresh()->type)->toBe(UserType::Staff);
+});


### PR DESCRIPTION
## The route this misses

Every route that binds one client asks whether this staff member may manage
that client. `ClientFilesController::index():39-42`, behind
`clients/{client}/files`, says so out loud:

> A client-scoped staff member may only browse this for clients assigned to
> them — the same boundary StaffLibraryScope enforces everywhere else in the
> library.

`POST users/convert/{user}` binds one too, and asks nothing about it.

`AccountConversion::guardToStaff()` (`:83-102`) explains why it skips
`StaffAccounts::guardTarget`:

```php
// No guardTarget here — see guardToClient(). What actually limits
// a promotion is the role being granted, and that is enforced by
// the caller validating role_id against
// StaffAccounts::assignableRoleIds(): nobody hands out authority
// they do not hold.
```

That reasoning is sound as far as it goes. `guardTarget` asks "could the actor
have granted the target's current role", and `guardToClient()` explains one line
above why that is meaningless of a client:

> the Client system role grants `upload` and `create_own_folders`, so a User
> Manager who happens not to hold `upload` would be refused permission to
> promote anybody — a refusal about nothing.

So `guardTarget` is the wrong question here. But it was the only question being
asked, and dropping it left the target unasked about entirely. The comment
answers "may they grant this role"; nothing answers "may they reach this
account".

## What that gets you

A client-scoped staff member holding `manage_users`, `edit_users` and
`edit_clients` can promote **any** client on the installation. Measured
against a client outside their roster:

| | |
|---|---|
| `StaffLibraryScope::canAssignClient($actor, $client)` | **false** |
| `POST /users/convert/{that client}` with `direction=to_staff` | **302** |
| the account afterwards | `type = staff`, holding the role the actor picked |

It is the most far-reaching thing that can be done to a client account.
`toStaff()` takes their portal access away, deletes every
`staff_client_assignments` row that made them somebody's client, rewrites
`auth_source` to `Local`, and leaves them holding a staff role. The client is
never told.

With **#1696** in the tree the asymmetry is exact: `GET /clients/{that client}`
answers **404** while `POST /users/convert/{same client}` answers **302** — the
same object, the same actor, one door shut and the one next to it open. Without
#1696 the sibling routes are equally open, which is #1696's business; this is
the one route that binds a client and is not among them.

### Reachability, stated honestly

The route needs `manage_users` (route group), `edit_users` and `edit_clients`
(route middleware). No shipped role combines those with `client_scoped` —
`Client Manager`, the only client-scoped role that ships, is file-focused. This
needs a custom role, which the roles screen offers. That lowers the severity; it
is the same configuration #1696 and #1697 address.

## The fix

`guardToStaff()` asks the question that was missing, using the predicate the
sharing path already uses:

```php
abort_unless($this->library->canAssignClient($actor, $target), 404);
```

404 rather than 403, matching both the `abort_unless($user->isClient(), 404)`
the controller makes on the way in and the answer #1696 gives on the clients
routes: a client this staff member may not manage should not be
distinguishable from one that is not there. Unscoped staff pass by construction
— `canAssignClient` returns true whenever `assignableClientIds` is `null` — so
the ordinary administrator path is untouched.

The comment that used to explain the omission now explains the split: the role
question is the caller's, through `assignableRoleIds()`; the target question is
this one.

### Not changed (deliberate)

- **`guardToClient()`.** Its target is a staff account, `guardTarget` is the
  right question to ask about one, and it was already being asked. Measured
  still answering 403.
- **The account list on the converter screen.** It runs under `can:edit_users`
  and shows every account of the chosen direction, the same way every other
  staff surface that lists clients shows all of them — the reason #1696 gives
  for leaving the roster listing alone applies unchanged. What differs now is
  that the button on the row refuses instead of going through.
- **`toStaff()` itself.** The conversion is correct; who may ask for it was the
  problem.

## Merge note

Clean against all eighteen open branches, checked pairwise with
`git merge-tree --write-tree`.

**One behavioural interaction with #1697**, which git cannot see. That branch's
`AssignedClientsAuthorityTest` has a case — "converting an account to staff
cannot hand out clients either" — that promotes a freshly created client and
expects a 422 on `assigned_clients.0`. With this change the request is refused
at 404 before validation runs, because that client is not on the actor's roster
either, so the assertion no longer fires. The refusal is stronger, not weaker,
and the case's own closing expectation (`$target->refresh()->isClient()`) still
holds.

The resolution is one line in that test: point it at a client the actor does
hold, so the request reaches validation and the `assigned_clients` rule is what
refuses it — which is what the case is about.

```php
-    $target = User::factory()->client()->create();
+    $target = $this->mine;
```

Verified: with that line changed, a branch carrying all eighteen plus this one
runs green, PHPStan clean.

## Tests

`tests/Feature/Identity/AccountConversionScopeTest.php`, six cases: the
promotion refused, everything it would have done left alone (roster rows, group
membership, the activity log), the refusal indistinguishable from a
non-existent id, a client of the actor's own still promotable, unscoped staff
promoting anybody as before, and the demotion direction still answering through
`guardTarget`.

Counter-check, stated plainly: against the unfixed code **two of the six go
red** — the promotion and its consequences. The other four hold without the fix;
they are regression guards for what must not change, not proof of the bug.

Full suite **1854 passed / 1 skipped** against `main` at `073101d1` (baseline
1848 / 1, same container image — exactly the six new tests, nothing else moved).
PHPStan level 8 clean. `pint --test` clean on both changed files.