### PR TITLE
Ask the seat cap where a pending client is approved through edit()

### DIFF
--- a/app/Modules/Clients/Http/Controllers/Api/ClientsController.php
+++ b/app/Modules/Clients/Http/Controllers/Api/ClientsController.php
@@ -191,7 +191,11 @@ class ClientsController extends Controller
             $client->storage_quota_mb = $validated['storage_quota_mb'] ?? 0;
         }
 
+        // Approval, and so the moment the seat is spent — same rule the
+        // web edit screen and approve() answer to. Inside the branch, so a
+        // capped installation can still edit a client it already holds.
         if (($validated['active'] ?? false) && $client->account_requested) {
+            $this->seats->guardClient('active');
             $client->account_requested = false;
         }
 

--- a/app/Modules/Clients/Http/Controllers/ClientsController.php
+++ b/app/Modules/Clients/Http/Controllers/ClientsController.php
@@ -234,8 +234,13 @@ class ClientsController extends Controller
         ]);
 
         // Activating a pending account through the edit screen counts as
-        // approval and clears the request flag.
+        // approval and clears the request flag — which is the moment a
+        // seat is spent, so the cap is asked here for the same reason
+        // AccountRequestsController::approve() asks it one screen over.
+        // Inside the branch, not above it: an installation at its cap must
+        // still be able to rename a client it already has.
         if ($client->account_requested && $validated['active']) {
+            $this->seats->guardClient('active');
             $client->account_requested = false;
         }
 

--- a/tests/Feature/Platform/SeatAllowanceTest.php
+++ b/tests/Feature/Platform/SeatAllowanceTest.php
@@ -9,6 +9,7 @@ use App\Modules\Platform\Seats\SeatAllowance;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
 use Illuminate\Validation\ValidationException;
+use Laravel\Sanctum\Sanctum;
 
 /**
  * A cap is only a cap if every door asks.
@@ -189,6 +190,53 @@ test('door: approving an account request', function () {
         ->assertSessionHasErrors('email');
 
     expect($pending->refresh()->account_requested)->toBeTrue();
+});
+
+test('door: approving a pending client through the edit screen', function () {
+    seatLimits(clients: 0);
+
+    $pending = User::factory()->client()->create(['account_requested' => true, 'active' => false]);
+
+    $this->actingAs($this->admin)->patch("/clients/{$pending->id}", [
+        'name' => $pending->name,
+        'email' => $pending->email,
+        'active' => true,
+    ])->assertSessionHasErrors('active');
+
+    // Nothing is written: the guard throws before save(), so a refused
+    // approval does not leave the name or the flag half-applied.
+    expect($pending->refresh()->account_requested)->toBeTrue()
+        ->and($pending->active)->toBeFalse();
+});
+
+test('door: approving a pending client through the API', function () {
+    seatLimits(clients: 0);
+
+    $pending = User::factory()->client()->create(['account_requested' => true, 'active' => false]);
+
+    Sanctum::actingAs($this->admin, ['*']);
+
+    $this->patchJson("/api/v1/clients/{$pending->id}", ['active' => true])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('active');
+
+    expect($pending->refresh()->account_requested)->toBeTrue();
+});
+
+test('the cap does not block editing a client the installation already holds', function () {
+    // The guard sits inside the approval branch. Above it, an installation
+    // sitting at its cap could not rename anybody.
+    seatLimits(clients: 0);
+
+    $client = User::factory()->client()->create(['account_requested' => false, 'active' => true]);
+
+    $this->actingAs($this->admin)->patch("/clients/{$client->id}", [
+        'name' => 'Renamed Ltd',
+        'email' => $client->email,
+        'active' => true,
+    ])->assertSessionHasNoErrors();
+
+    expect($client->refresh()->name)->toBe('Renamed Ltd');
 });
 
 test('door: demoting a staff account to client', function () {


### PR DESCRIPTION
`SeatAllowance`'s docblock says a cap is only a cap if every door asks, and the
class carries a test per door for that reason. Two doors do not ask.

## Where a seat is spent

The moment is the one that clears `account_requested`. Eight places do it:

| | asks the cap |
|---|---|
| `AccountRequestsController::approve()` | yes, `guardClient()` |
| `ClientsController::store()` | yes, `guardClient()` |
| `Api\ClientsController::store()` | yes, `guardClient()` |
| `ClientProvisioning::provision()` (auto-approve) | yes, `guardClient()` |
| `AccountConversion::toClient()` | yes, via `guardToClient()` |
| `AccountConversion::toStaff()` | yes, `guardStaff()` — the account stops being a client |
| **`ClientsController::update()`** | **no** |
| **`Api\ClientsController::update()`** | **no** |

Both `update()`s clear the flag under a comment that names exactly what they are
doing:

```php
// Activating a pending account through the edit screen counts as
// approval and clears the request flag.
```

Measured with `clients: 0` and one pending registration:

```
POST /account-requests/{id}/approve       refused, flag still set
PATCH /clients/{id}          active=true  approved, clientUsed() 0 → 1
PATCH /api/v1/clients/{id}   active=true  approved, clientUsed() 0 → 1
```

A managed installation sitting at its cap therefore keeps taking clients on —
from the edit screen, or from a PATCH — for as long as registrations keep
arriving. Self-registration is open to strangers, so the supply of pending rows
is not the operator's to control.

## The fix

`$this->seats->guardClient('active')` in both, inside the existing branch.

## Not changed (deliberate)

- **Inside the branch, not above it.** Above it, an installation at its cap could
  not rename a client it already holds — one wrong refusal traded for another.
  There is a test pinning that, and it is green with or without this fix, so it
  guards the fix rather than the bug.
- **The field is `active`, not the default `email`.** On this screen the
  administrator is toggling `active`, and an error under the email field would
  point at the wrong control. `approve()` has no form of its own and keeps the
  default. This is a judgement call and easy to reverse if you would rather both
  doors read the same.
- **`store()`, `approve()` and both conversions are untouched.** They already
  ask, each the cap that applies to the direction it moves the account in.
- **The count itself.** `clientUsed()` is unchanged; this is about who asks it.

## Tests

Three, in `SeatAllowanceTest` where the other eight per-door tests live. The two
door tests were measured red against the unguarded controllers (**2 failed / 18
passed**). Both also assert that nothing is written on a refusal — the guard
throws before `save()`, so a refused approval leaves neither the name nor the
flag half-applied.

Full suite passes (2051 passed / 2 skipped), PHPStan level 8 clean.

## One thing this branch does not touch

If you run the suite in parallel you may see an unrelated failure in another
file — `require(bootstrap/cache/services.php): Failed to open stream`, or
`Target [Inertia\Ssr\Gateway] is not instantiable`. Both are the same thing:
`UpdateCommandTest` runs the real `UpdateInstallation` in several tests (the
ones its own comments mark as "not through the seam"), that runs
`clear-compiled`, and `bootstrap/cache/` is shared by every worker. It predates
this branch and reproduces on untouched `main`; raised only because it has been
invisible while the tests workflow does not parse.