### PR TITLE
Fail a zip build without handing the requester the server's reason

### DIFF
--- a/app/Modules/Files/Jobs/BuildZipDownloadJob.php
+++ b/app/Modules/Files/Jobs/BuildZipDownloadJob.php
@@ -245,9 +245,21 @@ class BuildZipDownloadJob implements ShouldQueue
                 @unlink($tempFile);
             }
 
+            // Same division as the write failure above: the reason is the
+            // operator's, the sentence is the requester's. An exception
+            // message here has already named a disk in practice — "Disk
+            // [x] does not have a configured driver." — and can name a
+            // server path, and this column is shown to whoever asked for
+            // the archive, including clients.
+            Log::error('A zip download could not be built.', [
+                'zip_download_id' => $zipDownload->id,
+                'exception' => $e::class,
+                'reason' => $e->getMessage(),
+            ]);
+
             $zipDownload->update([
                 'status' => ZipDownload::STATUS_FAILED,
-                'error' => $e->getMessage(),
+                'error' => 'The zip archive could not be built.',
             ]);
         }
     }
@@ -312,21 +324,50 @@ class BuildZipDownloadJob implements ShouldQueue
             throw new \RuntimeException('Could not create a temp file for '.$file->original_name);
         }
 
+        // Registered before anything else can fail. tempnam() has already
+        // created the file, and the caller's cleanup only knows the paths
+        // it was told about — so every throw between here and the end of
+        // the copy used to leave a zip-src- file behind for good.
+        $tempFiles[] = $tempPath;
+
         $stream = Storage::disk($file->disk)->readStream($file->path);
         $out = fopen($tempPath, 'wb');
 
         if ($stream === null || $out === false) {
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+
+            if ($out !== false) {
+                fclose($out);
+            }
+
             throw new \RuntimeException('Could not read '.$file->original_name.' from its storage disk.');
         }
 
-        stream_copy_to_stream($stream, $out);
-        fclose($out);
+        try {
+            // A copy that stops early is a truncated member added to the
+            // archive as though it were the file: the build reports ready,
+            // and the recipient gets something that opens and is wrong.
+            // fclose is checked for the same reason it is in
+            // LocalPartStore: it flushes, so a volume that filled on the
+            // last buffer fails there rather than here.
+            $copied = stream_copy_to_stream($stream, $out);
+            $flushed = fclose($out);
+            $out = false;
 
-        if (is_resource($stream)) {
-            fclose($stream);
+            if ($copied === false || ! $flushed) {
+                throw new \RuntimeException('Could not copy '.$file->original_name.' from its storage disk.');
+            }
+        } finally {
+            if ($out !== false) {
+                fclose($out);
+            }
+
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
         }
-
-        $tempFiles[] = $tempPath;
 
         return $tempPath;
     }

--- a/tests/Feature/Files/ZipDownloadsTest.php
+++ b/tests/Feature/Files/ZipDownloadsTest.php
@@ -338,6 +338,58 @@ test('a source file deleted after it was queued fails the build instead of servi
         ->and(Storage::disk('files')->exists("zips/{$zipDownload->id}.zip"))->toBeFalse();
 });
 
+// The write failure a few lines above it already keeps libzip's string out
+// of the requester's view, "a libzip string means nothing to them and can
+// name a server path". The catch-all around the whole build did the
+// opposite and stored the exception message.
+test('a build that throws tells the requester nothing about the server', function () {
+    $file = zipUploadFile($this->admin, 'contract.pdf');
+
+    // A disk name with no configured driver: Storage::disk() throws on
+    // resolution, and the message names the disk.
+    $file->update(['disk' => 'a-disk-that-is-not-configured']);
+
+    $zipDownload = ZipDownload::query()->create([
+        'requested_by' => $this->admin->id,
+        'status' => ZipDownload::STATUS_PENDING,
+        'file_ids' => [$file->id],
+        'folder_ids' => [],
+    ]);
+
+    (new BuildZipDownloadJob($zipDownload->id))->handle();
+
+    $zipDownload->refresh();
+
+    expect($zipDownload->status)->toBe(ZipDownload::STATUS_FAILED)
+        ->and($zipDownload->error)->toBe('The zip archive could not be built.')
+        ->and($zipDownload->error)->not->toContain('a-disk-that-is-not-configured');
+});
+
+test('a build that throws mid-copy leaves no temp file behind', function () {
+    // tempnam() creates the file before anything is copied into it, and the
+    // cleanup loop only knows the paths it was told about — so a throw
+    // between the two left a zip-src- file in the system temp directory for
+    // good.
+    $file = zipUploadFile($this->admin, 'contract.pdf');
+    $file->update(['disk' => 'files_external', 'path' => 'nowhere/contract.pdf']);
+
+    $zipDownload = ZipDownload::query()->create([
+        'requested_by' => $this->admin->id,
+        'status' => ZipDownload::STATUS_PENDING,
+        'file_ids' => [$file->id],
+        'folder_ids' => [],
+    ]);
+
+    $before = glob(sys_get_temp_dir().'/zip-src-*') ?: [];
+
+    (new BuildZipDownloadJob($zipDownload->id))->handle();
+
+    $after = glob(sys_get_temp_dir().'/zip-src-*') ?: [];
+
+    expect($zipDownload->refresh()->status)->toBe(ZipDownload::STATUS_FAILED)
+        ->and(array_diff($after, $before))->toBe([]);
+});
+
 // A build that blows the worker timeout is killed mid-run: handle()'s own
 // catch never executes, so without this hook the row would poll as pending
 // forever and the frontend would never stop.


### PR DESCRIPTION
`BuildZipDownloadJob` already draws this line, in the write-failure branch:
"What the requester sees stays generic: a libzip string means nothing to them and
can name a server path. An operator needs the opposite — 'disk full' and 'the
source file vanished' are different problems — so the reason goes to the log
instead."

Thirty-seven lines below it, the catch-all around the whole build stores
`$e->getMessage()` in the row the requester polls. Measured on `main`, a client
asking for an archive of a file whose disk is no longer configured:

```
error column           → "Disk [a-disk-that-is-not-configured] does not have a configured driver."
what the client is told → the same, verbatim
```

**Fix.** The reason goes to the log with the exception class; the row carries the
same kind of sentence `fail()` already uses.

**Two more in the same method, while here.**

- `tempnam()` creates the file, and `$tempFiles[]` was appended only *after* the
  copy finished. Every throw in between — a disk that will not resolve, a stream
  that will not open — left a `zip-src-` file in the system temp directory that
  nothing ever removes. It is now registered the moment it exists.
- The copy itself was unchecked. A copy that stops early is a truncated member
  added to the archive as though it were the file: the build reports ready and
  the recipient gets something that opens and is wrong. The copy and the `fclose`
  that flushes it are both checked, and both handles close on every path.

**Not changed (deliberate).**
- Comparing the copied byte count against `files.size`. A stale size column would
  then fail archives that are perfectly good, and the checks above already cover
  the failures that report themselves.
- The write-failure branch, its log line and its wording.
- The skipped-files reporting, which still says which files and why.

**Tests.** Two in `tests/Feature/Files/ZipDownloadsTest.php`: the failure message
names nothing about the server, and a build that throws mid-copy leaves no temp
file behind.

Counter-check: with `BuildZipDownloadJob.php` reset to `main` and the tests kept,
that file alone goes **2 failed / 35 passed**.

Full suite passes (**2107 passed / 2 skipped**, 11414 assertions; `main`
(`06c364d2`) measures 2105/2). PHPStan level 8 clean, `pint --test` clean on both
changed files. No frontend or API controller touched, so `tsc`, ESLint and
`scramble:export` were not run.

**Merge note.** Both files here were also touched by **#1715**
(`fix/zip-duplicate-selection`), which has since landed in `main`. That was the
closest pairing of the series: most of its hunks were in the selection walk and
these are in the catch-all, but both change `localPathFor()`, and both append to
`ZipDownloadsTest.php`.

Because a clean textual merge of two changes to one method says nothing about
the result, the combination was run rather than assumed — first as a merged tree
while #1715 was still open, and now directly, since this branch is rebased on
top of it. `ZipDownloadsTest` is 37 passed, and the counter-check above is
measured against `main` with #1715 already in it.