### PR TITLE
Write a rendition through a temporary file, and never serve an empty one

### DIFF
--- a/app/Modules/Files/Http/Controllers/FileThumbnailController.php
+++ b/app/Modules/Files/Http/Controllers/FileThumbnailController.php
@@ -202,8 +202,19 @@ class FileThumbnailController extends Controller
 
         $disk = Storage::disk('files');
 
+        // Existence is the cache, and an empty file is not a rendition: it
+        // is what a render that died before writing anything leaves behind,
+        // and serving it hands the viewer a broken image for as long as the
+        // file lives — nothing invalidates a rendition once it is there.
+        // ThumbnailGenerator writes through a temporary file now, so this
+        // state can no longer be created here; it can still be inherited
+        // from an installation that ran an older version.
         if ($disk->exists($path)) {
-            return $path;
+            if ($disk->size($path) > 0) {
+                return $path;
+            }
+
+            $disk->delete($path);
         }
 
         $disk->makeDirectory(dirname($path));

--- a/app/Modules/Files/Thumbnails/ThumbnailGenerator.php
+++ b/app/Modules/Files/Thumbnails/ThumbnailGenerator.php
@@ -134,6 +134,31 @@ class ThumbnailGenerator
         // listening the image is written exactly as produced above.
         Event::dispatch(new RenderingImage($image, $mimeType, $audience, $rendition));
 
-        $image->toFile($destinationPath, $mimeType);
+        // Written beside the destination and renamed into place, so the
+        // cached path never exists half-finished. Both callers test only
+        // that the path exists and then serve whatever is there
+        // (FileThumbnailController::render, PublicGroupsController::
+        // thumbnail), and nothing ever invalidates a rendition —
+        // RenderedImageCache::flush() runs on an event no core code raises.
+        // A render that died partway would therefore be served as the
+        // rendition from then on.
+        //
+        // It also settles the race: two requests rendering the same file at
+        // once used to encode into one path together. rename() within a
+        // directory is atomic and replaces what is there, so now the loser
+        // leaves a complete rendition behind rather than a mixture of two.
+        $temporaryPath = $destinationPath.'.'.bin2hex(random_bytes(8)).'.partial';
+
+        try {
+            $image->toFile($temporaryPath, $mimeType);
+
+            if (! rename($temporaryPath, $destinationPath)) {
+                throw new RuntimeException('Could not move the rendered image into place.');
+            }
+        } finally {
+            if (is_file($temporaryPath)) {
+                @unlink($temporaryPath);
+            }
+        }
     }
 }

--- a/app/Modules/Groups/Http/Controllers/PublicGroupsController.php
+++ b/app/Modules/Groups/Http/Controllers/PublicGroupsController.php
@@ -251,6 +251,13 @@ class PublicGroupsController extends Controller
 
         $disk = Storage::disk('files');
 
+        // An empty file is not a rendition — same rule as the signed-in
+        // twin in FileThumbnailController::render(), and the same reason:
+        // nothing invalidates one once it is cached.
+        if ($disk->exists($thumbnailPath) && $disk->size($thumbnailPath) === 0) {
+            $disk->delete($thumbnailPath);
+        }
+
         if (! $disk->exists($thumbnailPath)) {
             $disk->makeDirectory(dirname($thumbnailPath));
 

--- a/tests/Feature/Files/FileThumbnailsTest.php
+++ b/tests/Feature/Files/FileThumbnailsTest.php
@@ -6,6 +6,8 @@ use App\Models\User;
 use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLog;
 use App\Modules\Files\Models\File;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -48,6 +50,47 @@ test('a second request reuses the cached thumbnail instead of regenerating it', 
     Storage::disk('files')->delete($file->path);
 
     $this->actingAs($this->admin)->get("/files/{$file->id}/thumbnail")->assertOk();
+});
+
+// Existence is the whole cache test, and nothing invalidates a rendition
+// once it is there: RenderedImageCache::flush() runs on an event no core
+// code raises. So an empty file left by a render that died before writing
+// anything was served as the thumbnail from then on.
+test('an empty cached rendition is replaced rather than served', function () {
+    $file = uploadImageFile($this->admin);
+    $path = "thumbnails/{$file->id}.jpg";
+
+    Storage::disk('files')->put($path, '');
+
+    $this->actingAs($this->admin)->get("/files/{$file->id}/thumbnail")->assertOk();
+
+    expect(Storage::disk('files')->size($path))->toBeGreaterThan(0);
+});
+
+test('the public thumbnail route replaces an empty rendition too', function () {
+    $file = publicListingImageFile($this->admin);
+    $path = "thumbnails/external/{$file->id}.jpg";
+
+    app(Settings::class)->set(Setting::PublicListingEnabled, true);
+    app(Settings::class)->set(Setting::PublicListingSlug, 'public');
+
+    Storage::disk('files')->put($path, '');
+
+    $this->get(route('public.thumbnail', ['public', $file->slug]))->assertOk();
+
+    expect(Storage::disk('files')->size($path))->toBeGreaterThan(0);
+});
+
+test('a generated rendition leaves nothing half-written beside it', function () {
+    // The temporary file the generator renames into place is its own, and
+    // it does not outlive the request that made it.
+    $file = uploadImageFile($this->admin);
+
+    $this->actingAs($this->admin)->get("/files/{$file->id}/thumbnail")->assertOk();
+
+    expect(collect(Storage::disk('files')->files('thumbnails'))
+        ->filter(fn (string $path): bool => str_contains($path, '.partial'))
+        ->all())->toBe([]);
 });
 
 test('a non-image file 404s when a thumbnail is requested', function () {


### PR DESCRIPTION
Both thumbnail routes treat "the file exists" as "the rendition is cached", and
nothing ever invalidates one: `RenderedImageCache::flush()` runs on
`ImageRenderingChanged`, which no code in core raises. Whatever sits at the path
is what every later viewer gets.

`ThumbnailGenerator::generate()` encoded straight onto that path
(`$image->toFile($destinationPath, …)`). So:

- a render that died partway — a full volume, a killed worker — left a
  half-written file that was then served as the rendition indefinitely;
- two requests rendering the same file at once encoded into the same path
  together.

**Fix, write side.** The image is written beside its destination and renamed into
place. `rename()` within a directory is atomic and replaces what is there, so the
path holds either the previous rendition or a complete new one, and the loser of
a race leaves a whole image rather than a mixture of two. The temporary file is
removed on the way out either way.

**Fix, read side.** An empty file is not a rendition, so both routes replace one
rather than serve it. Writing through a temporary file means this state can no
longer be created here — but an installation that ran an older version can
already have it on disk, and nothing else will ever clear it.

**Not changed (deliberate).**
- The cache itself: a non-empty rendition is still reused without further checks.
  Decoding every cached image on every request to prove it is intact would cost
  the cache its whole point.
- `RenderedImageCache` and `ImageRenderingChanged`. That flush path is for
  packages that decorate renderings; it is unreachable from core either way, and
  making it noisier is a separate question.
- The `RenderingImage` seam, which still fires before the encode.

**Tests.** Three in `tests/Feature/Files/FileThumbnailsTest.php`: an empty cached
rendition is replaced on the signed-in route and on the public one, and a
successful render leaves nothing half-written beside it.

Counter-check: with the three application files reset to `main` and the tests
kept, that file alone goes **2 failed / 12 passed**. The third test is about the
fix's own temporary file and passes either way — stated here rather than left to
be discovered.

Full suite passes (**2108 passed / 2 skipped**, 11415 assertions; `main`
(`06c364d2`) measures 2105/2). PHPStan level 8 clean, `pint --test` clean on all
four changed files. No frontend or API controller touched, so `tsc`, ESLint and
`scramble:export` were not run.

**Merge note.** Two files here are also touched by the
`fix/public-preview-log-debounce` branch, and in both the hunks are in different
methods: `PublicGroupsController.php` (its `preview()`, this one's `thumbnail()`)
and `FileThumbnailController.php` (its constructor and `preview()`, this one's
private `render()`). The two branches merge without conflict in either order.