### PR TITLE
Add a file to a zip once, however many ways the selection reaches it

### DIFF
--- a/app/Modules/Files/Jobs/BuildZipDownloadJob.php
+++ b/app/Modules/Files/Jobs/BuildZipDownloadJob.php
@@ -135,7 +135,14 @@ class BuildZipDownloadJob implements ShouldQueue
             // count, is what lets the download action log exactly what it
             // hands over instead of resolving the selection a second time
             // against a scope that may have moved since.
-            $addedIds = [];
+            //
+            // Keyed by id rather than appended to a list, because it is
+            // also what keeps a file out of the archive twice. The loose
+            // selection cannot repeat itself — one whereIn on the primary
+            // key — but a selected folder can hold a file that was also
+            // named loosely, and the cap is 10000 sources, so the check
+            // has to be a lookup rather than a scan.
+            $added = [];
 
             foreach ((clone $visible)->whereIn('id', $zipDownload->file_ids)->get() as $file) {
                 // Re-checked here for the same reason visibility is: the
@@ -150,11 +157,11 @@ class BuildZipDownloadJob implements ShouldQueue
                 $entryName = $this->dedupeName($usedNames, $this->entrySegment($file->original_name));
                 $zip->addFile($this->localPathFor($file, $tempFiles), $entryName);
                 $totalSize += $file->size;
-                $addedIds[] = $file->id;
+                $added[$file->id] = true;
             }
 
-            foreach (Folder::query()->whereIn('id', $zipDownload->folder_ids)->get() as $folder) {
-                $totalSize += $this->addFolder($zip, $folder, $requester, $usedNames, $tempFiles, $visible, $skipped, $addedIds);
+            foreach ($this->outermostFolders($zipDownload->folder_ids) as $folder) {
+                $totalSize += $this->addFolder($zip, $folder, $requester, $usedNames, $tempFiles, $visible, $skipped, $added);
             }
 
             // Re-checked here, not only in ZipDownloadsController: the
@@ -197,7 +204,7 @@ class BuildZipDownloadJob implements ShouldQueue
                 @unlink($tempFile);
             }
 
-            if ($written !== true || $addedIds === []) {
+            if ($written !== true || $added === []) {
                 if ($written !== true) {
                     // What the requester sees stays generic: a libzip
                     // string means nothing to them and can name a server
@@ -229,8 +236,8 @@ class BuildZipDownloadJob implements ShouldQueue
                 'status' => ZipDownload::STATUS_READY,
                 'path' => $relativePath,
                 'total_size' => $totalSize,
-                'file_count' => count($addedIds),
-                'contained_file_ids' => $addedIds,
+                'file_count' => count($added),
+                'contained_file_ids' => array_keys($added),
                 'skipped_files' => $skipped === [] ? null : $skipped,
             ]);
         } catch (Throwable $e) {
@@ -329,9 +336,9 @@ class BuildZipDownloadJob implements ShouldQueue
      * @param  array<int, string>  $tempFiles
      * @param  Builder<File>  $visible  every file the requester may read
      * @param  list<array{id: int, name: string}>  $skipped
-     * @param  list<int>  $addedIds  every file really written into the archive
+     * @param  array<int, true>  $added  every file really written into the archive, keyed by id
      */
-    private function addFolder(ZipArchive $zip, Folder $folder, User $requester, array &$usedNames, array &$tempFiles, Builder $visible, array &$skipped, array &$addedIds): int
+    private function addFolder(ZipArchive $zip, Folder $folder, User $requester, array &$usedNames, array &$tempFiles, Builder $visible, array &$skipped, array &$added): int
     {
         $allowance = app(DownloadAllowance::class);
 
@@ -342,6 +349,15 @@ class BuildZipDownloadJob implements ShouldQueue
         $totalSize = 0;
 
         foreach ((clone $visible)->whereIn('folder_id', $subtreeIds)->get() as $file) {
+            // Already in the archive under another part of the selection —
+            // named loosely, or inside a folder selected before this one.
+            // Skipped rather than added again: a second entry is a second
+            // copy of the same bytes, and delivery charges one download
+            // however many copies went out.
+            if (isset($added[$file->id])) {
+                continue;
+            }
+
             // Holding the folder does not entitle the requester to a file
             // inside it whose own allowance is spent — same reason the
             // per-file visibility filter is re-derived rather than
@@ -357,10 +373,36 @@ class BuildZipDownloadJob implements ShouldQueue
             $entryPath = $this->dedupeName($usedNames, $entryPath);
             $zip->addFile($this->localPathFor($file, $tempFiles), $entryPath);
             $totalSize += $file->size;
-            $addedIds[] = $file->id;
+            $added[$file->id] = true;
         }
 
         return $totalSize;
+    }
+
+    /**
+     * The selected folders with the redundant ones dropped: one that sits
+     * inside another selected folder is already covered by it.
+     *
+     * Zipping both would reach the same file twice, and which of the two
+     * paths the surviving entry ended up under would be decided by
+     * whatever order the database returned the rows in. Keeping the outer
+     * folder keeps the fuller path — Reports/Q1/report.pdf rather than
+     * Q1/report.pdf — and gives the same archive on every run.
+     *
+     * @param  list<int>  $folderIds
+     * @return Collection<int, Folder>
+     */
+    private function outermostFolders(array $folderIds): Collection
+    {
+        /** @var Collection<int, Folder> $folders */
+        $folders = Folder::query()->whereIn('id', $folderIds)->orderBy('id')->get();
+
+        return $folders
+            ->reject(fn (Folder $folder): bool => $folders->contains(
+                fn (Folder $other): bool => $other->id !== $folder->id
+                    && str_starts_with($folder->path, $other->subtreePathPrefix()),
+            ))
+            ->values();
     }
 
     /**

--- a/tests/Feature/Files/ZipDownloadsTest.php
+++ b/tests/Feature/Files/ZipDownloadsTest.php
@@ -596,3 +596,88 @@ test('a zip build is queued away from ordinary work', function () {
 
     Queue::assertPushed(BuildZipDownloadJob::class, fn (BuildZipDownloadJob $job): bool => $job->queue === 'zips');
 });
+
+/*
+|--------------------------------------------------------------------------
+| A selection that reaches the same file more than once
+|--------------------------------------------------------------------------
+*/
+
+test('a file reached by both a loose pick and a folder is added once', function () {
+    $folder = Folder::query()->create(['name' => 'Reports']);
+    $file = zipUploadFile($this->admin, 'report.pdf', $folder->id);
+
+    $response = $this->actingAs($this->admin)->postJson('/zip-downloads', [
+        'file_ids' => [$file->id],
+        'folder_ids' => [$folder->id],
+    ])->assertOk();
+
+    $zipDownload = ZipDownload::query()->findOrFail($response->json('id'));
+
+    // The loose pick reaches it first, so that is where the one copy sits.
+    expect(zipEntryNames($zipDownload))->toBe(['report.pdf'])
+        ->and($zipDownload->file_count)->toBe(1)
+        ->and($zipDownload->total_size)->toBe($file->size)
+        ->and($zipDownload->contained_file_ids)->toBe([$file->id]);
+});
+
+test('a folder inside another selected folder does not duplicate its contents', function () {
+    $parent = Folder::query()->create(['name' => 'Reports']);
+    $child = Folder::query()->create(['name' => 'Q1', 'parent_id' => $parent->id, 'path' => "/{$parent->id}/"]);
+    $file = zipUploadFile($this->admin, 'report.pdf', $child->id);
+
+    $response = $this->actingAs($this->admin)->postJson('/zip-downloads', [
+        'folder_ids' => [$parent->id, $child->id],
+    ])->assertOk();
+
+    $zipDownload = ZipDownload::query()->findOrFail($response->json('id'));
+
+    // The outer folder wins, so the entry keeps the fuller path.
+    expect(zipEntryNames($zipDownload))->toBe(['Reports/Q1/report.pdf'])
+        ->and($zipDownload->file_count)->toBe(1)
+        ->and($zipDownload->total_size)->toBe($file->size);
+});
+
+test('the same file selected three ways is handed over once and charged once', function () {
+    $parent = Folder::query()->create(['name' => 'Reports']);
+    $child = Folder::query()->create(['name' => 'Q1', 'parent_id' => $parent->id, 'path' => "/{$parent->id}/"]);
+    $file = zipUploadFile($this->admin, 'report.pdf', $child->id);
+
+    $response = $this->actingAs($this->admin)->postJson('/zip-downloads', [
+        'file_ids' => [$file->id],
+        'folder_ids' => [$parent->id, $child->id],
+    ])->assertOk();
+
+    $zipDownload = ZipDownload::query()->findOrFail($response->json('id'));
+    $this->actingAs($this->admin)->get("/zip-downloads/{$zipDownload->id}/download")->assertOk();
+
+    // Delivery logs one FileDownloaded per contained file, so as many
+    // copies as the archive holds must be as many as the log records —
+    // otherwise a file limited to one download leaves in several.
+    $logged = ActivityLog::query()
+        ->where('action', Action::FileDownloaded)
+        ->where('subject_id', $file->id)
+        ->count();
+
+    expect(count(zipEntryNames($zipDownload)))->toBe(1)
+        ->and($logged)->toBe(1);
+});
+
+test('two selected folders that merely share a name are both zipped', function () {
+    // The pruning above is about containment, not about names: neither of
+    // these is inside the other, so both belong in the archive, and the
+    // usual collision suffix keeps them apart.
+    $first = Folder::query()->create(['name' => 'Reports']);
+    $second = Folder::query()->create(['name' => 'Reports']);
+    zipUploadFile($this->admin, 'a.pdf', $first->id);
+    zipUploadFile($this->admin, 'b.pdf', $second->id);
+
+    $response = $this->actingAs($this->admin)->postJson('/zip-downloads', [
+        'folder_ids' => [$first->id, $second->id],
+    ])->assertOk();
+
+    $zipDownload = ZipDownload::query()->findOrFail($response->json('id'));
+
+    expect($zipDownload->file_count)->toBe(2)
+        ->and(zipEntryNames($zipDownload))->toContain('Reports/a.pdf');
+});


### PR DESCRIPTION
`BuildZipDownloadJob` walks the loose file ids, then every selected folder's
subtree, and adds whatever each pass finds. A selection can reach the same file
from more than one of them, and nothing noticed.

## Measured

```
file_ids [f], folder_ids [Reports]
  → ['report.pdf', 'Reports/report.pdf']

file_ids [f], folder_ids [Reports, Reports/Q1]
  → three entries, file_count 3, total_size three times the file
```

Two copies of the same bytes in one archive. `total_size` is also what the size
cap is checked against, so a selection could be refused for a weight it does not
have.

The one that costs more than bandwidth is delivery. It logs one `FileDownloaded`
per contained file, and `DownloadAllowance` counts those records — so a file
limited to a single download left in three copies while the log recorded one.
Measured: three entries, one record.

## Two causes, so two halves

**A file reached twice.** `$added` is keyed by id instead of appended to a list,
and the folder pass skips a file already in the archive. A lookup rather than a
scan, because the selection cap is 10000 sources. The loose pass runs first, so a
file picked both ways sits under its loose name — either answer is defensible,
but it has to be the same one on every run.

**A folder inside another selected folder.** Dropped before either is walked.
Zipping both would reach every file in the inner one twice, and which path the
surviving entry ended up under would be decided by the order the rows came back
in. Keeping the outer folder keeps the fuller path — `Reports/Q1/report.pdf`
rather than `Q1/report.pdf`.

Containment is decided on the materialized path, so it is one comparison per pair
and no extra queries: a folder's `path` starts with an ancestor's
`subtreePathPrefix()`. Both end in `/`, so `/5/` cannot match `/50/`.

## Not changed (deliberate)

- **The per-file re-checks inside the folder pass.** Visibility and the download
  allowance are still re-derived per file, and the duplicate skip happens before
  them — so a duplicate does not spend an allowance twice either.
- **The selection endpoint.** A caller may send whatever selection they like;
  the job is where it is resolved, and that is where the pruning belongs.
- **`skipped_files`.** A duplicate is not a skip — nothing was refused — so it is
  not reported as one.

## Tests

Four. Three measured red against the unfixed job (**3 failed / 32 passed**): the
loose-plus-folder case, the nested-folder case, and the three-way case asserted
through delivery rather than through the archive — as many `FileDownloaded`
records as copies handed over.

The fourth — two selected folders that merely share a name are both zipped — is
green either way. It guards the pruning against becoming about names rather than
containment.

Full suite passes (2052 passed / 2 skipped), PHPStan level 8 clean.