### PR TITLE
Stop the update tests emptying bootstrap/cache for every other worker

### DIFF
--- a/tests/Feature/Platform/StaleCodeNoticeTest.php
+++ b/tests/Feature/Platform/StaleCodeNoticeTest.php
@@ -127,8 +127,13 @@ test('it names the command this kind of installation can actually run', function
 ]);
 
 // The rollback story, asserted end to end: whatever the marker said, the
-// command rewrites it to whatever is actually running.
+// command rewrites it to whatever is actually running. Through the artisan
+// seam, as everything that runs this command has to be — see
+// Tests\Support\RecordingUpdate. The settings write this asserts is the
+// real one.
 test('running the update clears the notice', function () {
+    recordingUpdate();
+
     applied('2.2.0');
     expect(noticeFor($this->admin))->not->toBeNull();
 

--- a/tests/Feature/Platform/UpdateCommandTest.php
+++ b/tests/Feature/Platform/UpdateCommandTest.php
@@ -8,68 +8,18 @@ use App\Modules\Identity\Permissions\SystemRole;
 use App\Modules\Identity\Models\Role;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
-use App\Modules\Platform\Updates\UpdateInstallation;
-use Illuminate\Console\OutputStyle;
 
 /**
- * The ordering constraints inside UpdateInstallation are invisible in its
- * result and expensive when wrong — a queue:restart before a cache clear
- * leaves a worker on old code indefinitely, and config:cache breaks
- * TRUSTED_PROXIES silently. An ordered list of the commands it ran is the
- * only thing that can assert them, so the artisan call is a seam.
+ * The command runs through Tests\Support\RecordingUpdate in every test
+ * here, including the ones below that assert the real wiring rather than
+ * the sequence — nothing in this file asserts that an artisan command
+ * actually ran, and running them for real reaches outside this test into
+ * a directory the whole suite shares. See the class, and the test at the
+ * end that pins it.
  */
-class RecordingUpdate extends UpdateInstallation
-{
-    /** @var list<string> */
-    public array $calls = [];
-
-    /** @var array<string, int> */
-    public array $exitCodes = [];
-
-    /** @var array{route: bool, event: bool, config: bool} */
-    public array $warm = ['route' => false, 'event' => false, 'config' => false];
-
-    /** The test database is always migrated, so this cannot be observed for real. */
-    public bool $existingInstall = true;
-
-    protected function artisan(string $command, array $parameters = [], ?OutputStyle $output = null): int
-    {
-        $this->calls[] = $command;
-
-        return $this->exitCodes[$command] ?? 0;
-    }
-
-    protected function warmCaches(): array
-    {
-        return $this->warm;
-    }
-
-    protected function hasRunMigrationsBefore(): bool
-    {
-        return $this->existingInstall;
-    }
-}
-
-/**
- * @param  array{route?: bool, event?: bool, config?: bool}  $warm
- * @param  array<string, int>  $exitCodes
- */
-function recordingUpdate(array $warm = [], array $exitCodes = []): RecordingUpdate
-{
-    $fake = new RecordingUpdate(
-        app(Illuminate\Contracts\Foundation\Application::class),
-        app(App\Modules\Identity\Permissions\EnsureSystemRoles::class),
-        app(Settings::class),
-        app(App\Modules\Audit\ActivityLogger::class),
-    );
-
-    $fake->warm = [...$fake->warm, ...$warm];
-    $fake->exitCodes = $exitCodes;
-
-    app()->instance(UpdateInstallation::class, $fake);
-
-    return $fake;
-}
+beforeEach(function () {
+    recordingUpdate();
+});
 
 test('it migrates, ensures roles, links storage and restarts the queue', function () {
     $fake = recordingUpdate();
@@ -154,8 +104,9 @@ test('it records the version it applied', function () {
         ->and(app(Settings::class)->get(Setting::AppliedVersionAt))->not->toBe('');
 });
 
-// The real thing, not the seam: both entrypoints run this on every boot,
-// so a second run has to be as uneventful as the first.
+// Both entrypoints run this on every boot, so a second run has to be as
+// uneventful as the first. The settings writes it asserts are the real
+// ones; only the artisan calls are recorded.
 test('running it twice is uneventful', function () {
     $this->artisan('projectsend:update')->assertSuccessful();
     $this->artisan('projectsend:update')->assertSuccessful();
@@ -163,10 +114,11 @@ test('running it twice is uneventful', function () {
     expect(app(Settings::class)->get(Setting::AppliedVersion))->toBe(config('projectsend.version'));
 });
 
-// Not through the seam: this is the one assertion that the real wiring
-// runs, and EnsureSystemRoles is the part of an update that a migration
-// cannot do for itself. AccountManager rather than Uploader — the latter
-// is legacy and deliberately never seeded.
+// The one assertion that the real wiring runs: EnsureSystemRoles is the
+// part of an update that a migration cannot do for itself, and the double
+// does not touch it — only the artisan calls are recorded. AccountManager
+// rather than Uploader — the latter is legacy and deliberately never
+// seeded.
 test('it puts back a system role somebody deleted', function () {
     Role::query()->where('name', SystemRole::AccountManager->value)->delete();
 
@@ -285,4 +237,30 @@ test('a rollback raises no welcome', function () {
 
     expect(app(Settings::class)->get(Setting::UpdateWelcomeTo))->toBe('')
         ->and(ActivityLog::query()->where('action', Action::ApplicationUpdated)->count())->toBe(1);
+});
+
+// The seam is not a convenience. bootstrap/cache holds one packages.php and
+// one services.php for the whole checkout, and `pest --parallel` gives eight
+// worker processes the same one: `clear-compiled` deletes both for all of
+// them at once. A worker that boots its application in the window between
+// that delete and its own rebuild reads an empty package manifest —
+// PackageManifest::getManifest() falls back to [] when the file it just
+// wrote is gone again — registers no package service providers, and dies on
+// the next page it renders with "Target [Inertia\Ssr\Gateway] is not
+// instantiable". It surfaced as UpdateWelcomeTest failing roughly one run in
+// six, in a file that has nothing to do with updates.
+//
+// Asserted on the files rather than on the recorded calls: what matters is
+// that nothing left this test, and a future double that forgot to intercept
+// one command would still pass a call-list assertion.
+test('it leaves the compiled caches the rest of the suite is reading alone', function () {
+    $manifests = [app()->getCachedPackagesPath(), app()->getCachedServicesPath()];
+
+    // Both are written during the first application boot of any run, so by
+    // now they are there to be deleted.
+    expect(array_filter($manifests, 'file_exists'))->toBe($manifests);
+
+    $this->artisan('projectsend:update')->assertSuccessful();
+
+    expect(array_filter($manifests, 'file_exists'))->toBe($manifests);
 });

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use App\Modules\Audit\ActivityLogger;
 use App\Modules\Files\DeletedAccountContent;
 use App\Modules\Files\Folders\FolderService;
 use App\Modules\Files\Models\File;
@@ -11,14 +12,19 @@ use App\Modules\Files\Models\Folder;
 use App\Modules\Groups\Models\Group;
 use App\Modules\Identity\Models\Role;
 use App\Modules\Identity\Models\RolePermission;
+use App\Modules\Identity\Permissions\EnsureSystemRoles;
 use App\Modules\Identity\Permissions\PermissionChecker;
 use App\Modules\Platform\Settings\ExternalStorageConfigApplier;
 use App\Modules\Platform\Settings\ExternalStorageSettings;
+use App\Modules\Platform\Settings\Settings;
+use App\Modules\Platform\Updates\UpdateInstallation;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use PragmaRX\Google2FA\Google2FA;
+use Tests\Support\RecordingUpdate;
 
 /*
 |--------------------------------------------------------------------------
@@ -281,4 +287,32 @@ function failAccountContentDisposal(): void
             throw new RuntimeException('content reassignment failed');
         }
     });
+}
+
+/**
+ * Swap the update in for one that records its artisan calls instead of
+ * running them, and return it.
+ *
+ * Used by every test that runs `projectsend:update`, in more than one file
+ * — see the class for why running the real commands is not an option in a
+ * parallel suite.
+ *
+ * @param  array{route?: bool, event?: bool, config?: bool}  $warm
+ * @param  array<string, int>  $exitCodes
+ */
+function recordingUpdate(array $warm = [], array $exitCodes = []): RecordingUpdate
+{
+    $fake = new RecordingUpdate(
+        app(Application::class),
+        app(EnsureSystemRoles::class),
+        app(Settings::class),
+        app(ActivityLogger::class),
+    );
+
+    $fake->warm = [...$fake->warm, ...$warm];
+    $fake->exitCodes = $exitCodes;
+
+    app()->instance(UpdateInstallation::class, $fake);
+
+    return $fake;
 }

--- a/tests/Support/RecordingUpdate.php
+++ b/tests/Support/RecordingUpdate.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use App\Modules\Platform\Updates\UpdateInstallation;
+use Illuminate\Console\OutputStyle;
+
+/**
+ * The real update with its artisan calls written down instead of run.
+ *
+ * Two reasons, and the second one is why every test that runs the command
+ * uses this and not the genuine article.
+ *
+ * The ordering constraints inside UpdateInstallation are invisible in its
+ * result and expensive when wrong — a queue:restart before a cache clear
+ * leaves a worker on old code indefinitely, and config:cache breaks
+ * TRUSTED_PROXIES silently. An ordered list of the commands it ran is the
+ * only thing that can assert them, so the artisan call is a seam.
+ *
+ * And those commands are not local. `clear-compiled` deletes
+ * bootstrap/cache/packages.php and bootstrap/cache/services.php, `view:clear`
+ * empties storage/framework/views, `storage:link` rewrites public/storage —
+ * one copy of each, shared by all eight workers of a parallel run. A worker
+ * that boots its application in the window between the delete and the
+ * rebuild reads an empty package manifest, registers no package service
+ * providers at all, and dies on the next page it renders with
+ * "Target [Inertia\Ssr\Gateway] is not instantiable". See the test in
+ * UpdateCommandTest that pins this.
+ *
+ * Everything above the artisan call stays real: EnsureSystemRoles, the
+ * settings writes, the activity log and the welcome marker all run, which
+ * is what the tests in both files actually assert.
+ */
+class RecordingUpdate extends UpdateInstallation
+{
+    /** @var list<string> */
+    public array $calls = [];
+
+    /** @var array<string, int> */
+    public array $exitCodes = [];
+
+    /** @var array{route: bool, event: bool, config: bool} */
+    public array $warm = ['route' => false, 'event' => false, 'config' => false];
+
+    /** The test database is always migrated, so this cannot be observed for real. */
+    public bool $existingInstall = true;
+
+    protected function artisan(string $command, array $parameters = [], ?OutputStyle $output = null): int
+    {
+        $this->calls[] = $command;
+
+        return $this->exitCodes[$command] ?? 0;
+    }
+
+    protected function warmCaches(): array
+    {
+        return $this->warm;
+    }
+
+    protected function hasRunMigrationsBefore(): bool
+    {
+        return $this->existingInstall;
+    }
+}


### PR DESCRIPTION
## The failure

On a parallel run, `UpdateWelcomeTest > staff who may not read system information
are not interrupted` fails roughly one run in six:

```
BindingResolutionException: Target [Inertia\Ssr\Gateway] is not instantiable.
  at storage/framework/views/<hash>.php:47
     app('Inertia\Ssr\Gateway')
```

Run on its own, that file is green every time. The cause is not in it.

## What causes it

`clear-compiled` deletes `bootstrap/cache/packages.php` and
`bootstrap/cache/services.php`. There is one of each for the whole checkout, and
`./vendor/bin/pest --parallel` gives eight worker processes the same one.

Ten tests run the real `projectsend:update`, which runs that command. Measured by
instrumenting `ClearCompiledCommand::handle()` over three full parallel runs:
**12 real invocations per run** — 11 from `UpdateCommandTest`, 1 from
`StaleCodeNoticeTest`. Instrumenting `PackageManifest::getManifest()` in the same
runs recorded the other workers finding the manifest gone at boot **46 times**.

What that costs is this, in `Illuminate\Foundation\PackageManifest`:

```php
if (! is_file($this->manifestPath)) {
    $this->build();
}

return $this->manifest = is_file($this->manifestPath) ?
    $this->files->getRequire($this->manifestPath) : [];
```

A worker that loses the second `is_file()` to another worker's `unlink()` gets
`[]`. No discovered packages means no package service providers, so
`Inertia\ServiceProvider::register()` never runs and its
`bind(Gateway::class, HttpGateway::class)` never happens. The next page that
worker renders dies in the compiled root view, where `@inertia` compiles down to
`app(\Inertia\Ssr\Gateway::class)->dispatch($page)`. Whichever test was booting
at that moment is the one that fails, which is why it moves around and why the
file that fails has nothing to do with updates.

Both halves are measured rather than argued. Rebuilding the manifest with
`inertiajs/inertia-laravel` in `extra.laravel.dont-discover` reproduces the
reported failure exactly — same test, same exception, same frame. And 12 real
`clear-compiled` calls per run is the count above.

`view:clear` and `storage:link --force` ride along in the same sequence and are
just as shared; they have not been observed failing anything, but they are
outside the test that runs them for the same reason.

## The fix

`UpdateCommandTest` already owns a double for this and says why in its own
docblock: *"An ordered list of the commands it ran is the only thing that can
assert them, so the artisan call is a seam."* Nine of its tests, and one in
`StaleCodeNoticeTest`, simply do not use it.

None of those ten asserts that a command ran. They assert `EnsureSystemRoles`,
the settings writes, the activity log and the welcome marker — and the double
overrides only `artisan()`, `warmCaches()` and `hasRunMigrationsBefore()`, so all
of that stays real. In the test environment the last two answer exactly what the
genuine ones answer: no `route`/`event`/`config` cache file exists, and the test
database is always migrated.

So the seam now covers the whole file, through a `beforeEach` rather than per
test — the next test added here should not have to know any of this. The two
comments that said "the real thing, not the seam" and "not through the seam" now
say what is actually still real.

The double moves to `tests/Support/RecordingUpdate.php` and its helper to
`tests/Helpers.php`, for the reason `tests/Helpers.php` documents at the top:
Pest hands whole files to workers, so something declared in one test file does
not exist for another.

### Not changed (deliberate)

- **`UpdateInstallation`.** `clear-compiled` belongs in a real update. Nothing
  about the production sequence is wrong.
- **Per-worker `bootstrap/cache`** via `APP_PACKAGES_CACHE` / `APP_SERVICES_CACHE`
  and friends. That would make the destruction cheap rather than remove it, and
  nothing in the suite needs those commands to run at all.
- **`tests/Feature/Platform/UpdateCommandTest.php`'s import order.** `pint`
  reports `ordered_imports` on it; it is misordered on `main` too, and this is
  not the branch for it.

## Tests

One new test, in `UpdateCommandTest`:

```
it leaves the compiled caches the rest of the suite is reading alone
```

It asserts on the files rather than on the recorded call list, because a future
double that forgot to intercept one command would still satisfy a call-list
assertion.

Counter-checked: with the `beforeEach` removed it goes red on both manifests
being gone — **1 failed / 22 passed**, the diff being
`['bootstrap/cache/packages.php', 'bootstrap/cache/services.php']` against `[]`.

Beyond the test, the mechanism itself was measured before and after:

|                                              | before | after |
| -------------------------------------------- | ------ | ----- |
| real `clear-compiled` calls per parallel run  | 12     | 0     |
| `bootstrap/cache` manifest mtimes after a run | rewritten | untouched |
| consecutive parallel runs green               | —      | 8 / 8 |

Full suite passes (**2049 passed / 2 skipped**). PHPStan level 8 clean — it
analyses `app` only, so it does not cover this change.