### PR TITLE
Refuse to provision over a deleted account's address instead of crashing

### DIFF
--- a/app/Modules/Clients/ClientProvisioning.php
+++ b/app/Modules/Clients/ClientProvisioning.php
@@ -49,6 +49,22 @@ class ClientProvisioning
     }
 
     /**
+     * Whether an address is free for a new account.
+     *
+     * The unique index on `email` spans soft-deleted rows — AvailableEmailRule
+     * is built on exactly that, so a deleted account keeps its address until
+     * erasure takes the row away. The registration form learns this from
+     * validation. The machine paths have no form to validate: a directory or
+     * an identity provider hands over an address and provision() inserts it,
+     * so without asking first the insert raises a QueryException in the
+     * middle of somebody's sign-in.
+     */
+    public function addressIsFree(string $email): bool
+    {
+        return ! User::withTrashed()->where('email', $email)->exists();
+    }
+
+    /**
      * @param  bool|null  $autoApprove  Null asks Setting::ClientsAutoApprove,
      *                                  which is the right question for the
      *                                  public registration form. A caller

--- a/app/Modules/Identity/Ldap/LdapProvisioner.php
+++ b/app/Modules/Identity/Ldap/LdapProvisioner.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Modules\Audit\Action;
 use App\Modules\Clients\ClientProvisioning;
 use App\Modules\Identity\AuthSource;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 /**
@@ -52,6 +53,19 @@ class LdapProvisioner
         $identity = $this->ldap->attempt($email, $password);
 
         if ($identity === null) {
+            return null;
+        }
+
+        // Same reason as SocialProvisioner: a deleted account keeps its
+        // address until erasure removes the row, so provisioning over one
+        // raises a QueryException at the moment of login. Refused here, the
+        // sign-in fails the ordinary way instead, and a directory identity
+        // does not silently reclaim an account somebody deleted.
+        if (! $this->clients->addressIsFree($identity->email)) {
+            Log::warning('A directory identity was not provisioned: the address belongs to a deleted account.', [
+                'email' => $identity->email,
+            ]);
+
             return null;
         }
 

--- a/app/Modules/Identity/Social/SocialProvisioner.php
+++ b/app/Modules/Identity/Social/SocialProvisioner.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Modules\Audit\Action;
 use App\Modules\Clients\ClientProvisioning;
 use App\Modules\Identity\AuthSource;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 /**
@@ -41,6 +42,21 @@ class SocialProvisioner
     public function provision(SocialSettings $settings, SocialIdentity $identity, bool $autoApprove): ?User
     {
         if (! $settings->auto_provision || $identity->email === null) {
+            return null;
+        }
+
+        // A deleted account still holds its address, and the insert below
+        // would hit the unique index — a 500 in the middle of a sign-in.
+        // Refusing here gives the caller the same "there is no account here
+        // for that address" it gives every other unprovisionable identity,
+        // which is also all a stranger should learn: whether an address was
+        // once an account here is not the provider's to publish.
+        if (! $this->clients->addressIsFree($identity->email)) {
+            Log::warning('A provider identity was not provisioned: the address belongs to a deleted account.', [
+                'provider' => $settings->provider->value,
+                'email' => $identity->email,
+            ]);
+
             return null;
         }
 

--- a/tests/Feature/Auth/LdapAuthenticationTest.php
+++ b/tests/Feature/Auth/LdapAuthenticationTest.php
@@ -270,6 +270,27 @@ test('auto-provisioning creates a client, never staff, and signs them in', funct
     expect(ActivityLog::query()->where('action', Action::LdapClientProvisioned)->exists())->toBeTrue();
 });
 
+// A deleted account keeps its address: the unique index spans trashed
+// rows, which is what AvailableEmailRule is built on. Provisioning over
+// one used to raise a QueryException in the middle of the sign-in.
+test('a directory identity whose address belongs to a deleted account is refused, not crashed', function () {
+    enableLdap(autoProvision: true, autoApprove: true);
+    fakeDirectory(['gone@example.test' => ['password' => 'directory-pass', 'name' => 'Gone Again']]);
+
+    $gone = User::factory()->client()->create(['email' => 'gone@example.test']);
+    $gone->delete();
+
+    $this->post('/login', ['email' => 'gone@example.test', 'password' => 'directory-pass'])
+        ->assertSessionHasErrors('email');
+
+    $this->assertGuest();
+
+    // Nothing was created, and the deleted account was not resurrected.
+    expect(User::query()->where('email', 'gone@example.test')->exists())->toBeFalse()
+        ->and(User::withTrashed()->where('email', 'gone@example.test')->count())->toBe(1)
+        ->and(User::withTrashed()->where('email', 'gone@example.test')->sole()->trashed())->toBeTrue();
+});
+
 // The directory proves who you are; the installation still decides whether
 // it wants you. This falls out of the phase ordering with no special case.
 test('auto-provisioning honours the directory approval setting', function () {

--- a/tests/Feature/Auth/SocialLoginTest.php
+++ b/tests/Feature/Auth/SocialLoginTest.php
@@ -257,6 +257,25 @@ test('provisioning is refused when the provider may not create accounts', functi
     expect(User::query()->where('email', 'new@example.test')->exists())->toBeFalse();
 });
 
+test('an address belonging to a deleted account is refused, not crashed', function () {
+    // The unique index on email spans soft-deleted rows, so the insert used
+    // to raise a QueryException mid-callback. The refusal says no more than
+    // it says for any other address the provider cannot provision: whether
+    // one was once an account here is not the provider's to publish.
+    socialSettings(autoProvision: true, autoApprove: true);
+    fakeProvider(identity(email: 'gone@example.test', verified: true));
+
+    $gone = User::factory()->client()->create(['email' => 'gone@example.test']);
+    $gone->delete();
+
+    signInWith()->assertRedirect(route('login'));
+
+    $this->assertGuest();
+
+    expect(User::query()->where('email', 'gone@example.test')->exists())->toBeFalse()
+        ->and(User::withTrashed()->where('email', 'gone@example.test')->sole()->trashed())->toBeTrue();
+});
+
 test('a provisioned account waits for approval when the provider says so', function () {
     socialSettings(autoProvision: true, autoApprove: false);
     fakeProvider(identity(email: 'new@example.test', verified: true));


### PR DESCRIPTION
The unique index on `users.email` spans soft-deleted rows — `AvailableEmailRule`
is built on exactly that — so a deleted account keeps its address until erasure
removes the row. The registration form learns this from validation. The machine
paths have no form to validate: a directory or an identity provider hands over an
address and `ClientProvisioning::provision()` inserts it.

Measured on `main`, a client deleted earlier signing in through a provider that
may auto-provision:

```
GET /auth/google/callback → 500   (QueryException, unique constraint)
```

Same shape through LDAP at `POST /login`. Nothing is created, nobody is signed
in, and what the person meets is a server error.

**Fix.** Both provisioners ask `ClientProvisioning::addressIsFree()` first and
refuse. The social flow already has a refusal for an identity it cannot provision
— "There is no account here for that address." — which is also all a stranger
should learn: whether an address was once an account here is not the provider's
to publish. The LDAP flow falls through to the ordinary failed sign-in.

**Not changed (deliberate).**
- The deleted account is not resurrected, and not linked. Restoring one because a
  directory still lists the address is a decision for a person, not a side effect
  of somebody signing in.
- The registration form, which already refuses through validation.
- Everything about an address that belongs to a *live* account: linking,
  takeover refusals and the verified-email rules are untouched.

**Tests.** Two, one per path (`tests/Feature/Auth/LdapAuthenticationTest.php`,
`tests/Feature/Auth/SocialLoginTest.php`): the sign-in is refused, nothing is
created, and the trashed row is still trashed.

Counter-check: with the three application files reset to `main` and the tests
kept, those two files together go **2 failed / 45 passed**.

Full suite passes (**2107 passed / 2 skipped**, 11420 assertions; `main`
(`06c364d2`) measures 2105/2). PHPStan level 8 clean. `pint --test` is clean on
both test files and on the two provisioners; `ClientProvisioning.php` reports
`unary_operator_spaces, braces_position, not_operator_with_successor_space` here
and reports exactly the same on `main`'s version — nothing added. No frontend or
API controller touched, so `tsc`, ESLint and `scramble:export` were not run.

**Note on the flake.** One parallel run of this branch hit
`UpdateWelcomeTest > staff who may not read…` (`Ssr\Gateway is not
instantiable`), and the re-run was green. That was measured before #1711 landed;
it is that PR's `clear-compiled` flake rather than anything in this branch, and
this branch now sits on top of the merged fix.