### PR TITLE
Stop an expired file locking a group shut for a scoped staff member

### DIFF
--- a/app/Modules/Files/Access/StaffLibraryScope.php
+++ b/app/Modules/Files/Access/StaffLibraryScope.php
@@ -268,6 +268,15 @@ class StaffLibraryScope
      * row rather than from the assignment ignores the dead ones by
      * construction, which is also the right answer: a deleted file is
      * not reach, because nobody can reach it.
+     *
+     * An expired file is the same answer for the same reason. Membership
+     * in this group grants nobody access to it — File::scopeVisibleToClient
+     * ends in notExpired(), so it is gone from every member's /my-files and
+     * the download is refused — while its absence from files() otherwise
+     * reads as "outside my library" and locks the group exactly as a
+     * deleted file used to. Expiry is reversible where deletion is not, so
+     * the file counts as reach again the moment it does: this asks what is
+     * reachable now, at the moment somebody is added or removed.
      */
     private function groupReachesNoFurther(User $user, Group $group): bool
     {
@@ -282,6 +291,7 @@ class StaffLibraryScope
 
         $outside = File::query()
             ->whereIn('id', $assignedFiles)
+            ->notExpired()
             ->whereNotIn('id', $this->files($user)->select('id'))
             ->exists();
 

--- a/tests/Feature/Groups/GroupMembershipScopeTest.php
+++ b/tests/Feature/Groups/GroupMembershipScopeTest.php
@@ -325,6 +325,58 @@ test('a deleted file does not excuse a live one that is still out of reach', fun
         ->assertForbidden();
 });
 
+// Expiry is the same answer for the same reason: membership grants nobody
+// access to an expired file, because scopeVisibleToClient ends in
+// notExpired(). It is only invisible to files(), which read as reach.
+test('a group is not locked shut by a file that has since expired', function () {
+    $group = Group::query()->create(['name' => 'Seasonal', 'slug' => 'seasonal', 'public' => false]);
+    $group->members()->syncWithoutDetaching([$this->mine->id]);
+
+    $file = uploadNamedFile($this->admin, 'summer-offer');
+    shareFileWithGroup($file, $group);
+
+    $second = User::factory()->client()->create(['name' => 'Also Mine']);
+    $this->rep->assignedClients()->attach($second->id);
+
+    $this->actingAs($this->rep)
+        ->post("/groups/{$group->id}/members", ['user_id' => $second->id])
+        ->assertRedirect();
+
+    $file->update(['expires_at' => now()->subDay()]);
+
+    // Nobody in the group can reach it any more — the premise of the rule.
+    $this->actingAs($this->mine)->get("/files/{$file->id}/download")->assertForbidden();
+
+    $third = User::factory()->client()->create(['name' => 'Mine Too']);
+    $this->rep->assignedClients()->attach($third->id);
+
+    $this->actingAs($this->rep)
+        ->post("/groups/{$group->id}/members", ['user_id' => $third->id])
+        ->assertRedirect();
+
+    expect($group->members()->count())->toBe(3);
+
+    // And taking their own client out again, which is the part that reads
+    // worst: the rep could not undo their own membership change.
+    $this->actingAs($this->rep)
+        ->delete("/groups/{$group->id}/members/{$third->id}")
+        ->assertRedirect();
+
+    expect($group->members()->count())->toBe(2);
+});
+
+test('an expired file does not excuse a live one that is still out of reach', function () {
+    $expired = uploadNamedFile($this->admin, 'was-current');
+    shareFileWithGroup($expired, $this->strangerGroup);
+    $expired->update(['expires_at' => now()->subDay()]);
+
+    // $this->secret is live, shared with the same group and outside this
+    // rep's library — the guard still has to answer no.
+    $this->actingAs($this->rep)
+        ->post("/groups/{$this->strangerGroup->id}/members", ['user_id' => $this->mine->id])
+        ->assertForbidden();
+});
+
 
 /**
  * The rep role ships without delete_groups, and these cases are about the


### PR DESCRIPTION
`StaffLibraryScope::groupReachesNoFurther()` decides whether a client-scoped
staff member may edit a group, by asking whether anything shared with it sits
outside their library. `f1b35cc9` settled the shape of that answer for deleted
files, and its docblock states the principle: start from the live row, because
"a deleted file is not reach, because nobody can reach it".

An expired file is the same case and was not covered. `File::scopeVisibleToClient`
ends in `notExpired()`, so the moment a file expires it leaves every member's
`/my-files` and the download answers 403 — and it leaves `files()` too, where its
absence reads as "outside my library".

Measured on `main` (`d58e4830`), one file shared with a group holding this rep's
own client:

```
before expiry:  may_add true    may_change true
after expiry:   may_add false   may_change false
DELETE /groups/{id}/members/{their own client} → 403
```

They cannot undo their own membership change, and the group is unmanageable for
good.

**Fix.** The reach query skips expired files as it already skips deleted ones —
one `notExpired()` on the file half.

**Not changed (deliberate).**
- `File::scopeVisibleToClient`. What expiry does to a scoped viewer's library was
  settled deliberately in `c8078f65`; this is about what counts as *reach*, not
  about what anyone may open.
- The folder half needs nothing: folders do not expire.
- Expiry is reversible where deletion is not, and that needs no special handling.
  The guard asks what is reachable at the moment somebody is added or removed —
  the same moment-in-time question `#1701` settled — and the file counts as reach
  again as soon as it stops being expired.

**The limit this leaves open,** stated rather than implied: a membership added
while a file was expired outlives the expiry. If somebody with edit rights later
clears `expires_at`, the client reaches a file that was outside the actor's
library at the moment the decision was made. `f1b35cc9` leaves exactly the same
opening for a file restored from the trash. Closing either one would mean the
guard weighing rows nobody can currently reach, which is the thing both fixes
exist to stop.

**Tests.** Two in `tests/Feature/Groups/GroupMembershipScopeTest.php`, placed
beside the deleted-file pair they mirror: the lockout itself (including that the
members really cannot reach the file any more), and the half that must not
soften — a live out-of-reach file is still reach with an expired sibling next to
it.

Counter-check: with `StaffLibraryScope.php` reset to `main` and the tests kept,
the file goes **1 failed / 25 passed**. The guard test stays green either way, by
design.

Full suite passes (**2107 passed / 2 skipped**, 11416 assertions; `main` (`06c364d2`) measures 2105/2). PHPStan level 8 clean. `pint --test` reports the same two pre-existing
rules on this test file as it does for `main`'s version of it — nothing added. No
frontend or API controller touched, so `tsc`, ESLint and `scramble:export` were
not run.

**Merge note.** #1714 (`fix/group-edit-client-roster`) was the only other change
to `GroupMembershipScopeTest.php`, and it has since landed in `main`. Both were
additions at different points in the file, so this branch now sits on top of it
rather than beside it — the counter-check above is measured against the merged
code, which is the stronger statement.

**Merge note, sibling.** `fix/group-reach-subtree` changes the **same method** —
its folder half, where this changes the file half — and appends to the same test
file. A clean textual merge of two changes to one method is not evidence, so the
merged tree was built and run: `GroupMembershipScopeTest` is 25 passed, and the
full suite is `main` plus both branches' tests exactly.