### PR TITLE
Say what `exists:folders,id` was already being read as

### DIFF
--- a/app/Modules/Files/Http/Controllers/Api/FilesController.php
+++ b/app/Modules/Files/Http/Controllers/Api/FilesController.php
@@ -174,7 +174,7 @@ class FilesController extends Controller
             'file' => ['required', 'file'],
             'name' => ['nullable', 'string', 'max:255'],
             'description' => ['nullable', 'string', 'max:2000'],
-            'folder_id' => ['nullable', 'integer', 'exists:folders,id'],
+            'folder_id' => Rules::folderId(),
         ]);
 
         /** @var UploadedFile $upload */
@@ -275,7 +275,7 @@ class FilesController extends Controller
         $validated = $request->validate([
             'name' => ['sometimes', 'string', 'max:255'],
             'description' => ['sometimes', 'nullable', 'string', 'max:2000'],
-            'folder_id' => ['sometimes', 'nullable', 'integer', 'exists:folders,id'],
+            'folder_id' => ['sometimes', ...Rules::folderId()],
             'public' => ['sometimes', 'boolean'],
             'commentable' => ['sometimes', 'boolean'],
             'slug' => Rules::slug('files', $file->id),

--- a/app/Modules/Files/Http/Controllers/ChunkedUploadsController.php
+++ b/app/Modules/Files/Http/Controllers/ChunkedUploadsController.php
@@ -24,6 +24,7 @@ use App\Modules\Identity\UserType;
 use App\Modules\Notifications\Notifier;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
+use App\Support\Rules;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -71,7 +72,7 @@ class ChunkedUploadsController extends Controller
             'size' => ['required', 'integer', 'min:1'],
             'type' => ['nullable', 'string', 'max:255'],
             'description' => ['nullable', 'string', 'max:2000'],
-            'folder_id' => ['nullable', 'integer', 'exists:folders,id'],
+            'folder_id' => Rules::folderId(),
             'previous_file_id' => ['nullable', 'integer'],
         ]);
 

--- a/app/Modules/Files/Http/Controllers/FilesController.php
+++ b/app/Modules/Files/Http/Controllers/FilesController.php
@@ -76,7 +76,7 @@ class FilesController extends Controller
             'file' => ['required', 'file', 'max:102400'],
             'name' => ['nullable', 'string', 'max:255'],
             'description' => ['nullable', 'string', 'max:2000'],
-            'folder_id' => ['nullable', 'integer', 'exists:folders,id'],
+            'folder_id' => Rules::folderId(),
         ]);
 
         /** @var UploadedFile $upload */
@@ -242,7 +242,7 @@ class FilesController extends Controller
         $validated = $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string', 'max:2000'],
-            'folder_id' => ['nullable', 'integer', 'exists:folders,id'],
+            'folder_id' => Rules::folderId(),
             'public' => ['sometimes', 'boolean'],
             'commentable' => ['sometimes', 'boolean'],
             // The slug only matters (and is only shown) once a file is
@@ -327,7 +327,7 @@ class FilesController extends Controller
         Gate::authorize('update', $file);
 
         $validated = $request->validate([
-            'folder_id' => ['nullable', 'integer', 'exists:folders,id'],
+            'folder_id' => Rules::folderId(),
         ]);
 
         $folderId = $validated['folder_id'] ?? null;
@@ -363,7 +363,7 @@ class FilesController extends Controller
             'file_ids.*' => ['integer', 'distinct'],
 
             'folder_action' => ['required', Rule::in(['no_change', 'move'])],
-            'folder_id' => ['nullable', 'integer', 'exists:folders,id'],
+            'folder_id' => Rules::folderId(),
 
             'description_action' => ['required', Rule::in(['no_change', 'set'])],
             'description' => ['nullable', 'string', 'max:2000'],

--- a/app/Modules/Files/Http/Controllers/FoldersController.php
+++ b/app/Modules/Files/Http/Controllers/FoldersController.php
@@ -305,7 +305,7 @@ class FoldersController extends Controller
 
         $validated = $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'parent_id' => ['nullable', 'integer', 'exists:folders,id'],
+            'parent_id' => Rules::folderId(),
             'public' => ['sometimes', 'boolean'],
             'slug' => Rules::slug('folders'),
             'allow_client_uploads' => ['sometimes', 'boolean'],
@@ -389,7 +389,7 @@ class FoldersController extends Controller
         Gate::authorize('update', $folder);
 
         $validated = $request->validate([
-            'parent_id' => ['nullable', 'integer', 'exists:folders,id'],
+            'parent_id' => Rules::folderId(),
         ]);
 
         $newParent = $this->resolveParent($request->user(), $validated['parent_id'] ?? null);

--- a/app/Modules/Files/Http/Controllers/MyFoldersController.php
+++ b/app/Modules/Files/Http/Controllers/MyFoldersController.php
@@ -10,6 +10,7 @@ use App\Modules\Audit\ActivityLogger;
 use App\Modules\Files\Folders\FolderService;
 use App\Modules\Files\Models\File;
 use App\Modules\Files\Models\Folder;
+use App\Support\Rules;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
@@ -43,7 +44,7 @@ class MyFoldersController extends Controller
 
         $validated = $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'parent_id' => ['nullable', 'integer', 'exists:folders,id'],
+            'parent_id' => Rules::folderId(),
         ]);
 
         $parent = null;

--- a/app/Support/Rules.php
+++ b/app/Support/Rules.php
@@ -51,6 +51,40 @@ class Rules
     }
 
     /**
+     * The rule for an id naming a library folder.
+     *
+     * Shared because the plain `exists:folders,id` it replaces is not
+     * true: Folder uses SoftDeletes, and the presence check runs against
+     * the table, so a folder in the trash passes it. Every caller then
+     * reads the rule as "this folder exists" and behaves accordingly —
+     * and the ones that resolve the id afterwards resolve it through
+     * Folder::query(), which does honour the soft delete, so the guard
+     * sees no folder at all while the value that reaches the write is
+     * still the id.
+     *
+     * FilesController::store() and Api\FilesController::store() ended up
+     * filing an upload into a deleted folder that way: the guard read
+     * null and allowed it as a root upload, and the row was written with
+     * the id. Deleting a folder deletes every file in its subtree, so
+     * that is a live file inside a folder whose deletion already removed
+     * everything in it — reachable by id, in search and over the API,
+     * and absent from the listing its uploader would look in.
+     *
+     * Making the rule mean what its readers already assume fixes those
+     * and leaves the paths that resolve through StaffLibraryScope alone;
+     * they refuse a trashed id today by a longer route.
+     *
+     * Presence is the caller's business, as with slug() above: spread it
+     * behind `sometimes` where a PATCH may omit the field.
+     *
+     * @return array<int, mixed>
+     */
+    public static function folderId(): array
+    {
+        return ['nullable', 'integer', Rule::exists('folders', 'id')->whereNull('deleted_at')];
+    }
+
+    /**
      * The rule for an IANA timezone identifier.
      *
      * Shared because two things write `users.timezone` — the picker on the

--- a/tests/Feature/Files/DeletedFolderTargetTest.php
+++ b/tests/Feature/Files/DeletedFolderTargetTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Files\Folders\FolderService;
+use App\Modules\Files\Models\File;
+use App\Modules\Files\Models\Folder;
+use App\Modules\Files\Uploads\UploadSession;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Folder uses SoftDeletes, so `exists:folders,id` — which runs against
+ * the table — passes for a folder in the trash, while every resolution
+ * that follows goes through Folder::query() and finds nothing. The
+ * upload paths wrote the id anyway.
+ */
+beforeEach(function () {
+    Storage::fake('files');
+    $this->admin = User::factory()->create();
+
+    $folder = app(FolderService::class)->create('Doomed', null);
+    $this->trashedId = $folder->id;
+    app(FolderService::class)->delete($folder);
+
+    expect(Folder::query()->whereKey($this->trashedId)->exists())->toBeFalse()
+        ->and(Folder::withTrashed()->whereKey($this->trashedId)->exists())->toBeTrue();
+});
+
+test('a web upload cannot be filed into a deleted folder', function () {
+    $this->actingAs($this->admin)->post('/files', [
+        'file' => UploadedFile::fake()->create('b.txt', 1, 'text/plain'),
+        'folder_id' => $this->trashedId,
+    ])->assertSessionHasErrors('folder_id');
+
+    expect(File::query()->where('original_name', 'b.txt')->exists())->toBeFalse();
+});
+
+test('an API upload cannot be filed into a deleted folder', function () {
+    $token = $this->admin->createToken('t', ['upload'])->plainTextToken;
+
+    $this->withToken($token)->postJson('/api/v1/files', [
+        'file' => UploadedFile::fake()->create('c.txt', 1, 'text/plain'),
+        'folder_id' => $this->trashedId,
+    ])->assertJsonValidationErrors('folder_id');
+
+    expect(File::query()->where('original_name', 'c.txt')->exists())->toBeFalse();
+});
+
+test('a file already in the library cannot be moved into a deleted folder', function () {
+    $file = uploadNamedFile($this->admin, 'movable');
+
+    $this->actingAs($this->admin)
+        ->patch("/files/{$file->id}", ['name' => 'movable', 'folder_id' => $this->trashedId])
+        ->assertSessionHasErrors('folder_id');
+
+    expect($file->fresh()->folder_id)->toBeNull();
+});
+
+test('the API cannot move one there either', function () {
+    $file = uploadNamedFile($this->admin, 'api-movable');
+    $token = $this->admin->createToken('t', ['edit_files'])->plainTextToken;
+
+    $this->withToken($token)
+        ->patchJson("/api/v1/files/{$file->id}", ['folder_id' => $this->trashedId])
+        ->assertJsonValidationErrors('folder_id');
+
+    expect($file->fresh()->folder_id)->toBeNull();
+});
+
+test('a chunked upload says so up front instead of quietly using the root', function () {
+    $this->actingAs($this->admin)->postJson('/uploads', [
+        'filename' => 'a.txt',
+        'size' => 5,
+        'folder_id' => $this->trashedId,
+    ])->assertJsonValidationErrors('folder_id');
+
+    expect(UploadSession::query()->count())->toBe(0);
+});
+
+test('the paths that resolve through the library scope keep refusing too', function () {
+    $file = uploadNamedFile($this->admin, 'movable');
+
+    $this->actingAs($this->admin)
+        ->patch("/files/{$file->id}/move", ['folder_id' => $this->trashedId])
+        ->assertSessionHasErrors('folder_id');
+
+    $this->actingAs($this->admin)->patch('/files/bulk-edit', [
+        'file_ids' => [$file->id],
+        'folder_action' => 'move',
+        'folder_id' => $this->trashedId,
+        'description_action' => 'no_change',
+        'expiration_action' => 'no_change',
+    ])->assertSessionHasErrors('folder_id');
+
+    expect($file->fresh()->folder_id)->toBeNull();
+});
+
+test('a folder cannot be created inside, or moved into, a deleted one', function () {
+    $this->actingAs($this->admin)
+        ->post('/folders', ['name' => 'Orphan', 'parent_id' => $this->trashedId])
+        ->assertSessionHasErrors('parent_id');
+
+    $folder = app(FolderService::class)->create('Live', null);
+
+    $this->actingAs($this->admin)
+        ->patch("/folders/{$folder->id}/move", ['parent_id' => $this->trashedId])
+        ->assertSessionHasErrors('parent_id');
+
+    expect(Folder::query()->where('name', 'Orphan')->exists())->toBeFalse()
+        ->and($folder->fresh()->parent_id)->toBeNull();
+});
+
+test('a live folder is still a perfectly good upload target', function () {
+    $live = app(FolderService::class)->create('Live', null);
+
+    $this->actingAs($this->admin)->post('/files', [
+        'file' => UploadedFile::fake()->create('ok.txt', 1, 'text/plain'),
+        'folder_id' => $live->id,
+    ])->assertSessionHasNoErrors();
+
+    expect(File::query()->where('original_name', 'ok.txt')->value('folder_id'))->toBe($live->id);
+
+    $this->actingAs($this->admin)->postJson('/uploads', [
+        'filename' => 'chunk.txt',
+        'size' => 5,
+        'folder_id' => $live->id,
+    ])->assertOk();
+
+    expect(UploadSession::query()->value('folder_id'))->toBe($live->id);
+});
+
+test('the root is still the root', function () {
+    $this->actingAs($this->admin)->post('/files', [
+        'file' => UploadedFile::fake()->create('root.txt', 1, 'text/plain'),
+        'folder_id' => null,
+    ])->assertSessionHasNoErrors();
+
+    expect(File::query()->where('original_name', 'root.txt')->value('folder_id'))->toBeNull();
+});


### PR DESCRIPTION
## The premise that is not true

`Folder` uses `SoftDeletes`. The `exists` rule runs against the *table*, so a
folder in the trash passes it — while every resolution that follows goes
through `Folder::query()`, which honours the soft delete and finds nothing.

Ten rules across five controllers rely on that check, and each one reads it as
"this folder exists":

```php
'folder_id' => ['nullable', 'integer', 'exists:folders,id'],
```

## Where the two readings meet

`Api\FilesController::store()` resolves the folder, asks the guard, and then
writes the id it was handed rather than the folder it resolved:

```php
$folder = isset($validated['folder_id'])
    ? Folder::query()->whereKey($validated['folder_id'])->first()   // :192 — null for a trashed id
    : null;

abort_unless(Folder::uploadableBy($user, $folder), 403);            // :196 — "root upload, allowed"

…

    folderId: $validated['folder_id'] ?? null,                      // :243 — the id goes in anyway
```

Checked against one thing, booked against another. `FilesController::store()`
is the same shape once **#1694** gives it that guard; `FilesController::update()`
and `Api\FilesController::update()` write it straight through with nothing in
between.

Measured on `main`: `POST /files` → 302 and `POST /api/v1/files` → 201, both
with `folder_id` set to a folder in the trash; `PATCH /files/{file}` → 302 and
`PATCH /api/v1/files/{file}` → 200, likewise.

## What that gets you

Not access to anything. `File::scopeVisibleToClient` reaches folder content
through `Folder::query()`, which drops the trashed row, so nothing is exposed
to anybody. What it produces is a state nothing else in the application
produces: `FolderService::delete():71-82` deletes **every file in the subtree**
along with the folder, so a live file whose `folder_id` names a deleted folder
is a file sitting inside a folder whose deletion already removed everything in
it.

Measured, the row is reachable by id (details, edit and download all 200), in
`GET /files?search=…`, and in `GET /api/v1/files` — and absent from the root
listing, which is where the person who uploaded it would look.

## The fix

Make the rule mean what its readers already assume, once, where the reasoning
can be written down — the argument `Rules::slug()` makes for itself one method
above in the same class:

```php
public static function folderId(): array
{
    return ['nullable', 'integer', Rule::exists('folders', 'id')->whereNull('deleted_at')];
}
```

Every site takes it, including the ones that were already refusing by a longer
route, so the file cannot end up carrying two spellings of the same rule with
no way to tell which is the safe one. Spread it behind `sometimes` where a
PATCH may omit the field:

```php
'folder_id' => ['sometimes', ...Rules::folderId()],
```

### What changes, path by path

- **`POST /files`, `POST /api/v1/files`, `PATCH /files/{file}`,
  `PATCH /api/v1/files/{file}`** refuse a folder in the trash instead of writing
  its id. This is the fix.
- **`POST /uploads`** used to accept it and quietly file the upload at the root
  — its guard and its write already agreed, on `null`. It now says so instead,
  which is what the other upload paths do.
- **`files/{file}/move`, `files/bulk-edit`, `folders`, `folders/{folder}/move`
  and the portal's `my-folders`** already refused, through
  `StaffLibraryScope::folders()` or `Folder::scopeVisibleToClient()`, both of
  which drop trashed rows. They still refuse; the answer is now 422 naming the
  field rather than a bare 404. Those two guards are asking a different question
  — "is this folder *yours*" — and they keep asking it.

No live folder id behaves differently anywhere, and the root (a null
`folder_id`) is untouched.

### One way in that this does not close

A rule in front of a request only sees that request. A chunked upload is two:
`POST /uploads` records the resolved folder on the `UploadSession`, and
`complete()` reads it back from the session rather than from the caller. Delete
the folder between the two and `complete()` still files the assembled bytes into
it. Measured, on `main` and with this change alike: start a session against a
live folder, delete the folder, complete — **200**, and a live `File` row whose
`folder_id` names a trashed folder.

So this fix removes the version anybody can ask for in one request, and leaves a
race that needs a deletion landing inside somebody else's upload. Closing that
one belongs in `complete()`, which would have to re-resolve `session->folder_id`
through `Folder::query()` and decide what to do when it has gone — file at the
root, or refuse and keep the session. That is a question about the resumable
upload contract rather than about a validation rule, and #1686 and #1691 are
already in that area, so I have not answered it here.

### Three calls in this that are mine, in case they are the wrong ones

Each is cheap to reverse, so they are stated rather than buried.

**1. `POST /uploads` refuses now instead of quietly using the root.** It is the
only path here where a request that used to succeed now fails, so it is the one
worth arguing about. My reasoning: the other two upload paths refuse a folder
they cannot resolve, and of the two surprises available — "your upload was
rejected, pick a folder" and "your upload silently went somewhere you did not
choose" — the first is the kinder one, especially since the folder it did not go
into no longer exists. If you would rather it kept coercing, dropping
`Rules::folderId()` from `ChunkedUploadsController` alone restores the old
behaviour exactly: the guard there already resolves through `Folder::query()`
and passes `$folder?->id`, which is `null`.

Related, if this stays: the refusal carries Laravel's default message, "The
selected folder id is invalid", which is thin for "the folder you picked has
since been deleted". A better one is easy but costs the single-definition
property — `Rules::folderId()` returns rules, not messages, so a custom one
means either a `messages()` array at ten call sites or wrapping the rule in an
object. Happy to do either; it seemed like the wrong trade to make unasked.

**2. The five paths that already refused now answer 422 instead of 404.**
`files/{file}/move`, `files/bulk-edit`, `folders`, `folders/{folder}/move` and
`my-folders` were never letting a trashed id through. Taking them along is what
keeps one spelling of the rule in each file; leaving them alone would keep
`exists:folders,id` at six sites next to the corrected one, with nothing to tell
a later reader which of the two is the safe one — the situation `Rules::slug()`
one method above says it exists to prevent. If you would rather not move a
status code on a path that was already correct, those five lines — and one
import that goes unused with them — revert on their own, and the fix still
stands.

**3. `Rules::folderId()` lives in `App\Support\Rules`.** `slug()` and
`timezone()` there are shared across modules; this one is only used inside
Files. The class's own opening line is the reason I put it there anyway —
"validation rules shared across modules, **where having one definition matters
more than having it next to its caller**" — and the false premise needs
somewhere its explanation can sit once rather than ten times. If you would
prefer it closer to home, the body of the method is a single expression and
moves wherever you like.

### Not changed (deliberate)

- **The guards themselves.** `Folder::uploadableBy()`, `StaffLibraryScope::folders()`
  and `Folder::scopeVisibleToClient()` all behave correctly on a trashed row.
  The rule in front of them was the part that did not.
- **`exists:` on anything else.** Only `folders` is soft-deleted among the
  tables these rules name.
- **Restoring folders.** There is no restore path, which is part of why this is
  low-severity rather than a data-loss risk.

The published API document is unchanged: `exists` renders the same either way.
Regenerated with `php artisan scramble:export` and byte-identical.

## Merge note

Clean against all eighteen open branches, checked pairwise with
`git merge-tree --write-tree`, including **#1694** and **#1681**, which touch
the same two controllers.

Worth naming, since the three overlap in subject:

- **#1694** adds the resolve-and-guard block to `FilesController::store()`. It
  lands above the validation array this changes, and the two are complementary:
  #1694 decides *whether the folder is yours*, this decides *whether it is
  there*.
- **#1681** adds `scope->folders()->findOrFail()` to both `update()` methods.
  Once it lands, those two paths refuse a trashed id by its route as well as by
  this one — belt and braces, and neither is redundant, since #1681's guard
  answers a different question and this rule covers `store()`, which #1681 does
  not touch.

Verified by merging into a branch carrying all eighteen: suite green, PHPStan
clean.

## Tests

`tests/Feature/Files/DeletedFolderTargetTest.php`, nine cases: the web upload,
the API upload, the web update, the API update, the chunked upload, the two
scope-resolving paths (`move` and `bulk-edit`), folder create and move on a
deleted parent, a live folder still working on both the plain and the chunked
path, and the root still being the root.

Counter-check, stated plainly: against the unfixed code **seven of the nine go
red**, but they are not all the same claim, and the difference matters:

- **five close the hole** — the two uploads and the two updates wrote the
  trashed id, and the chunked path accepted it and silently used the root;
- **two only change the shape of a refusal that already happened** — `move`,
  `bulk-edit` and the folder-parent paths answered 404 through their scope
  guards and now answer 422 through the rule. They go red because the test
  asserts the new shape, not because anything was getting through.

The remaining two hold without the fix; they are regression guards for a live
folder and for the root.

Full suite **1857 passed / 1 skipped** against `main` at `073101d1` (baseline
1848 / 1, same container image — exactly the nine new tests, nothing else
moved). PHPStan level 8 clean. `pint --test` clean on all seven changed files.