### PR TITLE
Make the storage durability dashboard test assert the verdict

### DIFF
--- a/tests/Feature/Platform/StorageDurabilityTest.php
+++ b/tests/Feature/Platform/StorageDurabilityTest.php
@@ -136,7 +136,21 @@ test('nothing is reported when uploads go to external storage instead', function
 test('the dashboard carries the verdict to the system widget', function () {
     $admin = User::factory()->create();
 
+    // Substituted rather than read live, for the same reason the rest of
+    // this file substitutes it: the real answer depends on whatever machine
+    // the suite runs on. What is under test here is that the verdict this
+    // class produced reaches the widget whole — the level, and the volume
+    // name the card prints alongside it.
+    app()->instance(
+        StorageDurability::class,
+        durability(mounts('/docker/volumes/projectsend_files/_data', storage_path('app/files'))),
+    );
+
     $this->actingAs($admin)
         ->get('/dashboard')
-        ->assertInertia(fn ($page) => $page->has('system'));
+        ->assertInertia(fn ($page) => $page->where('system.storage_durability', [
+            'level' => StorageDurabilityLevel::DockerVolume->value,
+            'volume' => 'projectsend_files',
+            'source' => null,
+        ]));
 });


### PR DESCRIPTION
`StorageDurabilityTest > the dashboard carries the verdict to the system widget`
asserted only that a `system` key exists:

```php
->assertInertia(fn ($page) => $page->has('system'));
```

`system` is an unconditional key of `DashboardController`'s `Inertia::render`
array, and `has()` is a key check. The verdict the test is named for was never
looked at.

## What that costs

Deleting the line that puts it there —

```php
'storage_durability' => $this->storageDurability->inspect(),
```

— leaves the file green. Measured, with that one line removed:

```
old assertion   ✓ the dashboard carries the verdict to the system widget
new assertion   ⨯ Property [system.storage_durability] does not exist.
```

So the only test standing between the durability card and an empty payload did
not hold.

## The fix

Substitute `StorageDurability` the way the rest of the file already does, and
assert the payload:

```php
->assertInertia(fn ($page) => $page->where('system.storage_durability', [
    'level' => StorageDurabilityLevel::DockerVolume->value,
    'volume' => 'projectsend_files',
    'source' => null,
]));
```

That is the shape `InstallationKindTest` next door already uses for
`install_kind` — `app()->instance()` for the class whose answer depends on the
machine, then `where()` on the value that reached the page.

## Not changed (deliberate)

- **The class under test.** `StorageDurability::inspect()` is correct; what was
  missing was an assertion that its answer arrives.
- **The other tests in the file.** They exercise the classification against a
  substituted mount table and are unaffected.
- **`has('system')` elsewhere.** Only this one test claimed to check the verdict.

## Tests

No new test — the existing one now asserts what its name says. Counter-checked
against the controller with `storage_durability` removed from `systemInfo()`:
the old assertion passes there, the new one fails on
`Property [system.storage_durability] does not exist`.

The suite count is unchanged at **2048 passed / 2 skipped**; the assertion count
goes from 11194 to 11195, which is the whole of what this changes. PHPStan level
8 clean.