### PR TITLE
Keep a private reply private after the client is deleted

### DIFF
--- a/app/Modules/Comments/FileComments.php
+++ b/app/Modules/Comments/FileComments.php
@@ -220,10 +220,27 @@ class FileComments
             return null;
         }
 
+        // Asked of the column, not of the relation. client_context_id is
+        // cascadeOnDelete, but a user is soft-deleted, so the cascade
+        // never fires: the column goes on pointing at a row that is still
+        // there while the relation resolves to null. Branching on the
+        // relation therefore read "this is Alice's conversation" as "this
+        // has no conversation" — and a null context on a Clients comment
+        // is the branch every client on the file reads (see
+        // VisibleCommentScope's opening rule). A private reply became a
+        // circular, and canAssignClient below was skipped on the way.
+        if ($replyTo->client_context_id === null) {
+            return null;
+        }
+
         $client = $replyTo->clientContext;
 
         if ($client === null) {
-            return null;
+            // The column points at somebody, and that somebody is gone.
+            // There is nobody to answer, and the one outcome that must
+            // not follow from a filled column is the broadcast above, so
+            // this refuses rather than falling through to it.
+            throw new AuthorizationException('You cannot reply in this conversation.');
         }
 
         if (! $this->library->canAssignClient($author, $client)) {

--- a/app/Modules/Comments/Models/FileComment.php
+++ b/app/Modules/Comments/Models/FileComment.php
@@ -113,18 +113,32 @@ class FileComment extends Model
      * The name to show. Snapshotted for guests at write time; read live
      * for accounts so a rename is reflected everywhere at once.
      *
-     * author_id cascades on delete, so a row that has one always has the
-     * account behind it — there is no deleted-author case to snapshot
-     * against, unlike the activity log's actor_name.
+     * A deleted account is still read. author_id cascades on delete, but
+     * a user is soft-deleted and the cascade never fires, so the row
+     * behind a deleted commenter is still there — and reading it through
+     * the plain relation returned null, which sent a named client's
+     * comment out as "Anonymous". That is what a guest comment looks
+     * like, and a guest comment is governed by different rules; the two
+     * must not be able to look the same. Whether the author is a guest is
+     * decided by author_id alone, which is also what isFromGuest() asks.
      */
     public function authorName(): string
     {
+        if ($this->author_id === null) {
+            return $this->guest_name ?? (string) __('Anonymous');
+        }
+
         $author = $this->author;
 
         if ($author !== null) {
             return $author->name;
         }
 
-        return $this->guest_name ?? (string) __('Anonymous');
+        // Trashed: the row is still there, the relation simply will not
+        // hand it over. Nothing comes back only once the grace-period
+        // erasure has removed the row for real.
+        $name = $this->author()->withTrashed()->value('name');
+
+        return is_string($name) ? $name : (string) __('Anonymous');
     }
 }

--- a/tests/Feature/Comments/DeletedClientThreadTest.php
+++ b/tests/Feature/Comments/DeletedClientThreadTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Comments\Access\VisibleCommentScope;
+use App\Modules\Comments\CommentVisibility;
+use App\Modules\Comments\Models\FileComment;
+use App\Modules\Files\Models\File;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * `file_comments.client_context_id` and `author_id` are both
+ * cascadeOnDelete, and neither cascade ever fires: users are
+ * soft-deleted, so the row survives and the column goes on pointing at
+ * it. Everything that asked the *relation* instead of the column read
+ * that as "there is no client here" — and for client_context_id, "no
+ * client" is the branch every client on the file reads.
+ */
+beforeEach(function () {
+    Storage::fake('files');
+    $this->admin = User::factory()->create();
+    $this->file = File::factory()->create(['name' => 'Quote']);
+    $this->alice = User::factory()->client()->create(['name' => 'Alice Ltd']);
+    $this->bob = User::factory()->client()->create(['name' => 'Bob GmbH']);
+
+    shareFileWith($this->file, $this->alice);
+    shareFileWith($this->file, $this->bob);
+
+    $this->fromAlice = FileComment::factory()->for($this->file)->inThreadOf($this->alice)->create([
+        'author_id' => $this->alice->id,
+        'body' => 'What is your best price?',
+    ]);
+});
+
+function readableBy(User $viewer, File $file): array
+{
+    return app(VisibleCommentScope::class)->for($viewer, $file)->pluck('id')->map(intval(...))->all();
+}
+
+test('a reply into a deleted client\'s thread is refused, not broadcast', function () {
+    $this->alice->delete();
+
+    $this->actingAs($this->admin)
+        ->postJson("/files/{$this->file->id}/comments", [
+            'body' => 'For you only: 40% off.',
+            'visibility' => CommentVisibility::Clients->value,
+            'reply_to' => $this->fromAlice->id,
+        ])
+        ->assertForbidden();
+
+    expect(FileComment::query()->where('body', 'For you only: 40% off.')->exists())->toBeFalse()
+        ->and(readableBy($this->bob, $this->file))->toBe([]);
+});
+
+test('a staff message to everybody still reaches everybody', function () {
+    // The null context is a real branch, not only a failure mode: staff
+    // writing fresh address every client on the file, and that must keep
+    // working.
+    $this->actingAs($this->admin)
+        ->postJson("/files/{$this->file->id}/comments", [
+            'body' => 'The catalogue is attached.',
+            'visibility' => CommentVisibility::Clients->value,
+        ])
+        ->assertCreated();
+
+    $broadcast = FileComment::query()->where('body', 'The catalogue is attached.')->sole();
+
+    expect($broadcast->client_context_id)->toBeNull()
+        ->and(readableBy($this->bob, $this->file))->toContain($broadcast->id);
+});
+
+test('a reply into a live client\'s thread still lands in that thread alone', function () {
+    $this->actingAs($this->admin)
+        ->postJson("/files/{$this->file->id}/comments", [
+            'body' => 'For you only: 40% off.',
+            'visibility' => CommentVisibility::Clients->value,
+            'reply_to' => $this->fromAlice->id,
+        ])
+        ->assertCreated();
+
+    $reply = FileComment::query()->where('body', 'For you only: 40% off.')->sole();
+
+    expect($reply->client_context_id)->toBe($this->alice->id)
+        ->and(readableBy($this->alice, $this->file))->toContain($reply->id)
+        ->and(readableBy($this->bob, $this->file))->not->toContain($reply->id);
+});
+
+test('a deleted client\'s comment keeps their name instead of reading as a guest', function () {
+    $this->alice->delete();
+
+    expect($this->fromAlice->fresh()->authorName())->toBe('Alice Ltd');
+});
+
+test('a genuine guest comment is still anonymous', function () {
+    $guest = FileComment::factory()->for($this->file)->fromGuest()->create();
+
+    expect($guest->authorName())->not->toBe('Alice Ltd')
+        ->and($guest->author_id)->toBeNull();
+});


### PR DESCRIPTION
`file_comments.client_context_id` is `cascadeOnDelete`, but users are
soft-deleted — so the cascade never fires. The column keeps pointing at a row
that is still there, while the Eloquent relation resolves to `null`.

`resolveClientContext()` branched on the relation. `VisibleCommentScope` says
what a null context means, in its own docblock:

> A Clients comment carrying `client_context_id = C` is never returned to any
> non-staff viewer other than C. […] A Clients comment with a *null* context is
> a staff message to everyone on the file, and every client with access reads
> it.

So a staff reply into one client's private thread became a circular to all of
them — and `canAssignClient()` was skipped on the way, because the code returned
before reaching it.

## Measured

One file shared with two clients; the first comments, then her account is
deleted:

```
column client_context_id      3
relation clientContext        null
POST reply into her thread    201, stored with client_context_id null
read by the other client      yes
```

## The fix

Ask the column, not the relation. When the column is filled and the account
behind it is gone there is nobody left to answer, and the one outcome that must
not follow from a filled column is the broadcast — so it refuses rather than
falling through to it.

`authorName()` had the same root cause from the other column. Its docblock
claimed `author_id` cascades so there is no deleted author; a deleted client's
comment was going out as **"Anonymous"**, which is what a guest comment looks
like — and a guest comment is read by different rules. Whether the author is a
guest is now decided by `author_id` alone, the same question `isFromGuest()`
asks, and a trashed author is read with `withTrashed()`. Nothing comes back only
once the grace-period erasure has removed the row for real.

## The cost of that read

One query per comment whose author is trashed. Measured on a ten-comment thread:

| | queries |
|---|---|
| before, all ten authors deleted | 11 |
| after, all ten authors deleted | 21 |
| after, all ten authors alive | 20 |

So a thread of deleted authors now costs about what the same thread costs with
live ones, rather than answering wrongly for free.

## Not changed (deliberate)

- **Eager loading.** The trashed read stays lazy rather than adding
  `->withTrashed()` to every call site's eager load: each caller would have to
  remember it, and the cost only applies to comments whose author is gone.
- **The cascade definitions.** `cascadeOnDelete` on a soft-deleting parent is
  misleading, but changing the migration is a schema question of its own; this
  makes the reads honest about what the data actually is.
- **The null-context branch.** It is a real feature, not only a failure mode:
  staff writing fresh with no reply target address every client on the file, and
  that keeps working.

## Tests

Five, two measured red against the unfixed code (**2 failed / 3 passed**) — one
per column. The three that stay green either way are the branches that must not
move: a staff message with no context still reaches everybody, a reply into a
live client's thread still lands in that thread alone, and a genuine guest
comment is still anonymous.

Full suite passes (2053 passed / 2 skipped), PHPStan level 8 clean.