### PR TITLE
Let an enforced user reach the far side of the confirm-password screen

### DIFF
--- a/app/Modules/Identity/Http/Middleware/EnforceTwoFactor.php
+++ b/app/Modules/Identity/Http/Middleware/EnforceTwoFactor.php
@@ -40,12 +40,17 @@ class EnforceTwoFactor
             return $next($request);
         }
 
-        // password.confirm is on this list because the two-factor mutation
+        // password.confirm* is on this list because the two-factor mutation
         // routes now require it: without the exemption, enrolling would
         // redirect to the confirm-password screen, which this middleware
         // would redirect straight back to two-factor.show — a loop that
         // locks the user out of the only exit.
-        if ($request->routeIs('two-factor.*', 'password.confirm', 'logout', 'locale.update')) {
+        //
+        // The pattern covers both halves of that screen. Naming only the
+        // GET left the form rendering and its submission redirected away,
+        // so the password was never confirmed and the loop stayed shut
+        // one step further along than before.
+        if ($request->routeIs('two-factor.*', 'password.confirm*', 'logout', 'locale.update')) {
             return $next($request);
         }
 

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -95,7 +95,12 @@ Route::middleware('auth')->group(function () {
     Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
         ->name('password.confirm');
 
-    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
+    // Named so EnforceTwoFactor can exempt it. Its exemption list matches
+    // on route names, and an unnamed route matches nothing -- which left
+    // the form reachable and its submission not, closing the enrolment
+    // path enforcement depends on.
+    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store'])
+        ->name('password.confirm.store');
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
         ->name('logout');

--- a/tests/Feature/Identity/TwoFactorEnforcementTest.php
+++ b/tests/Feature/Identity/TwoFactorEnforcementTest.php
@@ -55,7 +55,12 @@ test('the 2fa setup screen itself and logout stay reachable under enforcement', 
     $this->actingAs(User::factory()->create());
 
     $this->get('/settings/two-factor')->assertOk();
-    $this->post('/settings/two-factor')->assertRedirect();
+    // Named rather than bare: enabling is behind password.confirm, so the
+    // redirect it answers with is the confirm-password screen. A bare
+    // assertRedirect() passes on any target, including this middleware
+    // bouncing the request back to two-factor.show, which is the shape
+    // this file exists to refuse.
+    $this->post('/settings/two-factor')->assertRedirect(route('password.confirm'));
     $this->post('/logout')->assertRedirect('/');
 });
 
@@ -101,4 +106,47 @@ test('clients cannot access security settings', function () {
 
     $this->get('/system/settings/security')->assertRedirect(route('dashboard'));
     $this->patch('/system/settings/security', ['two_factor_enforcement' => 'all'])->assertForbidden();
+});
+
+/**
+ * The exemption list matches on route names, and only the GET half of the
+ * confirm-password screen had one. So the form rendered and its submission
+ * did not: enforcement sent the POST back to two-factor.show, the password
+ * was never confirmed, and enrolment -- the one exit enforcement leaves
+ * open -- could not be started by anybody.
+ */
+test('an enforced user can confirm their password, which is what enrolling needs', function () {
+    app(Settings::class)->set(Setting::TwoFactorEnforcement, 'all');
+
+    $this->actingAs(User::factory()->create());
+
+    $this->post('/settings/two-factor')->assertRedirect(route('password.confirm'));
+    $this->get('/confirm-password')->assertOk();
+
+    $this->post('/confirm-password', ['password' => 'password'])
+        ->assertSessionHasNoErrors();
+
+    expect(session()->has('auth.password_confirmed_at'))->toBeTrue();
+});
+
+test('enrolment can actually be started under enforcement', function () {
+    app(Settings::class)->set(Setting::TwoFactorEnforcement, 'all');
+
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $this->post('/confirm-password', ['password' => 'password']);
+
+    // store() answers back(), so the target is the referer rather than a
+    // fixed route -- what matters is that it ran at all instead of being
+    // bounced to the confirm-password screen it can no longer get past.
+    $this->post('/settings/two-factor')->assertSessionHasNoErrors();
+
+    // The secret is what enabling writes; without it the enrolment screen
+    // has no QR code to show and there is nothing to confirm against.
+    expect($user->refresh()->two_factor_secret)->not->toBeNull();
+
+    $this->get('/settings/two-factor')->assertOk()->assertInertia(
+        fn (AssertableInertia $page) => $page->where('pending', true)
+    );
 });


### PR DESCRIPTION
`EnforceTwoFactor` exempts by route name, and only the GET half of the
confirm-password screen has one.

```php
Route::get('confirm-password', …)->name('password.confirm');   // routes/auth.php:95
Route::post('confirm-password', …);                            // :98 — no name
```

`Route::named()` answers `false` for a null name, so `routeIs('password.confirm')`
never matches the submission.

## The loop is still there, one step further along

The comment above the exemption already describes it:

> `password.confirm` is on this list because the two-factor mutation routes now
> require it: without the exemption, enrolling would redirect to the
> confirm-password screen, which this middleware would redirect straight back to
> `two-factor.show` — a loop that locks the user out of the only exit.

Measured with `Setting::TwoFactorEnforcement` set to `all` and an un-enrolled
account:

```
GET   /dashboard                  → two-factor.show
GET   /system/settings/security   → two-factor.show
PATCH /system/settings/security   → two-factor.show
POST  /settings/two-factor        → /confirm-password   (RequirePassword)
GET   /confirm-password           → 200, the form renders
POST  /confirm-password           → two-factor.show     ← not exempt
```

`auth.password_confirmed_at` is never written. Enrolling cannot start, and every
route off the exemption list stays shut — including Settings → Security, the one
screen that would turn enforcement back off. Logout is the only door left;
recovery is CLI or database access.

One administrator turning the setting on reaches every account on the
installation at once, including their own.

## The fix

Name the submission `password.confirm.store`, and widen the exemption to
`password.confirm*` so it covers both halves of one screen — matching
`two-factor.*` in the same expression.

Exempting the submission grants nothing further. `store()` validates the
password, writes a session flag and redirects; the redirect it issues enters
this middleware like every other request, so Settings → Security is still
answered with `two-factor.show` after confirming. What changes is that enrolment
can be started.

## Not changed (deliberate)

- **The pattern rather than two literal names.** `password.confirm*` is one
  namespace belonging entirely to a flow enrolment already depends on being
  reachable, and the same expression already wildcards `two-factor.*`, which is
  broader and more powerful. Checked against the route table: it reaches
  `password.confirm` and `password.confirm.store` and nothing else. It is a
  prefix, so a future route named under it would inherit the exemption —
  `password.reset`, `password.store` and the rest are not under it.
- **The other three entries.** `two-factor.*`, `logout` and `locale.update` are
  unchanged.
- **Naming a route puts it in the Ziggy payload.** `app.blade.php` calls
  `@routes` with no filter and there is no `config/ziggy.php`, so every named
  route is serialised into the page. Measured, the payload goes from 289 routes
  to 290, the addition being:

  ```
  password.confirm.store [POST] confirm-password
  ```

  Stated rather than left to be found: it discloses nothing, since the form on
  that screen already posts to that URL in plain sight.
- **`resources/js/pages/auth/confirm-password.tsx`.** It submits with
  `route('password.confirm')`, which resolves to the same URI — the two halves
  share it. Pointing it at the new name would read better and change nothing, so
  it is left for you to decide rather than folded in here.
- **`RequirePassword` itself.** The redirect to the confirm screen is correct;
  what was broken is getting off it. `route('password.confirm')` still resolves
  to the GET route, and there are no duplicate route names.

## Tests

Two, both **measured red against the unfixed middleware** (2 failed / 10 passed;
12 passed with the fix): the password confirmation sticks, and enrolment can be
started afterwards — the secret is written and the enrolment screen reports
`pending`.

Also named the redirect the existing test settles for. `->assertRedirect()` with
no target passes on this middleware bouncing the request back to
`two-factor.show`, which is the shape that file exists to refuse. Stated plainly:
that assertion is green either way, because the redirect it sees comes from
`RequirePassword` — it is a clarification, not a guard.

Full suite passes (2050 passed / 2 skipped), PHPStan level 8 clean.

## A note on this PR's checks

`.github/workflows/tests.yml` currently carries two top-level `concurrency:`
keys, so it does not parse. On `push` GitHub creates a run and schedules no jobs
— every commit since `c05927c1` has one with `jobs=0`. On `pull_request` it
creates nothing at all, which is why this PR shows no tests check rather than a
failing one. The numbers above were measured locally, as CI runs them
(`pest --parallel`, `DB_DATABASE=':memory:'`).

#1707 removes the duplicate key and touches nothing else. Its own check ran and
passed, which is the fix demonstrating itself: a pull request is checked against
the workflow file as it would be after merging. Merging that one first makes this
one's check meaningful. The two branches share no files.