### PR TITLE
Decide what is an API request from the route, not from the caller's headers

### DIFF
--- a/app/Modules/Api/Support/ProblemDetails.php
+++ b/app/Modules/Api/Support/ProblemDetails.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Modules\Api\Support;
 
 use App\Modules\Platform\Capabilities\CapabilityUnavailable;
+use App\Support\ApiSurface;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -16,7 +17,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
 
 /**
- * RFC 7807 error bodies for /api/* only.
+ * RFC 7807 error bodies for the API surface only -- see ApiSurface, which
+ * is the same question the capability middleware asks.
  *
  * Two properties this class exists to guarantee:
  *
@@ -55,7 +57,7 @@ class ProblemDetails
 
     public function shouldHandle(Request $request): bool
     {
-        return $request->is('api/*');
+        return ApiSurface::matches($request);
     }
 
     public function render(Request $request, Throwable $e): JsonResponse

--- a/app/Modules/Platform/Http/Middleware/EnsureCapability.php
+++ b/app/Modules/Platform/Http/Middleware/EnsureCapability.php
@@ -7,6 +7,7 @@ namespace App\Modules\Platform\Http\Middleware;
 use App\Modules\Platform\Capabilities\Capability;
 use App\Modules\Platform\Capabilities\CapabilityRegistry;
 use App\Modules\Platform\Capabilities\CapabilityUnavailable;
+use App\Support\ApiSurface;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,6 +17,12 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * API requests get a machine-readable 403; web requests get a 404 so
  * unavailable features are absent, not teased.
+ *
+ * Which of the two a request is comes from the route (see ApiSurface), not
+ * from its Accept header. Whether an endpoint exists in this edition is a
+ * property of the installation; deciding it from what the caller is
+ * willing to parse answered the same API route 403 or 404 depending on
+ * nothing but a header, and routes/api.php promises the 403.
  *
  * The API half throws CapabilityUnavailable rather than returning a body,
  * so the refusal goes through ProblemDetails like every other API error
@@ -35,7 +42,7 @@ class EnsureCapability
             return $next($request);
         }
 
-        if ($request->expectsJson()) {
+        if (ApiSurface::matches($request)) {
             throw new CapabilityUnavailable($capability, $this->capabilities->edition());
         }
 

--- a/app/Support/ApiSurface.php
+++ b/app/Support/ApiSurface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Http\Request;
+
+/**
+ * Whether a request is on the API rather than on the web site.
+ *
+ * Two questions used to answer this, and both answer something else. A
+ * path test alone (`api/*`) is wrong because two staff *pages* live under
+ * that prefix — the API dashboard at /api and the OpenAPI reference at
+ * /api/docs, both registered in routes/web.php — and their errors belong
+ * to the web site: a signed-out visitor to /api/docs wants the login
+ * redirect, not a 401 telling them to send a Bearer token. An
+ * `expectsJson()` test is wrong because the Accept header is the caller's
+ * preference, not a property of the route: whether an endpoint exists in
+ * this edition cannot depend on what the caller is willing to parse.
+ *
+ * So: under the API prefix, and not part of the `web` middleware group.
+ * The group is what actually separates the two — sessions, cookies and
+ * CSRF on one side, tokens on the other — and it stays right for a future
+ * /api/v2 without this being edited.
+ *
+ * An unmatched path has no route to ask, and that is the API's answer:
+ * a request to a URL under the API prefix that resolves to nothing is a
+ * 404 the API should describe in its own error format.
+ */
+class ApiSurface
+{
+    public static function matches(Request $request): bool
+    {
+        if (! $request->is('api/*')) {
+            return false;
+        }
+
+        return ! in_array('web', $request->route()?->middleware() ?? [], true);
+    }
+}

--- a/tests/Feature/Api/ProblemDetailsTest.php
+++ b/tests/Feature/Api/ProblemDetailsTest.php
@@ -53,6 +53,14 @@ test('an unexpected failure never leaks its message when debug is off', function
     expect($response->getContent())->not->toContain('hunter2');
 });
 
+test('a staff page that lives under the API prefix is not an API route', function () {
+    // /api/docs and /api are pages from routes/web.php. Answering their
+    // errors in problem+json told a signed-out visitor to send a Bearer
+    // token, on a page whose whole purpose is to be read in a browser.
+    $this->get('/api/docs')->assertRedirect('/login');
+    $this->get('/api')->assertRedirect('/login');
+});
+
 test('web routes are untouched by the API error format', function () {
     // The renderer is scoped by path, not by whether the request accepts
     // JSON — Inertia requests do accept JSON, and reshaping their errors

--- a/tests/Feature/Platform/EnsureCapabilityMiddlewareTest.php
+++ b/tests/Feature/Platform/EnsureCapabilityMiddlewareTest.php
@@ -53,6 +53,27 @@ test('a capability unavailable in the current edition returns a machine-readable
         ]);
 });
 
+test('an API route answers 403 whatever the caller is willing to parse', function () {
+    // Accept is the caller's preference; whether a feature exists in this
+    // edition is not. routes/api.php promises the machine-readable 403,
+    // and a caller sending */* -- a curl default -- used to get a bare 404
+    // on the same route instead.
+    config()->set('projectsend.edition', Edition::Community);
+
+    $this->get('api/test/cloud-only', ['Accept' => '*/*'])
+        ->assertForbidden()
+        ->assertHeader('Content-Type', 'application/problem+json')
+        ->assertJson(['type' => 'capability_unavailable']);
+});
+
+test('a web route still answers 404 even when the caller asks for JSON', function () {
+    // The mirror image: an Inertia request accepts JSON, and an
+    // unavailable feature must stay absent rather than announce itself.
+    config()->set('projectsend.edition', Edition::Community);
+
+    $this->getJson('/test/cloud-only')->assertNotFound();
+});
+
 test('the same routes flip availability when running as the cloud edition', function () {
     config()->set('projectsend.edition', Edition::Cloud);
 


### PR DESCRIPTION
Two places ask "is this the API?", and each gets it wrong in the opposite
direction.

**`EnsureCapability` asks `$request->expectsJson()`.** Whether a feature exists
in this installation's edition is a property of the installation, not of what
the caller is willing to parse. Measured on `main`, one route, one missing capability, two Accept headers:

```
Accept: application/json  → 403 problem+json  capability_unavailable
Accept: */*               → 404 problem+json  not_found
```

`routes/api.php:232` promises the first in as many words ("A caller in an edition
without it gets 403 `capability_unavailable`, which says what is wrong; an
endpoint that silently was not there would not"). `*/*` is curl's default.

The mirror image is worse. An Inertia visit to a capability-gated **web** screen
accepts JSON, so it takes the API branch:

```
GET /users (JSON accepted, capability absent)
→ 403 {"message":"This installation does not include …",
       "exception":"App\Modules\Platform\Capabilities\CapabilityUnavailable"}
```

where the whole point of the 404 is that an unavailable feature is *absent, not
teased*.

**`ProblemDetails` asks `$request->is('api/*')`.** Two staff pages live under
that prefix — the API dashboard at `/api` and the OpenAPI reference at
`/api/docs`, both registered in `routes/web.php`. Signed out:

```
GET /api/docs → 401 application/problem+json
  "Send a valid API token in the Authorization header as \"Bearer <token>\""
```

instead of the login redirect every other page gives.

**Fix.** One question, asked once, in `App\Support\ApiSurface`: under the API
prefix, **and** not part of the `web` middleware group. The group is what
actually separates the two surfaces — sessions, cookies and CSRF on one side,
tokens on the other — and it keeps answering correctly for a future `/api/v2`
without being edited, which the path prefix alone would not.

**Not changed (deliberate).**
- An unmatched path has no route to ask, and stays the API's answer: a 404 under
  the API prefix is one the API should describe in its own format. The existing
  test for that (`a missing API route is a problem+json 404`) is untouched and
  green.
- `EnsureStaff` keeps its `expectsJson()` check. There the question really is
  about the caller — a browser wants a redirect, an XHR does not.
- `ChunkedUploadsController:174` keeps its own `is('api/*')`; it picks a route
  name, not an error shape, and no web route under the prefix reaches it.

**Tests.** Three: both header directions in
`tests/Feature/Platform/EnsureCapabilityMiddlewareTest.php`, and the two staff
pages under `/api` in `tests/Feature/Api/ProblemDetailsTest.php`. Both files
already own these rules.

Counter-check: with the two application files reset to `main` and
`app/Support/ApiSurface.php` removed, those two files together go **3 failed /
9 passed** — every new test, no old one.

Full suite passes (**2108 passed / 2 skipped**, 11418 assertions; `main`
(`06c364d2`) measures 2105/2). PHPStan level 8 clean, `pint --test` clean on all five changed files.
`php artisan scramble:export` on this branch produces a `docs/api/openapi.json`
byte-identical to `main`'s. No frontend change, so `tsc`/ESLint were not run.