### PR TITLE
Spend a recovery code once, the way the docblock says

### DIFF
--- a/app/Modules/Identity/TwoFactor/TwoFactorService.php
+++ b/app/Modules/Identity/TwoFactor/TwoFactorService.php
@@ -14,6 +14,7 @@ use BaconQrCode\Renderer\RendererStyle\Fill;
 use BaconQrCode\Renderer\RendererStyle\RendererStyle;
 use BaconQrCode\Writer;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use PragmaRX\Google2FA\Google2FA;
 
@@ -112,20 +113,45 @@ class TwoFactorService
 
     /**
      * Consume a recovery code; each code works exactly once.
+     *
+     * Read the list, filter it, write the whole list back is not once.
+     * Two requests that both read before either writes each store their
+     * own filtered copy, and the second write puts back the code the
+     * first removed -- so a spent code is available again, and the same
+     * code offered twice is accepted twice. Neither lets in anybody who
+     * was not already holding a code, which is why this is a promise not
+     * being kept rather than a door standing open. The promise is the
+     * sentence above, and it is the reason recovery codes are printed
+     * out and crossed off.
+     *
+     * Decide from the row as it stands, read back under a lock inside
+     * the transaction that writes it -- the same shape
+     * SendNotificationDigest uses to claim the rows it is about to
+     * delete. The lock is what makes it atomic against a request
+     * arriving at the same moment; the re-read is what makes the
+     * decision right, and it is the half that can be demonstrated in a
+     * test, since SQLite ignores lockForUpdate.
+     *
+     * The caller's own instance is what gets saved, so it does not walk
+     * away holding a list the database no longer has.
      */
     public function consumeRecoveryCode(User $user, string $code): bool
     {
-        /** @var list<string>|null $codes */
-        $codes = $user->two_factor_recovery_codes;
+        return DB::transaction(function () use ($user, $code): bool {
+            $locked = User::query()->whereKey($user->getKey())->lockForUpdate()->first();
 
-        if ($codes === null || ! in_array($code, $codes, true)) {
-            return false;
-        }
+            /** @var list<string>|null $codes */
+            $codes = $locked?->two_factor_recovery_codes;
 
-        $user->forceFill([
-            'two_factor_recovery_codes' => array_values(array_diff($codes, [$code])),
-        ])->save();
+            if ($codes === null || ! in_array($code, $codes, true)) {
+                return false;
+            }
 
-        return true;
+            $user->forceFill([
+                'two_factor_recovery_codes' => array_values(array_diff($codes, [$code])),
+            ])->save();
+
+            return true;
+        });
     }
 }

--- a/tests/Feature/Identity/RecoveryCodeSingleUseTest.php
+++ b/tests/Feature/Identity/RecoveryCodeSingleUseTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Identity\SignIn;
+use App\Modules\Identity\TwoFactor\TwoFactorService;
+
+/**
+ * "Each code works exactly once" -- the promise in the docblock, and the
+ * reason a printed sheet of recovery codes can be crossed off.
+ *
+ * Two independently loaded instances of the same row stand in for two
+ * requests that both read the list before either writes it back. That is
+ * what the old read-filter-write lost, and it is a thing SQLite can
+ * demonstrate; lockForUpdate is a no-op there, so what these pin is the
+ * re-read, not the lock.
+ */
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->user->forceFill([
+        'two_factor_secret' => 'SECRET',
+        'two_factor_recovery_codes' => ['aaa-111', 'bbb-222', 'ccc-333'],
+        'two_factor_confirmed_at' => now(),
+    ])->save();
+
+    $this->service = app(TwoFactorService::class);
+});
+
+function storedCodes(User $user): array
+{
+    /** @var list<string> $codes */
+    $codes = User::query()->findOrFail($user->id)->two_factor_recovery_codes ?? [];
+
+    return $codes;
+}
+
+test('spending two different codes at once does not put either back', function () {
+    $first = User::query()->findOrFail($this->user->id);
+    $second = User::query()->findOrFail($this->user->id);
+
+    expect($this->service->consumeRecoveryCode($first, 'aaa-111'))->toBeTrue()
+        ->and($this->service->consumeRecoveryCode($second, 'bbb-222'))->toBeTrue()
+        ->and(storedCodes($this->user))->toBe(['ccc-333']);
+});
+
+test('the same code is not accepted twice', function () {
+    $first = User::query()->findOrFail($this->user->id);
+    $second = User::query()->findOrFail($this->user->id);
+
+    expect($this->service->consumeRecoveryCode($first, 'aaa-111'))->toBeTrue()
+        ->and($this->service->consumeRecoveryCode($second, 'aaa-111'))->toBeFalse()
+        ->and(storedCodes($this->user))->toBe(['bbb-222', 'ccc-333']);
+});
+
+test('the caller instance is left holding what the database holds', function () {
+    $instance = User::query()->findOrFail($this->user->id);
+
+    $this->service->consumeRecoveryCode($instance, 'aaa-111');
+
+    expect($instance->two_factor_recovery_codes)->toBe(['bbb-222', 'ccc-333'])
+        ->and($instance->isDirty())->toBeFalse();
+});
+
+test('a code still works, once, in the ordinary case', function () {
+    expect($this->service->consumeRecoveryCode($this->user, 'bbb-222'))->toBeTrue()
+        ->and(storedCodes($this->user))->toBe(['aaa-111', 'ccc-333'])
+        ->and($this->service->consumeRecoveryCode($this->user, 'bbb-222'))->toBeFalse();
+});
+
+test('a code nobody issued is refused, and an account with none at all', function () {
+    expect($this->service->consumeRecoveryCode($this->user, 'zzz-999'))->toBeFalse()
+        ->and(storedCodes($this->user))->toBe(['aaa-111', 'bbb-222', 'ccc-333']);
+
+    $plain = User::factory()->create();
+
+    expect($this->service->consumeRecoveryCode($plain, 'aaa-111'))->toBeFalse();
+});
+
+test('spending the last code empties the list', function () {
+    $this->user->forceFill(['two_factor_recovery_codes' => ['only-one']])->save();
+
+    expect($this->service->consumeRecoveryCode($this->user, 'only-one'))->toBeTrue()
+        ->and(storedCodes($this->user))->toBe([]);
+});
+
+test('the challenge screen still signs somebody in with one, and spends it', function () {
+    $this->withSession([
+        SignIn::TWO_FACTOR_ID => $this->user->id,
+        SignIn::TWO_FACTOR_REMEMBER => false,
+    ])->post('/two-factor-challenge', ['recovery_code' => ' aaa-111 '])
+        ->assertRedirect(route('dashboard', absolute: false));
+
+    $this->assertAuthenticatedAs($this->user);
+    expect(storedCodes($this->user))->toBe(['bbb-222', 'ccc-333']);
+});


### PR DESCRIPTION
## The promise that is not kept

`TwoFactorService::consumeRecoveryCode()` opens with it:

```php
/**
 * Consume a recovery code; each code works exactly once.
 */
public function consumeRecoveryCode(User $user, string $code): bool
{
    /** @var list<string>|null $codes */
    $codes = $user->two_factor_recovery_codes;

    if ($codes === null || ! in_array($code, $codes, true)) {
        return false;
    }

    $user->forceFill([
        'two_factor_recovery_codes' => array_values(array_diff($codes, [$code])),
    ])->save();

    return true;
}
```

Read the whole list, filter one code out, write the whole list back. Two
requests that both read before either writes each store their own copy, and the
second write puts back the code the first removed.

Measured with two independently loaded instances of the same row — which is
what two concurrent requests hold:

| | |
|---|---|
| start | `["aaa-111", "bbb-222", "ccc-333"]` |
| spend `aaa-111`, then `bbb-222` | both return `true` |
| stored afterwards | `["aaa-111", "ccc-333"]` — a spent code is back |
| the same code offered twice | `true` twice |

## How much this is worth

Not much, and it is worth saying so plainly: nobody gets in through this who
was not already holding a valid recovery code. It is a promise not being kept
rather than a door standing open.

The promise is still worth keeping. It is the entire reason a printed sheet of
recovery codes can be crossed off, and it is what makes a code somebody watched
being typed in stop working. A method whose first line says "exactly once"
should be once.

## The fix

The decision comes from the row as it stands, re-read under a lock inside the
transaction that writes it:

```php
return DB::transaction(function () use ($user, $code): bool {
    $locked = User::query()->whereKey($user->getKey())->lockForUpdate()->first();

    /** @var list<string>|null $codes */
    $codes = $locked?->two_factor_recovery_codes;

    if ($codes === null || ! in_array($code, $codes, true)) {
        return false;
    }

    $user->forceFill([
        'two_factor_recovery_codes' => array_values(array_diff($codes, [$code])),
    ])->save();

    return true;
});
```

This is the shape `SendNotificationDigest:55` already uses to claim the rows it
is about to delete — lock inside the transaction, decide from what the lock
returned.

**Why not a conditional update.** That is the other precedent in the tree:
`PublicShareController:96-97` holds a share link to `max_downloads` with a
conditional increment, and #1692's `deliverOnce()` claims a zip download with a
conditional update on `delivered_at`. Both work because the database can
evaluate the condition. Here it cannot: `two_factor_recovery_codes` is
`encrypted:array`, so there is nothing in the column a `WHERE` can compare. The
comparison has to happen after decryption, which means it has to happen under
something that holds the row while it does.

Saving through the caller's own instance keeps that instance in step with the
row, so a caller cannot go on to decide from a list the database no longer has.

### What the tests prove, and what they do not

The lock is what makes this atomic against a request arriving at the same
moment. The re-read is what makes the decision right. **Only the re-read is what
the tests demonstrate** — the suite runs on SQLite, where `lockForUpdate` is a
no-op — so the cases below are written around two independently loaded
instances, which is exactly the interleaving the old code lost, and they are not
claiming to prove the locking. `config/database.php` runs MySQL or Postgres in
production and both honour it.

This is the same distinction #1686's body draws about `Cache::lock` degrading to
the array driver under test.

### Not changed (deliberate)

- **`generateRecoveryCodes()` and `clear()`.** Neither reads-then-writes.
- **`TwoFactorChallengeController`.** It calls this and does the right thing
  with the answer; the rate limiter around it is untouched. A test pins that the
  challenge screen still signs somebody in with a recovery code and spends it.
- **Regenerating codes when one is used.** A product decision, and a different
  one.

## Merge note

Clean against all eighteen open branches, checked pairwise with
`git merge-tree --write-tree`; nothing else touches this file. Verified by
merging into a branch carrying all eighteen: suite green, PHPStan clean.

## Tests

`tests/Feature/Identity/RecoveryCodeSingleUseTest.php`, seven cases: two
different codes spent through two instances, the same code twice, the caller's
instance left in step with the row, a code still working once in the ordinary
case, an unknown code and an account with no codes at all, spending the last
one, and the challenge screen end to end.

Counter-check, stated plainly: against the unfixed code **two of the seven go
red** — the two that describe the lost update. The other five hold without the
fix; they are regression guards for the behaviour that must survive it, not
proof of the bug.

Full suite **1855 passed / 1 skipped** against `main` at `073101d1` (baseline
1848 / 1, same container image — exactly the seven new tests, nothing else
moved). PHPStan level 8 clean. `pint --test` clean on both changed files.