### PR TITLE
Leave the test workflow one concurrency block, so it parses again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,12 +44,6 @@ on:
       - 'docker/production/dockerhub-overview.md'
       - '.github/screenshots/**'
 
-# A second push supersedes the first: there is no value in finishing a run
-# for a commit nobody will look at again.
-concurrency:
-  group: tests-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 # A second push supersedes the first — the later run covers a superset of
 # what the earlier one was checking, so finishing both buys nothing and
 # costs a runner.


### PR DESCRIPTION
`c05927c1` added a `concurrency:` block on the premise that the test workflow
never had one. It already had one, four lines above — that commit's own hunk
header reads `@@ -50,6 +50,23 @@ concurrency:`, which is the existing block it
was appended below.

## What that costs

A YAML mapping cannot carry the same key twice, so `.github/workflows/tests.yml`
has not loaded since. GitHub still creates a run and then schedules nothing:

```
553f5fd2  (last green)  run 33036453748  jobs=1  ci → success
d58e4830  (main)        run 33114046849  jobs=0  failure
```

Every run since has that shape. The run list says it a second way: those runs
are listed as `.github/workflows/tests.yml` where the green ones are listed as
`tests` — the `name:` key sits inside the file that did not parse.

The last suite that actually ran is `553f5fd2`'s. Nothing after it has a suite
result, including the commit `v2.2.0` is tagged at:

```
01f41860  (v2.2.0)  run 33099444125  jobs=0
c172d0d6            run 33101374279  jobs=0
351da21e            run 33103722876  jobs=0
c49811f3            run 33110362583  jobs=0
d58e4830  (main)    run 33114046849  jobs=0
```

`linter` is unaffected — it carries one block — which is why `351da21e` shows a
green linter beside a failed tests run, and the tree reads as half-checked
rather than unchecked.

Reproduced with a parser rather than inferred from the job count (`symfony/yaml`,
already in the lock file):

```
before → THREW: Duplicate key "concurrency" detected at line 66.
after  → parsed ok, top-level keys: name,on,concurrency,jobs
```

## The fix

Delete the first block. Six lines, no application code.

## Not changed (deliberate)

- **Which block survives.** The second one, verbatim, because it is the state
  `c05927c1` meant to arrive at and its comment carries the reasoning —
  including the tradeoff that an intermediate commit on `main` can end up with
  no run of its own.
- **The group key.** `github.workflow` is constant within a workflow, so
  `tests-${{ github.workflow }}-${{ github.ref }}` and `tests-${{ github.ref }}`
  group identically. Worth knowing that `lint.yml` still uses the first shape,
  if you would rather the two files read alike — that is a rename, not a fix.
- **Everything else in the file.** Both `paths-ignore` lists are untouched, so
  `CHANGELOG.md` and `docs/` keep their deliberate absence from them, and the
  `ci` job keeps `--parallel` and `DB_DATABASE: ':memory:'`. The diff is six
  deleted lines and nothing else.
- **No test.** A workflow file that does not parse announces itself on the next
  push, and a test asserting no duplicate top-level key would be a second place
  to keep the same rule.

## Tests

None — nothing in `app/` or `tests/` changes. Measured on the branch anyway, as
CI runs it: 2048 passed / 2 skipped, PHPStan level 8 clean. Same as `main`.