### PR TITLE
Stop an expiry moving because somebody else saved the file

### DIFF
--- a/app/Modules/Files/Http/Controllers/FilesController.php
+++ b/app/Modules/Files/Http/Controllers/FilesController.php
@@ -173,7 +173,7 @@ class FilesController extends Controller
                 // calendar date the editor typed — read back in their
                 // zone, not the server's, or a file set to expire on the
                 // 12th reopens showing the 11th.
-                'expires_at' => $file->expires_at?->copy()->setTimezone($this->timezones->resolve($request->user()))->toDateString(),
+                'expires_at' => $this->expiryDateFor($file, $request->user()),
                 'expired' => $file->isExpired(),
                 'download_limit' => $file->download_limit,
                 'download_limit_scope' => ($file->download_limit_scope ?? DownloadLimitScope::Total)->value,
@@ -303,7 +303,19 @@ class FilesController extends Controller
         // own expiry — same "leave it alone if you lack the permission"
         // rule as the upload_public gate below.
         if ($request->user()?->can('set_file_expiration_date') === true) {
-            $attributes['expires_at'] = $this->expiryInstant($validated['expires_at'] ?? null, $request->user());
+            $posted = $validated['expires_at'] ?? null;
+
+            // Re-derived only when the date actually changed. The form was
+            // rendered with the stored instant read back as a date in *this*
+            // viewer's zone, and posts it again untouched with every other
+            // edit — so deriving it unconditionally moves the expiry by the
+            // difference between two people's zones each time somebody
+            // merely renames the file. Compared against the same string the
+            // form was given, above, so "unchanged" means what the editor
+            // saw.
+            if ($posted !== $this->expiryDateFor($file, $request->user())) {
+                $attributes['expires_at'] = $this->expiryInstant($posted, $request->user());
+            }
         }
 
         // Same rule again for the download cap, behind its own
@@ -539,5 +551,17 @@ class FilesController extends Controller
         return $date === null
             ? null
             : LocalDay::end($date, $this->timezones->resolve($setter));
+    }
+
+    /**
+     * The inverse: the calendar date a stored expiry falls on for this
+     * viewer, which is what the date input is given and what it posts back.
+     *
+     * The pair has to agree, or a re-save reads one date and writes
+     * another.
+     */
+    private function expiryDateFor(File $file, ?User $viewer): ?string
+    {
+        return $file->expires_at?->copy()->setTimezone($this->timezones->resolve($viewer))->toDateString();
     }
 }

--- a/tests/Feature/Platform/TimezoneTest.php
+++ b/tests/Feature/Platform/TimezoneTest.php
@@ -246,6 +246,76 @@ test('a file expiry set as a date means the end of that day where it was set', f
     expect($file->fresh()->expires_at->toIso8601String())->toBe('2026-08-13T02:59:59+00:00');
 });
 
+test('a re-save from another timezone does not move an expiry nobody touched', function () {
+    // The form is given the stored instant read back as a date in *this*
+    // viewer's zone, and posts it again untouched with every other edit.
+    // Deriving the instant from it unconditionally moved the expiry by the
+    // difference between the two zones -- 19 hours here -- for the price of
+    // a rename.
+    $setter = User::factory()->create(['timezone' => 'Pacific/Auckland']);
+    $other = User::factory()->create(['timezone' => 'America/Argentina/Buenos_Aires']);
+    $file = File::factory()->create(['uploaded_by' => $setter->id]);
+
+    $this->actingAs($setter)->patch("/files/{$file->id}", [
+        'name' => $file->name,
+        'expires_at' => '2026-09-12',
+    ])->assertRedirect();
+
+    $stored = $file->fresh()->expires_at->toIso8601String();
+
+    // Both see the same calendar date, which is why the rename posts it back.
+    $shown = $this->actingAs($other)->get("/files/{$file->id}")
+        ->viewData('page')['props']['file']['expires_at'];
+    expect($shown)->toBe('2026-09-12');
+
+    $this->actingAs($other)->patch("/files/{$file->id}", [
+        'name' => 'Renamed by somebody else',
+        'expires_at' => $shown,
+    ])->assertRedirect();
+
+    expect($file->fresh()->name)->toBe('Renamed by somebody else')
+        ->and($file->fresh()->expires_at->toIso8601String())->toBe($stored);
+});
+
+test('changing the date really does set it, in the zone of whoever changed it', function () {
+    // The half that must not stop working: a genuine change is still read
+    // as a day in the editor's own zone.
+    $setter = User::factory()->create(['timezone' => 'Pacific/Auckland']);
+    $other = User::factory()->create(['timezone' => 'America/Argentina/Buenos_Aires']);
+    $file = File::factory()->create(['uploaded_by' => $setter->id]);
+
+    $this->actingAs($setter)->patch("/files/{$file->id}", [
+        'name' => $file->name,
+        'expires_at' => '2026-09-12',
+    ])->assertRedirect();
+
+    $this->actingAs($other)->patch("/files/{$file->id}", [
+        'name' => $file->name,
+        'expires_at' => '2026-09-13',
+    ])->assertRedirect();
+
+    // 23:59:59 on the 13th in UTC-3.
+    expect($file->fresh()->expires_at->toIso8601String())->toBe('2026-09-14T02:59:59+00:00');
+});
+
+test('clearing the date from another timezone still clears it', function () {
+    $setter = User::factory()->create(['timezone' => 'Pacific/Auckland']);
+    $other = User::factory()->create(['timezone' => 'America/Argentina/Buenos_Aires']);
+    $file = File::factory()->create(['uploaded_by' => $setter->id]);
+
+    $this->actingAs($setter)->patch("/files/{$file->id}", [
+        'name' => $file->name,
+        'expires_at' => '2026-09-12',
+    ])->assertRedirect();
+
+    $this->actingAs($other)->patch("/files/{$file->id}", [
+        'name' => $file->name,
+        'expires_at' => null,
+    ])->assertRedirect();
+
+    expect($file->fresh()->expires_at)->toBeNull();
+});
+
 test('an expiry date comes back out of the form as the date that went in', function () {
     $staff = User::factory()->create(['timezone' => 'America/Argentina/Buenos_Aires']);
     $file = File::factory()->create(['uploaded_by' => $staff->id]);


### PR DESCRIPTION
The edit screen is given a file's expiry as a calendar date, read back in the
viewer's own zone — deliberately, and the comment there says why: "a file set to
expire on the 12th reopens showing the 11th" otherwise. Every save posts that
date back, touched or not, and `update()` derives a fresh instant from it every
time.

So the expiry drifts by the difference between two people's zones on any other
edit. Measured on `main`:

```
setter (Pacific/Auckland) sets 2026-09-12 → 2026-09-12T11:59:59Z
another viewer sees, as a date            → 2026-09-12
after that viewer merely renames the file → 2026-09-13T06:59:59Z
```

19 hours later, with nobody having gone near the date. It moves again on the next
save from a third zone, in whichever direction that zone lies.

**Fix.** The instant is re-derived only when the posted date differs from the one
the form was given — compared against the same string, through a named pair:
`expiryDateFor()` renders it, `expiryInstant()` reads it back. The edit screen now
calls the same method the comparison uses, so the two cannot drift apart.

**Not changed (deliberate).**
- What a *changed* date means: still the end of that day in the zone of whoever
  changed it, which is the rule `expiryInstant()` was written for.
- Clearing the date.
- `bulkUpdate()`. Its expiry is an explicit `set` / `clear` / `no_change` action,
  so an untouched expiry is never posted in the first place.
- The permission gate.

**Tests.** Three in `tests/Feature/Platform/TimezoneTest.php`, beside the two that
already pin this rule: the rename leaves the instant alone, a real change still
lands in the editor's own zone, and clearing still clears.

Counter-check: with `FilesController.php` reset to `main` and the tests kept, that
file alone goes **1 failed / 21 passed**. The other two stay green either way, by
design.

Full suite passes (**2108 passed / 2 skipped**, 11420 assertions; `main`
(`06c364d2`) measures 2105/2). PHPStan level 8 clean, `pint --test` clean on both
changed files. No frontend or API controller touched, so `tsc`, ESLint and
`scramble:export` were not run.

**Merge note.** `FilesController.php` is also touched by the
`fix/bulk-edit-skip-reason` branch: its hunk is in `bulkUpdate()`, these are in
`edit()`, `update()` and a new private method below them, and the two merge
without conflict in either order.