### PR TITLE
Deny a membership request once, as approve() already does

### DIFF
--- a/app/Modules/Groups/Http/Controllers/MembershipRequestsController.php
+++ b/app/Modules/Groups/Http/Controllers/MembershipRequestsController.php
@@ -87,6 +87,17 @@ class MembershipRequestsController extends Controller
 
     public function deny(MembershipRequest $membershipRequest): RedirectResponse
     {
+        // The half of approve()'s guard that applies here. A request that
+        // has already been denied is not a decision left to make, and
+        // taking it again re-stamps denied_at -- which is what the
+        // client's re-request cooldown counts from, so the same request
+        // repeated keeps a client out of a group indefinitely -- while
+        // writing a second log entry and sending a second "your request
+        // was declined" mail for one decision. The queue only ever lists
+        // pending requests, so this is not reachable through the screen;
+        // it is reachable by asking for the route directly.
+        abort_unless($membershipRequest->status === MembershipRequest::STATUS_PENDING, 404);
+
         $group = $membershipRequest->group;
         $client = $membershipRequest->user;
 

--- a/tests/Feature/Groups/DenyMembershipRequestOnceTest.php
+++ b/tests/Feature/Groups/DenyMembershipRequestOnceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Audit\Action;
+use App\Modules\Audit\ActivityLog;
+use App\Modules\Groups\Models\Group;
+use App\Modules\Groups\Models\MembershipRequest;
+use App\Modules\Groups\Notifications\GroupMembershipDeniedNotification;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+use Illuminate\Support\Facades\Notification;
+
+/**
+ * approve() refuses a request that is not pending. deny() did not, and a
+ * denial is not idempotent: it re-stamps denied_at, which is what the
+ * client's re-request cooldown counts from.
+ */
+beforeEach(function () {
+    $this->admin = User::factory()->create();
+    $this->client = User::factory()->client()->create();
+    $this->group = Group::query()->create(['name' => 'Guarded', 'slug' => 'guarded', 'public' => true]);
+
+    $this->request = MembershipRequest::query()->create([
+        'group_id' => $this->group->id,
+        'user_id' => $this->client->id,
+        'status' => MembershipRequest::STATUS_PENDING,
+    ]);
+});
+
+test('denying a pending request works, once', function () {
+    $this->actingAs($this->admin)->delete("/membership-requests/{$this->request->id}")->assertRedirect();
+
+    expect($this->request->fresh()->status)->toBe(MembershipRequest::STATUS_DENIED);
+
+    $this->actingAs($this->admin)->delete("/membership-requests/{$this->request->id}")->assertNotFound();
+});
+
+test('a second denial does not move the stamp, or the log, or the mail', function () {
+    Notification::fake();
+    app(Settings::class)->set(Setting::EmailNotificationsEnabled, true);
+
+    $this->actingAs($this->admin)->delete("/membership-requests/{$this->request->id}");
+    $stamped = $this->request->fresh()->denied_at;
+
+    $this->travel(5)->days();
+    $this->actingAs($this->admin)->delete("/membership-requests/{$this->request->id}")->assertNotFound();
+
+    expect($this->request->fresh()->denied_at?->toIso8601String())->toBe($stamped?->toIso8601String())
+        ->and(ActivityLog::query()->where('action', Action::GroupMembershipDenied->value)->count())->toBe(1);
+
+    Notification::assertSentToTimes($this->client, GroupMembershipDeniedNotification::class, 1);
+});
+
+test('a replayed denial cannot hold a client out of a group past the cooldown', function () {
+    app(Settings::class)->set(Setting::ClientsCanSelectGroup, 'public');
+    app(Settings::class)->set(Setting::ClientsMembershipDenyCooldownDays, 30);
+
+    $this->actingAs($this->admin)->delete("/membership-requests/{$this->request->id}");
+
+    // Day 29: still inside the cooldown, and a denial arriving now used
+    // to restart it.
+    $this->travel(29)->days();
+    $this->actingAs($this->admin)->delete("/membership-requests/{$this->request->id}")->assertNotFound();
+
+    $this->travel(2)->days();
+
+    $this->actingAs($this->client)
+        ->post('/my-groups', ['group_id' => $this->group->id])
+        ->assertSessionHasNoErrors();
+
+    expect($this->request->fresh()->status)->toBe(MembershipRequest::STATUS_PENDING);
+});
+
+test('approve already refused a request that is not pending', function () {
+    $this->actingAs($this->admin)->delete("/membership-requests/{$this->request->id}");
+
+    $this->actingAs($this->admin)
+        ->post("/membership-requests/{$this->request->id}/approve")
+        ->assertNotFound();
+
+    expect($this->group->members()->count())->toBe(0);
+});


### PR DESCRIPTION
## The guard one method up

`MembershipRequestsController::approve():76` refuses a request that is not
pending:

```php
abort_unless($group !== null && $client !== null
    && $membershipRequest->status === MembershipRequest::STATUS_PENDING, 404);
```

`deny():88`, immediately below it, checks nothing:

```php
public function deny(MembershipRequest $membershipRequest): RedirectResponse
{
    $group = $membershipRequest->group;
    $client = $membershipRequest->user;

    // The denied row persists: the client sees the outcome, and it
    // enforces the re-request cooldown.
    $membershipRequest->forceFill([
        'status' => MembershipRequest::STATUS_DENIED,
        'denied_at' => now(),
    ])->save();
    …
```

## Why that is not harmless

Denying is not idempotent, so repeating it is not a no-op:

- **`denied_at` is stamped again**, and that is what the client's re-request
  cooldown counts from (`MyGroupsController::inDenyCooldown()` →
  `$request->denied_at->addDays($days)->isFuture()`). Repeating the request
  keeps one client out of one group for as long as somebody cares to keep
  asking, without a single new decision being made. Measured: a second `DELETE`
  three days later moves the stamp three days forward.
- **a second `GroupMembershipDenied` entry** goes into the activity log, for a
  denial that did not happen. Measured: two entries for one decision.
- **a second "your request was declined" mail** goes to the client.

The queue lists only pending requests (`index()` → `->pending()`), so nothing on
the screen offers this; it takes asking for the route directly. It needs
`approve_groups_memberships_requests`, so it is not a stranger's move.

The one thing the screen can produce is a double submit, and that is the case
`approve()` already settles: it has no confirmation step at all — the button is a
bare `router.post` — and a second click has answered 404 since the guard was
written. Deny goes through a `ConfirmDialog`, so it is the harder of the two to
fire twice. Matching them makes the pair consistent rather than introducing a new
way to see an error page. Measured on `main`: deny twice is 302 then **302**,
approve twice is 302 then **404**.

## The fix

The same guard, answering the same 404, placed where `deny()` can reach it:

```php
abort_unless($membershipRequest->status === MembershipRequest::STATUS_PENDING, 404);
```

`deny()` keeps tolerating a vanished group or client — that tolerance is
deliberate and separate. The denied row persists for the cooldown even when the
group it named is gone, and `index()` already filters those rows out with
`whereHas('user')->whereHas('group')`, so they are never listed either way.
That is why this takes only the status half of `approve()`'s condition.

### Not in this change (deliberate)

`deny()` writes the status, the log entry and the notification without a shared
transaction, so a failure between them leaves a denied row with no record of
who denied it. `approve()` has exactly the same shape — membership write,
delete, log, notify, all unwrapped — so fixing one alone would replace a
symmetry with a difference. Doing both means also deciding where the mail sits
relative to the commit, which is the question **#1691** answers for file bytes
("delete a file's bytes when its transaction commits, not before"), and it is
worth answering on its own rather than inside a state-machine fix.

## Merge note

Clean against all eighteen open branches, checked pairwise with
`git merge-tree --write-tree`.

Clean against its sibling as well: another change in this series adds a library
boundary to `approve()` and `deny()` in this same controller. The two land on
opposite sides of `deny()`'s `$group`/`$client` reads — this one before them,
that one after — and `git` merges both without help. Verified: both applied on
top of a branch carrying all eighteen, `deny()` carrying both guards in the
right order, full `tests/Feature/Groups` suite green.

## Tests

`tests/Feature/Groups/DenyMembershipRequestOnceTest.php`, four cases: denying a
pending request working and the replay refused, the stamp and the log entry and
the mail each staying at one, a replayed denial no longer holding a client past
the cooldown (the concrete harm, end to end through `POST /my-groups`), and
`approve()` still refusing a non-pending request — the symmetry this restores.

Counter-check, stated plainly: against the unfixed code **three of the four go
red**. The fourth is `approve()`'s existing guard; it holds either way, and it
is there to pin the behaviour this is being made to match rather than to prove
the bug.

Full suite **1852 passed / 1 skipped** against `main` at `073101d1` (baseline
1848 / 1, same container image — exactly the four new tests, nothing else
moved). PHPStan level 8 clean. `pint --test` clean on both changed files.