### PR TITLE
Refuse the last administrator deleting themselves, and keep setup shut

### DIFF
--- a/app/Http/Controllers/Settings/ProfileController.php
+++ b/app/Http/Controllers/Settings/ProfileController.php
@@ -9,6 +9,7 @@ use App\Modules\Audit\ActivityLogger;
 use App\Modules\Clients\ClientFieldContext;
 use App\Modules\Clients\ClientPortalCustomFields;
 use App\Modules\Identity\Erasure\ErasureSchedule;
+use App\Modules\Identity\StaffAccounts;
 use App\Modules\Platform\Localization\TimezoneRegistry;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
@@ -24,6 +25,7 @@ class ProfileController extends Controller
     public function __construct(
         private readonly ClientPortalCustomFields $customFields,
         private readonly TimezoneRegistry $timezones,
+        private readonly StaffAccounts $accounts,
     ) {}
 
     /**
@@ -103,6 +105,19 @@ class ProfileController extends Controller
 
         $user = $request->user();
         assert($user !== null);
+
+        // The rule every other door into this already asks: Staff update(),
+        // guardDeletable(), and both role-conversion directions. This one
+        // did not, and self-deletion is the one door where the account
+        // being removed is certainly signed in — so the last active
+        // administrator could take themselves out, leaving no live staff
+        // row at all. EnsureSetupIsComplete then reopens first-run setup to
+        // anybody who asks, which is the other half of this and is closed
+        // below.
+        $this->accounts->guardLastAdministrator(
+            $user,
+            removesAdmin: $this->accounts->isAdministratorRole($user->role_id),
+        );
 
         Auth::logout();
 

--- a/app/Modules/Identity/Http/Controllers/SetupController.php
+++ b/app/Modules/Identity/Http/Controllers/SetupController.php
@@ -97,8 +97,16 @@ class SetupController extends Controller
         return Inertia::render('setup-success');
     }
 
+    /**
+     * Trashed staff count, for the reason EnsureSetupIsComplete gives:
+     * this asks whether the installation was ever set up, and store()
+     * below is the door a stranger walks through if the answer is wrong.
+     * The middleware and this must agree — one of them saying "not set
+     * up" while the other says "set up" is either a redirect loop or an
+     * open form.
+     */
     private function setupIsComplete(): bool
     {
-        return User::query()->where('type', UserType::Staff)->exists();
+        return User::query()->withTrashed()->where('type', UserType::Staff)->exists();
     }
 }

--- a/app/Modules/Identity/Http/Middleware/EnsureSetupIsComplete.php
+++ b/app/Modules/Identity/Http/Middleware/EnsureSetupIsComplete.php
@@ -16,6 +16,16 @@ use Symfony\Component\HttpFoundation\Response;
  * sent to the first-run setup screen. The database is the only source of
  * truth — no install flags. Client accounts do not count: setup is about
  * having an administrator.
+ *
+ * Trashed staff count. "Has this installation been set up" is not the
+ * same question as "does it have a working administrator right now", and
+ * only the first one belongs here: a soft-deleted staff row is still
+ * evidence that setup happened, and an installation that has lost its
+ * last administrator needs a recovery path, not a stranger filling in
+ * the first-run form. Deleting a staff account is guarded against
+ * reaching zero (StaffAccounts::guardLastAdministrator), so this is the
+ * second lock rather than the first — but the first one is asked at five
+ * separate doors, and this one is asked once.
  */
 class EnsureSetupIsComplete
 {
@@ -25,7 +35,7 @@ class EnsureSetupIsComplete
             return $next($request);
         }
 
-        if (User::query()->where('type', UserType::Staff)->exists()) {
+        if (User::query()->withTrashed()->where('type', UserType::Staff)->exists()) {
             return $next($request);
         }
 

--- a/tests/Feature/Identity/SoleAdministratorSelfDeletionTest.php
+++ b/tests/Feature/Identity/SoleAdministratorSelfDeletionTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Identity\Models\Role;
+use App\Modules\Identity\Permissions\SystemRole;
+use App\Modules\Identity\UserType;
+
+/**
+ * Deleting your own account goes through ProfileController, which asked
+ * for the current password and nothing else. Every other door that can
+ * remove an administrator asks StaffAccounts::guardLastAdministrator
+ * first; this one did not, and it is the one door where the account being
+ * removed is certainly signed in.
+ *
+ * The account is soft-deleted, so the row survives — but every "is this
+ * installation set up" check asked `exists()`, which does not see trashed
+ * rows. Zero live staff sends every request to the first-run setup form,
+ * and that form is registered without `guest`, without auth and without a
+ * throttle.
+ */
+function liveStaffCount(): int
+{
+    return User::query()->where('type', UserType::Staff)->count();
+}
+
+function onlyStaffAccount(): User
+{
+    User::query()->where('type', UserType::Staff)->forceDelete();
+
+    return User::factory()->create();
+}
+
+test('the last administrator cannot delete their own account', function () {
+    $admin = onlyStaffAccount();
+
+    $this->actingAs($admin)
+        ->from('/settings/delete-account')
+        ->delete('/settings/profile', ['password' => 'password'])
+        ->assertSessionHasErrors('role_id');
+
+    expect(liveStaffCount())->toBe(1)
+        ->and($admin->fresh())->not->toBeNull();
+});
+
+test('an administrator with a colleague still may', function () {
+    $admin = onlyStaffAccount();
+    $second = User::factory()->create();
+
+    $this->actingAs($admin)
+        ->delete('/settings/profile', ['password' => 'password'])
+        ->assertRedirect('/');
+
+    expect(liveStaffCount())->toBe(1)
+        ->and(User::query()->whereKey($second->id)->exists())->toBeTrue()
+        ->and(User::query()->whereKey($admin->id)->exists())->toBeFalse();
+});
+
+test('a staff member who is not an administrator still may', function () {
+    onlyStaffAccount();
+    $uploader = User::factory()->role(SystemRole::Uploader)->create();
+
+    $this->actingAs($uploader)
+        ->delete('/settings/profile', ['password' => 'password'])
+        ->assertRedirect('/');
+
+    expect(User::query()->whereKey($uploader->id)->exists())->toBeFalse();
+});
+
+test('a client can still close their own account', function () {
+    onlyStaffAccount();
+    $client = User::factory()->client()->create();
+
+    $this->actingAs($client)
+        ->delete('/settings/profile', ['password' => 'password'])
+        ->assertRedirect('/');
+
+    expect(User::query()->whereKey($client->id)->exists())->toBeFalse();
+});
+
+/*
+|--------------------------------------------------------------------------
+| The second lock: a trashed staff row still means "already set up"
+|--------------------------------------------------------------------------
+*/
+
+test('setup stays shut once a staff account has existed, even trashed', function () {
+    $admin = onlyStaffAccount();
+
+    // Reached past the guard on purpose — the point of this half is that
+    // the window stays closed even if some future door forgets to ask.
+    $admin->delete();
+
+    expect(liveStaffCount())->toBe(0)
+        ->and(User::query()->withTrashed()->where('type', UserType::Staff)->count())->toBe(1);
+
+    $this->get('/')->assertRedirect('/login');
+
+    $this->post('/setup', [
+        'site_name' => 'Taken Over',
+        'name' => 'Stranger',
+        'email' => 'stranger@example.com',
+        'password' => 'Str0ng-Passw0rd!x',
+        'password_confirmation' => 'Str0ng-Passw0rd!x',
+    ])->assertRedirect(route('home'));
+
+    expect(User::query()->where('email', 'stranger@example.com')->exists())->toBeFalse();
+});
+
+test('a genuinely fresh installation still reaches setup', function () {
+    User::query()->withTrashed()->forceDelete();
+
+    expect(User::query()->withTrashed()->count())->toBe(0);
+
+    $this->get('/')->assertRedirect(route('setup'));
+
+    $this->post('/setup', [
+        'site_name' => 'Fresh',
+        'name' => 'First Administrator',
+        'email' => 'first@example.com',
+        'password' => 'Str0ng-Passw0rd!x',
+        'password_confirmation' => 'Str0ng-Passw0rd!x',
+    ])->assertRedirect(route('setup.success'));
+
+    $created = User::query()->where('email', 'first@example.com')->sole();
+    $administrator = Role::query()->where('name', SystemRole::SystemAdministrator->value)->sole();
+
+    expect($created->type)->toBe(UserType::Staff)
+        ->and($created->role_id)->toBe($administrator->id);
+});

--- a/tests/Feature/Platform/GettingStartedTest.php
+++ b/tests/Feature/Platform/GettingStartedTest.php
@@ -111,7 +111,11 @@ test('installing wins over updating', function () {
 });
 
 test('completing setup raises the greeting', function () {
-    User::query()->delete();
+    // forceDelete, not delete: "a fresh installation" means no staff row
+    // at all. A soft-deleted one is evidence that setup already happened,
+    // and EnsureSetupIsComplete counts it as such so that losing the last
+    // administrator cannot reopen the first-run form to a stranger.
+    User::query()->forceDelete();
 
     $this->post('/setup', [
         'site_name' => 'Acme Files',
@@ -127,7 +131,7 @@ test('completing setup raises the greeting', function () {
 // Unattended provisioning skips the setup screen entirely, and is how
 // every container that came up from environment variables was installed.
 test('provisioning from the command line raises it too', function () {
-    User::query()->delete();
+    User::query()->forceDelete();
 
     $this->artisan('projectsend:admin', [
         '--name' => 'Ada',

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -67,6 +67,12 @@ class ProfileUpdateTest extends TestCase
     {
         $user = User::factory()->create();
 
+        // A second administrator, so what is under test is self-deletion
+        // and not the last-administrator refusal: the factory makes an
+        // administrator, and one on their own may no longer remove
+        // themselves — see SoleAdministratorSelfDeletionTest.
+        User::factory()->create();
+
         $response = $this
             ->actingAs($user)
             ->delete('/settings/profile', [
@@ -106,6 +112,10 @@ class ProfileUpdateTest extends TestCase
         app(Settings::class)->set(Setting::AccountErasureGraceDays, 5);
 
         $user = User::factory()->create();
+
+        // Same reason as above: this is about the grace period, not about
+        // who is allowed to go.
+        User::factory()->create();
 
         // Deleting your account has its own screen; the profile form no
         // longer carries the block or the grace period behind it.


### PR DESCRIPTION
`ProfileController::destroy()` validates `current_password` and soft-deletes. It
never asks `StaffAccounts::guardLastAdministrator()` — and every other door does:
`Staff::update()`, `guardDeletable()`, and both directions of the role
conversion. This is the one door where the account being removed is certainly
signed in.

## What that leaves

An installation with a single administrator has a button that empties it.
Measured on `main`:

```
DELETE /settings/profile   302, the account is gone
live staff rows            0     (the row is trashed, not removed)
anonymous GET /            302 → /setup
anonymous POST /setup      a new active System Administrator
```

`EnsureSetupIsComplete` asks `->exists()`, which excludes trashed rows, and
`routes/web.php` registers `GET`/`POST setup` with no auth and no `guest`
middleware — correctly, since a fresh installation has nobody to authenticate.
`SetupController::store()` re-checks the same condition, so both halves agreed
with each other and both were wrong once the last staff row was trashed.

## Two locks

One of these questions is asked at five doors; the other at one.

**The guard.** `destroy()` now asks `guardLastAdministrator()` — the same call
with the same message as everywhere else. An administrator with a colleague still
goes, a staff member who is not an administrator still goes, and a client still
closes their own account.

**What "set up" means.** *Has this installation been set up* is not the same
question as *does it have a working administrator right now*, and only the first
belongs in `EnsureSetupIsComplete`. A trashed staff row is still evidence that
setup happened, so it now counts — in the middleware and in
`SetupController::setupIsComplete()`, which have to agree or the result is either
a redirect loop or an open form.

The second lock holds even if a future door forgets the first. Measured with the
guard bypassed entirely and the row trashed directly: `GET /` answers with the
login screen, and `POST /setup` creates nothing.

## Worth saying plainly

An installation that has **already** lost its last administrator will now find
setup shut rather than open. That is the point. The recovery path for it is
`php artisan projectsend:admin` — which is also how every unattended container
installs itself — not a form anybody on the internet can reach.

## Not changed (deliberate)

- **The setup routes themselves.** They stay open to guests, because a fresh
  installation has nobody to authenticate. What changed is the answer to
  *"is this a fresh installation?"*.
- **`StaffAccounts::guardLastAdministrator()`.** Used exactly as the other four
  doors use it, message included, so an installation gets one wording for one
  rule.
- **Soft deletion.** Self-deletion still soft-deletes with the same erasure
  grace period; only the case that would leave nobody behind is refused.

## Tests

Six new, two measured red against the unfixed code (**2 failed / 4 passed**) —
one per lock. The other four are the boundaries: a colleague present, a staff
member who is not an administrator, a client, and a genuinely fresh installation
that must still reach setup.

Two existing tests needed saying more clearly rather than changing:
`ProfileUpdateTest`'s deletion cases now create a second administrator, so what
they assert is self-deletion and not this new refusal; and `GettingStartedTest`'s
*fresh installation* cases `forceDelete()` rather than `delete()`, because a
soft-deleted staff row is no longer a fresh installation — which is the whole of
the second lock.

Full suite passes (2054 passed / 2 skipped), PHPStan level 8 clean.