### PR TITLE
Hold the group edit screen to the same library boundary as the rest

### DIFF
--- a/app/Modules/Groups/Http/Controllers/Api/GroupsController.php
+++ b/app/Modules/Groups/Http/Controllers/Api/GroupsController.php
@@ -13,6 +13,7 @@ use App\Modules\Files\Access\StaffLibraryScope;
 use App\Modules\Groups\Models\Group;
 use App\Support\Rules;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -56,9 +57,20 @@ class GroupsController extends Controller
         return GroupResource::collection($this->polling->paginate($request, $query, 'groups'));
     }
 
-    public function show(Group $group): GroupResource
+    public function show(Request $request, Group $group): GroupResource
     {
-        return new GroupResource($group->loadCount('members')->load('members'));
+        $viewer = $request->user();
+        assert($viewer !== null);
+
+        // The web edit screen's boundary, on its API twin: this is the read
+        // half of the group that update() and destroy() below already refuse
+        // to touch, and it hands back the membership with addresses.
+        abort_unless($this->scope->allowsGroupChange($viewer, $group), 404);
+
+        return new GroupResource($group->loadCount('members')->load([
+            'members' => fn (BelongsToMany $members) => $members
+                ->whereIn('users.id', $this->scope->clients($viewer)->select('id')),
+        ]));
     }
 
     public function store(Request $request): JsonResponse

--- a/app/Modules/Groups/Http/Controllers/GroupsController.php
+++ b/app/Modules/Groups/Http/Controllers/GroupsController.php
@@ -10,7 +10,6 @@ use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLogger;
 use App\Modules\Files\Access\StaffLibraryScope;
 use App\Modules\Groups\Models\Group;
-use App\Modules\Identity\UserType;
 use App\Support\Pagination;
 use App\Support\PublicUrl;
 use App\Support\Rules;
@@ -102,8 +101,18 @@ class GroupsController extends Controller
         return $target->with('success', __('Group created.'));
     }
 
-    public function edit(Group $group): Response
+    public function edit(Request $request, Group $group): Response
     {
+        $viewer = $request->user();
+        assert($viewer !== null);
+
+        // The same reach question update() and destroy() ask, asked one
+        // step earlier. Without it this was the one group route holding no
+        // library boundary at all: a scoped staff member could open a group
+        // whose contents they cannot see, read its membership off the
+        // screen, and only be refused on save.
+        abort_unless($this->scope->allowsGroupChange($viewer, $group), 404);
+
         return Inertia::render('groups/edit', [
             'group' => [
                 'id' => $group->id,
@@ -112,14 +121,24 @@ class GroupsController extends Controller
                 'description' => $group->description,
                 'public' => $group->public,
             ],
-            'members' => $group->members()->orderBy('name')->get()
+            // Both lists narrow through StaffLibraryScope::clients(), which
+            // is the listing half of the rule this screen's buttons are
+            // already guarded with: a member outside the roster cannot be
+            // removed here (allowsGroupMembership refuses it), and a client
+            // outside it cannot be added. Naming them anyway, with their
+            // address, was the same mistake the client list made before
+            // that method existed. An unscoped viewer sees everything,
+            // unchanged.
+            'members' => $group->members()
+                ->whereIn('users.id', $this->scope->clients($viewer)->select('id'))
+                ->orderBy('name')
+                ->get()
                 ->map(fn (User $member): array => [
                     'id' => $member->id,
                     'name' => $member->name,
                     'email' => $member->email,
                 ])->all(),
-            'available_clients' => User::query()
-                ->where('type', UserType::Client)
+            'available_clients' => $this->scope->clients($viewer)
                 ->whereNotIn('id', $group->members()->pluck('users.id'))
                 ->orderBy('name')
                 ->get()

--- a/app/Modules/Groups/Http/Resources/Api/GroupResource.php
+++ b/app/Modules/Groups/Http/Resources/Api/GroupResource.php
@@ -13,9 +13,12 @@ use Illuminate\Http\Resources\Json\JsonResource;
  * @mixin Group
  *
  * Members carry a name and an email, which is what the group edit screen
- * already shows to anyone holding `edit_groups`. They are attached only
- * when explicitly loaded, so a listing of groups does not become a bulk
- * export of every client's address.
+ * shows the same viewer. That is a claim about the screen, so it holds
+ * only for as long as the screen does: both narrow the list to the
+ * clients the viewer may act on, and the controller loading this relation
+ * is where that narrowing is applied. They are attached only when
+ * explicitly loaded, so a listing of groups does not become a bulk export
+ * of every client's address.
  */
 class GroupResource extends JsonResource
 {

--- a/tests/Feature/Groups/GroupMembershipScopeTest.php
+++ b/tests/Feature/Groups/GroupMembershipScopeTest.php
@@ -420,3 +420,60 @@ test('an unscoped administrator manages every group exactly as before', function
 
     expect(Group::query()->whereKey($this->strangerGroup->id)->exists())->toBeFalse();
 });
+
+/*
+|--------------------------------------------------------------------------
+| The screen that edits a group, and its API twin
+|--------------------------------------------------------------------------
+*/
+
+test('a group reaching past the library cannot even be opened', function () {
+    // update() and destroy() already refuse this group. Reading it was the
+    // one group route that did not.
+    $this->actingAs($this->rep)->get("/groups/{$this->strangerGroup->id}")->assertNotFound();
+
+    $token = $this->rep->createToken('t', [Permission::EditGroups->value])->plainTextToken;
+    $this->withToken($token)->getJson("/api/v1/groups/{$this->strangerGroup->id}")->assertNotFound();
+});
+
+test('the edit screen stops naming clients this viewer has no business hearing about', function () {
+    // Nothing is shared with this group, so it reaches nowhere and stays
+    // open to the rep — which is exactly the case a reach guard alone
+    // would leave holding a stranger's address.
+    $ours = Group::query()->create(['name' => 'Ours', 'slug' => 'ours', 'public' => false]);
+    $ours->members()->syncWithoutDetaching([$this->mine->id, $this->stranger->id]);
+
+    $props = $this->actingAs($this->rep)->get("/groups/{$ours->id}")->assertOk()->viewData('page')['props'];
+
+    expect(array_column($props['members'], 'name'))->toBe(['Mine'])
+        ->and(array_column($props['members'], 'email'))->toBe([$this->mine->email])
+        // Every client the rep may reach is already in the group, so there
+        // is nobody left to add — rather than the stranger, whom they could
+        // not have added anyway.
+        ->and($props['available_clients'])->toBe([]);
+});
+
+test('the API twin narrows the membership it hands back', function () {
+    $ours = Group::query()->create(['name' => 'Ours', 'slug' => 'ours', 'public' => false]);
+    $ours->members()->syncWithoutDetaching([$this->mine->id, $this->stranger->id]);
+
+    $token = $this->rep->createToken('t', [Permission::EditGroups->value])->plainTextToken;
+    $data = $this->withToken($token)->getJson("/api/v1/groups/{$ours->id}")->assertOk()->json('data');
+
+    expect(array_column($data['members'], 'name'))->toBe(['Mine'])
+        // members_count is left whole on purpose: a size is not an
+        // identity, and it is the same number the group listing reports.
+        ->and($data['members_count'])->toBe(2);
+});
+
+test('an unscoped viewer keeps the whole roster and every member', function () {
+    $ours = Group::query()->create(['name' => 'Ours', 'slug' => 'ours', 'public' => false]);
+    $ours->members()->syncWithoutDetaching([$this->mine->id]);
+
+    $props = $this->actingAs($this->admin)->get("/groups/{$ours->id}")->assertOk()->viewData('page')['props'];
+
+    expect(array_column($props['members'], 'name'))->toBe(['Mine'])
+        ->and(array_column($props['available_clients'], 'name'))->toBe(['Not Mine']);
+
+    $this->actingAs($this->admin)->get("/groups/{$this->strangerGroup->id}")->assertOk();
+});


### PR DESCRIPTION
Every group route asks `StaffLibraryScope` whether this viewer may act on this
group — except the two that read it.

|  | boundary |
|---|---|
| `GroupsController::update()` | `abort_unless($this->scope->allowsGroupChange(…), 404)` |
| `GroupsController::destroy()` | same |
| `Api\GroupsController::update()` | same |
| `Api\GroupsController::destroy()` | same |
| **`GroupsController::edit()`** | **none** |
| **`Api\GroupsController::show()`** | **none** |

## What they hand over

The edit screen renders the membership with a name and an email per member, and
`available_clients` — every client on the installation. `show()` returns the same
membership over the API.

So a client-scoped staff member could open a group whose contents they cannot
see, read off every client on the installation, and only be refused when they
pressed save.

## The fix, in two halves

The leak has two shapes, and one guard does not cover both.

**The group itself.** Reading it now asks the same reach question the write half
asks, one step earlier, with the same 404 — a group that reaches past the
viewer's library is not theirs to open either.

**The lists inside it.** Both narrow through `StaffLibraryScope::clients()`, the
listing half of the rule this screen's buttons are already guarded with:
`allowsGroupMembership` refuses removing a member outside the roster, and refuses
adding a client outside it. Naming them anyway, with their address, is the
mistake `ClientsController` made before `clients()` existed — that method's own
docblock says so.

The reach guard alone would not have been enough. A group nobody has shared
anything with reaches nowhere, so it stays open to everybody — and it can still
hold a stranger's client. That case is why the lists narrow separately, and there
is a test for exactly it.

## Not changed (deliberate)

- **`members_count`.** Left whole on purpose: a size is not an identity, and it
  is the same number the group listing already reports.
- **The group listing**, and `Api\GroupsController::index()`. They report names
  and member counts, not identities, and every button on them is guarded.
- **`GroupResource`'s docblock**, only reworded. It said members are safe to
  expose because *"the group edit screen already shows [them] to anyone holding
  `edit_groups`"*. That was a claim about a screen, and it stopped being true the
  moment the screen narrowed. It now says what holds it up, and where.
- **The API document.** `php artisan scramble:export` is byte-identical:
  `GET /groups/{group}` already documented a 404, so the new `abort_unless` adds
  no response.
- **An unscoped viewer.** `clients()` returns the whole roster for them and
  `allowsGroupChange()` is true by construction, so nothing about their screen
  changes. There is a test saying so.

## Tests

Four, in the file that already covers this boundary for membership changes.
Three measured red against the unguarded controllers (**3 failed / 21 passed**):
the group cannot be opened at all, the edit screen stops naming strangers, and
the API twin narrows the membership it hands back.

The fourth — an unscoped viewer keeps the whole roster and every member — is
green either way. It guards against the fix over-refusing, not against the bug.

Full suite passes (2052 passed / 2 skipped), PHPStan level 8 clean.