### PR TITLE
Count a shared folder's contents as reach, not just the folder

### DIFF
--- a/app/Modules/Files/Access/StaffLibraryScope.php
+++ b/app/Modules/Files/Access/StaffLibraryScope.php
@@ -292,9 +292,54 @@ class StaffLibraryScope
         $assignedFolders = FolderAssignment::query()->select('folder_id')
             ->where('assignable_type', $morph)->where('assignable_id', $group->id);
 
-        return ! Folder::query()
-            ->whereIn('id', $assignedFolders)
+        // The whole subtree, not the folder the assignment names. A folder
+        // shared with a group hands its members everything inside it —
+        // File::scopeVisibleToClient matches on folder placement, and a
+        // folder is visible to a client when it or an ancestor is shared
+        // with them — so "is anything shared with this group outside my
+        // library" has to ask about the contents, which is what the
+        // docblock above already claims ("the folders whose subtrees it
+        // can browse").
+        //
+        // Measured: a scoped staff member's own folder, with a subfolder
+        // somebody else created inside it and somebody else's file in
+        // that. The folder is theirs, its contents are not, and adding
+        // their own client to a group holding the parent handed that
+        // client the file — which then enters the staff member's own
+        // library too, because files() is "everything my clients can
+        // see". That is the widening this guard exists to refuse, and the
+        // test above it says so in as many words.
+        $reachable = Folder::query()->whereIn('id', $assignedFolders)->get()
+            ->flatMap(fn (Folder $folder): array => $folder->subtreeFolderIds())
+            ->unique()
+            ->values()
+            ->all();
+
+        if ($reachable === []) {
+            return true;
+        }
+
+        if (Folder::query()
+            ->whereIn('id', $reachable)
             ->whereNotIn('id', $this->folders($user)->select('id'))
+            ->exists()
+        ) {
+            return false;
+        }
+
+        // And the files sitting in them. A folder can be inside the
+        // library while a file in it is not: files() is own uploads plus
+        // what an assigned client may see, and neither covers somebody
+        // else's upload into a folder this staff member happens to own.
+        //
+        // notExpired() for the same reason the assignment half above skips
+        // deleted files: membership in this group grants nobody access to
+        // an expired file, because scopeVisibleToClient ends by excluding
+        // them, and something nobody can reach is not reach.
+        return ! File::query()
+            ->whereIn('folder_id', $reachable)
+            ->notExpired()
+            ->whereNotIn('id', $this->files($user)->select('id'))
             ->exists();
     }
 }

--- a/tests/Feature/Groups/GroupMembershipScopeTest.php
+++ b/tests/Feature/Groups/GroupMembershipScopeTest.php
@@ -226,6 +226,88 @@ test('unscoped staff manage membership exactly as before', function () {
     expect($this->strangerGroup->members()->pluck('users.id')->all())->toBe([$this->mine->id]);
 });
 
+// A folder shared with a group hands over its whole subtree, so the guard
+// has to ask about the contents and not only about the folder named in
+// the assignment. The docblock on groupReachesNoFurther() already claims
+// it does ("the folders whose subtrees it can browse").
+test('a subfolder outside the library counts as reach as well', function () {
+    // The rep's own folder, so it is in their library by "own uploads".
+    $parent = app(FolderService::class)->create('Rep Folder', null);
+    $parent->forceFill(['created_by' => $this->rep->id])->save();
+
+    // Somebody else's subfolder inside it, which is not.
+    $child = app(FolderService::class)->create('Admin Subfolder', $parent);
+    $child->forceFill(['created_by' => $this->admin->id])->save();
+
+    $group = Group::query()->create(['name' => 'Newsletter', 'slug' => 'newsletter', 'public' => false]);
+    FolderAssignment::query()->create([
+        'folder_id' => $parent->id,
+        'assignable_type' => $group->getMorphClass(),
+        'assignable_id' => $group->id,
+    ]);
+
+    $this->actingAs($this->rep)
+        ->post("/groups/{$group->id}/members", ['user_id' => $this->mine->id])
+        ->assertForbidden();
+
+    expect($group->members()->count())->toBe(0);
+});
+
+test('a stranger file inside the rep own folder counts as reach', function () {
+    // Every folder in the subtree is theirs, and the file in it is not:
+    // files() is own uploads plus what an assigned client may see, and
+    // somebody else's upload into a folder this rep happens to own is
+    // neither. Adding their own client would have handed it over -- and
+    // handed it to the rep too, since files() then includes it.
+    $parent = app(FolderService::class)->create('Rep Folder', null);
+    $parent->forceFill(['created_by' => $this->rep->id])->save();
+
+    $secret = uploadNamedFile($this->admin, 'stranger-secret');
+    $secret->forceFill(['folder_id' => $parent->id])->save();
+
+    expect(libraryHolds($this->rep, $secret->id))->toBeFalse();
+
+    $group = Group::query()->create(['name' => 'Bulletin', 'slug' => 'bulletin', 'public' => false]);
+    FolderAssignment::query()->create([
+        'folder_id' => $parent->id,
+        'assignable_type' => $group->getMorphClass(),
+        'assignable_id' => $group->id,
+    ]);
+
+    $this->actingAs($this->rep)
+        ->post("/groups/{$group->id}/members", ['user_id' => $this->mine->id])
+        ->assertForbidden();
+
+    expect($group->members()->count())->toBe(0);
+});
+
+test('a subtree that is wholly inside the library stays manageable', function () {
+    // The half that must not harden: everything shared with this group is
+    // reachable by the rep, subfolder and file alike, so the group is
+    // theirs to populate.
+    $parent = app(FolderService::class)->create('Ours', null);
+    $parent->forceFill(['created_by' => $this->rep->id])->save();
+
+    $child = app(FolderService::class)->create('Ours Too', $parent);
+    $child->forceFill(['created_by' => $this->rep->id])->save();
+
+    $own = uploadNamedFile($this->rep, 'our-own-file');
+    $own->forceFill(['folder_id' => $child->id])->save();
+
+    $group = Group::query()->create(['name' => 'Ours', 'slug' => 'ours-group', 'public' => false]);
+    FolderAssignment::query()->create([
+        'folder_id' => $parent->id,
+        'assignable_type' => $group->getMorphClass(),
+        'assignable_id' => $group->id,
+    ]);
+
+    $this->actingAs($this->rep)
+        ->post("/groups/{$group->id}/members", ['user_id' => $this->mine->id])
+        ->assertRedirect();
+
+    expect($group->members()->count())->toBe(1);
+});
+
 test('a folder shared with a group counts as reach too', function () {
     $folder = app(FolderService::class)->create('Their Folder', null);
     FolderAssignment::query()->create([


### PR DESCRIPTION
`StaffLibraryScope::groupReachesNoFurther()` asks whether anything shared with a
group sits outside the viewer's library, and its docblock says the folder half
covers "the folders whose subtrees it can browse". It compares the folder ids the
assignment names, and stops there.

A folder shared with a group hands its members the whole subtree —
`File::scopeVisibleToClient` matches on folder placement, and a folder is visible
to a client when it or an ancestor is shared with them. So the guard passed on a
subtree it had never looked into.

Measured on `main`: a scoped rep's own folder, a subfolder somebody else created
inside it, and that person's file in the subfolder.

```
parent folder in the rep's library                    true
the subfolder                                         false
the file inside it                                    false
add their own client to a group holding the parent  → 302, allowed
the client can then reach the file                    true
```

And because `files()` is "own uploads plus everything my clients can see", that
file lands in the rep's own library on the next request. This is the widening the
guard exists to refuse — the first test in the file is called "a scoped staff
member cannot widen their own library through a group".

**Fix.** The folder half walks each assigned folder's subtree, and the files
inside it are checked too: a folder can be in the library while a file in it is
not, since somebody else's upload into a folder this rep owns is neither their own
nor their clients'.

**Not changed (deliberate).**
- The assignment half, which already starts from the live row so dead assignments
  are ignored by construction.
- Unscoped staff, who return early and never reach any of this.
- Expired files are skipped, for the reason deleted ones are: membership grants
  nobody access to one, and something nobody can reach is not reach. That is the
  same sentence the sibling branch `fix/group-reach-expired-file` adds to the
  assignment half — if that one is not taken, this `notExpired()` should come out
  with it.

**Tests.** Three in `tests/Feature/Groups/GroupMembershipScopeTest.php`: the
subfolder case, the stranger-file case, and a subtree wholly inside the library,
which stays manageable.

Counter-check: with `StaffLibraryScope.php` reset to `main` and the tests kept,
that file alone goes **2 failed / 25 passed**. The third test stays green either
way, which is what says this did not simply harden the guard shut.

Full suite passes (**2108 passed / 2 skipped**, 11416 assertions; `main` (`06c364d2`) measures 2105/2). PHPStan level 8 clean.

**Merge note.** `fix/group-reach-expired-file` changes the **same method**, its
file half rather than this folder half, and appends to the same test file. They
merge without conflict, but a clean textual merge of two changes to one method
is not evidence, so the merged tree was run: `GroupMembershipScopeTest` is
25 passed and the full suite is `main` plus both branches' tests exactly.

**#1714** also appended to that test file at a different point and has since
landed in `main`; this branch is rebased on top of it, and its counter-check
still goes red against the merged code.