### PR TITLE
Stop a client PATCH clearing custom fields it never mentioned

### DIFF
--- a/app/Modules/Clients/Http/Controllers/Api/ClientsController.php
+++ b/app/Modules/Clients/Http/Controllers/Api/ClientsController.php
@@ -29,6 +29,7 @@ use App\Modules\Identity\UserType;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -206,7 +207,7 @@ class ClientsController extends Controller
         $client->save();
 
         if (array_key_exists('custom_field_values', $validated)) {
-            $this->saveCustomFieldValues($client, $validated['custom_field_values']);
+            $this->patchCustomFieldValues($client, $validated['custom_field_values']);
         }
 
         $this->activity->log(Action::UserUpdated, subject: $client);
@@ -364,11 +365,43 @@ class ClientsController extends Controller
     }
 
     /**
+     * Every field, whether or not the request named it — a new client has
+     * no values yet, and create() is not a partial update.
+     *
      * @param  array<int, mixed>  $values  field id => submitted value
      */
     private function saveCustomFieldValues(User $client, array $values): void
     {
-        foreach (ClientCustomField::query()->get() as $field) {
+        $this->writeCustomFieldValues($client, ClientCustomField::query()->get(), $values);
+    }
+
+    /**
+     * Only the fields the request actually named.
+     *
+     * PATCH semantics, the same rule update() applies to every other
+     * column: an absent key means "leave alone", not "clear". Sharing
+     * create()'s "write every field" pass here emptied every custom field
+     * the caller had not mentioned, which is silent data loss on a request
+     * that looked like it changed one thing.
+     *
+     * @param  array<int, mixed>  $values  field id => submitted value
+     */
+    private function patchCustomFieldValues(User $client, array $values): void
+    {
+        $this->writeCustomFieldValues(
+            $client,
+            ClientCustomField::query()->whereIn('id', array_keys($values))->get(),
+            $values,
+        );
+    }
+
+    /**
+     * @param  Collection<int, ClientCustomField>  $fields
+     * @param  array<int, mixed>  $values  field id => submitted value
+     */
+    private function writeCustomFieldValues(User $client, Collection $fields, array $values): void
+    {
+        foreach ($fields as $field) {
             $submitted = $values[$field->id] ?? null;
             $value = $field->type === ClientCustomFieldType::Checkbox
                 ? ($submitted ? '1' : '0')

--- a/tests/Feature/Api/ClientsTest.php
+++ b/tests/Feature/Api/ClientsTest.php
@@ -85,6 +85,76 @@ test('the listing does not hand out every clients custom field data', function (
 |--------------------------------------------------------------------------
 */
 
+test('a PATCH leaves custom fields it does not name alone', function () {
+    // The same rule the rest of update() states: "an absent key means
+    // 'leave alone', not 'clear'". The custom-field pass was create()'s,
+    // which writes every field there is.
+    $name = ClientCustomField::query()->create([
+        'name' => 'contact', 'label' => 'Contact', 'type' => ClientCustomFieldType::Text,
+        'required' => false, 'sort_order' => 1,
+    ]);
+    $vat = ClientCustomField::query()->create([
+        'name' => 'vat', 'label' => 'VAT number', 'type' => ClientCustomFieldType::Text,
+        'required' => false, 'sort_order' => 2,
+    ]);
+
+    $client = User::factory()->client()->create();
+    ClientCustomFieldValue::query()->create([
+        'client_custom_field_id' => $name->id, 'user_id' => $client->id, 'value' => 'Alex',
+    ]);
+    ClientCustomFieldValue::query()->create([
+        'client_custom_field_id' => $vat->id, 'user_id' => $client->id, 'value' => 'ATU12345678',
+    ]);
+
+    $this->withToken($this->token)->patchJson("/api/v1/clients/{$client->id}", [
+        'custom_field_values' => [$name->id => 'Robin'],
+    ])->assertOk();
+
+    $values = ClientCustomFieldValue::query()->where('user_id', $client->id)
+        ->pluck('value', 'client_custom_field_id');
+
+    expect($values[$name->id])->toBe('Robin')
+        ->and($values[$vat->id])->toBe('ATU12345678');
+});
+
+test('a PATCH can still clear a field by naming it', function () {
+    $vat = ClientCustomField::query()->create([
+        'name' => 'vat', 'label' => 'VAT number', 'type' => ClientCustomFieldType::Text,
+        'required' => false, 'sort_order' => 1,
+    ]);
+    $client = User::factory()->client()->create();
+    ClientCustomFieldValue::query()->create([
+        'client_custom_field_id' => $vat->id, 'user_id' => $client->id, 'value' => 'ATU12345678',
+    ]);
+
+    $this->withToken($this->token)->patchJson("/api/v1/clients/{$client->id}", [
+        'custom_field_values' => [$vat->id => ''],
+    ])->assertOk();
+
+    expect(ClientCustomFieldValue::query()
+        ->where('user_id', $client->id)->where('client_custom_field_id', $vat->id)->value('value'))->toBeNull();
+});
+
+test('creating a client still records every field', function () {
+    // create() is not a partial update, and a checkbox nobody ticked is a
+    // recorded "no" rather than an absent row.
+    $optIn = ClientCustomField::query()->create([
+        'name' => 'newsletter', 'label' => 'Newsletter', 'type' => ClientCustomFieldType::Checkbox,
+        'required' => false, 'sort_order' => 1,
+    ]);
+
+    $this->withToken($this->token)->postJson('/api/v1/clients', [
+        'name' => 'Acme Ltd',
+        'email' => 'crud-custom@example.com',
+        'password' => 'super-secret-password',
+    ])->assertCreated();
+
+    $client = User::query()->where('email', 'crud-custom@example.com')->sole();
+
+    expect(ClientCustomFieldValue::query()
+        ->where('user_id', $client->id)->where('client_custom_field_id', $optIn->id)->value('value'))->toBe('0');
+});
+
 test('a client can be created', function () {
     $this->withToken($this->token)->postJson('/api/v1/clients', [
         'name' => 'Acme Ltd',


### PR DESCRIPTION
`Api\ClientsController::update()` states the rule eighteen lines above the bug:
"PATCH semantics, unlike the web form which always submits every field: an absent
key means 'leave alone', not 'clear'." Every column obeys it. The custom fields
did not — they go through `saveCustomFieldValues()`, which is `store()`'s pass:
it walks *every* field there is and writes null for the ones the request did not
carry.

Measured on `main`, two fields filled, a PATCH naming one:

```
status              → 200
the named field     → "Robin"
the other one       → null      (was "ATU12345678")
```

Nothing in the response says so, and there is no second copy of the value.

**Fix.** The write pass is shared but entered two ways: `create()` keeps writing
every field, and `update()` writes only the fields the request named.

**Not changed (deliberate).**
- Creating a client. It is not a partial update: a new client has no values, and
  a checkbox nobody ticked is a recorded "no" rather than an absent row. The test
  for that is in this PR.
- Clearing a field by naming it with an empty value still clears it.
- The validation rules, including `required` enforcement on create.
- The web controller's own copy, where the form does submit every field.

**Tests.** Three in `tests/Feature/Api/ClientsTest.php`: the untouched field
survives, a named empty value still clears, and create still records every field.

Counter-check: with `Api/ClientsController.php` reset to `main` and the tests
kept, that file alone goes **1 failed / 22 passed**. The other two stay green
either way — they are the guard that this did not stop writes happening.

Full suite passes (**2108 passed / 2 skipped**, 11416 assertions; `main`
(`06c364d2`) measures 2105/2). PHPStan level 8 clean. `php artisan
scramble:export` produces a `docs/api/openapi.json` byte-identical to `main`'s.
`pint --test` reports `unary_operator_spaces, braces_position,
not_operator_with_successor_space` on this file and reports exactly the same on
`main`'s version of it — nothing added. No frontend change, so `tsc`/ESLint were
not run.

**Merge note.** `Api/ClientsController.php` was also touched by #1709, which has
since landed in `main`: its hunk was the `guardClient()` call early in
`update()`. Most of this change is elsewhere — the import, the custom-field pass
and the private methods at the end — but one line of it sits in `update()` too,
about a dozen lines below where that call now is. They were the closest pair in
the series and they merged without a conflict marker; this branch is now rebased
on top of the merged code, and the guard runs before `save()`, so on a capped
installation the custom-field pass is never reached — which is the right order.