### PR TITLE
Give a download's presigned URL a minute rather than an hour

### DIFF
--- a/app/Modules/Files/Delivery/StoredFileResponse.php
+++ b/app/Modules/Files/Delivery/StoredFileResponse.php
@@ -30,30 +30,61 @@ use Illuminate\Support\Facades\Storage;
  * static handler answers those with 206s on its own, dropping the
  * Content-Length below in favour of the range it actually served.
  *
+ * The two paths are not equally revocable, which is why the lifetimes
+ * below differ. X-Accel-Redirect authorises one response: nginx serves
+ * these bytes, now, to this request. A presigned URL is a bearer
+ * credential — whoever holds it can fetch the file without passing the
+ * caller's checks again, and it outlives them: a download cap that is
+ * spent in the meantime, an expires_at that falls in between, an
+ * assignment that is withdrawn. Nothing here can revoke one, so the only
+ * dial is how long it lasts.
+ *
+ * A download needs to survive being followed, which is a redirect and a
+ * request: a minute is generous. A preview is held by the player for as
+ * long as somebody watches, and each seek outside the buffer is a fresh
+ * Range request against the same URL, so it keeps the hour. That is the
+ * trade, stated rather than left in a single number.
+ *
  * Callers of inline() must have established that the mime type is
  * inline-safe first; PreviewKind is the allowlist, and the reason there
  * is one.
  */
 class StoredFileResponse
 {
+    /**
+     * Long enough for a browser, a download manager or a queued transfer
+     * to follow the redirect and start the request. An object store
+     * checks the signature when the request arrives, not while it runs,
+     * so a transfer that begins inside this window finishes however long
+     * it takes.
+     */
+    private const DOWNLOAD_LINK_SECONDS = 60;
+
+    /**
+     * A preview is watched, not fetched: the player holds this URL and
+     * issues a Range request every time somebody seeks past the buffer,
+     * so it has to outlive the viewing rather than the redirect.
+     */
+    private const PREVIEW_LINK_SECONDS = 3600;
+
     /** Shown in place — a preview. */
     public function inline(File $file): Response|RedirectResponse
     {
-        return $this->make($file, ContentDisposition::inline($file->original_name));
+        return $this->make($file, ContentDisposition::inline($file->original_name), self::PREVIEW_LINK_SECONDS);
     }
 
     /** Handed over — a download. */
     public function attachment(File $file): Response|RedirectResponse
     {
-        return $this->make($file, ContentDisposition::attachment($file->original_name));
+        return $this->make($file, ContentDisposition::attachment($file->original_name), self::DOWNLOAD_LINK_SECONDS);
     }
 
-    private function make(File $file, string $disposition): Response|RedirectResponse
+    private function make(File $file, string $disposition, int $linkSeconds): Response|RedirectResponse
     {
         if ($file->disk !== 'files') {
             $url = Storage::disk($file->disk)->temporaryUrl(
                 $file->path,
-                now()->addHour(),
+                now()->addSeconds($linkSeconds),
                 ['ResponseContentDisposition' => $disposition],
             );
 

--- a/tests/Feature/Files/DownloadDispositionTest.php
+++ b/tests/Feature/Files/DownloadDispositionTest.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use App\Modules\Files\Models\File;
 use App\Support\ContentDisposition;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 
 beforeEach(function () {
@@ -60,4 +62,71 @@ test('downloads of files with non-ascii names send both header forms on the wire
     expect($header)
         ->toContain('attachment; filename="')
         ->toContain("filename*=utf-8''".rawurlencode('año contable — resumen.pdf'));
+});
+
+/*
+|--------------------------------------------------------------------------
+| How long a presigned URL stays usable
+|--------------------------------------------------------------------------
+|
+| On the local disk a delivery is an X-Accel-Redirect: it authorises one
+| response, to one request. On external storage it is a presigned URL,
+| which is a bearer credential -- forwardable, and valid whatever happens
+| to the file or the caller's checks in the meantime. Nothing can revoke
+| one, so its lifetime is the only dial there is.
+|
+*/
+
+test('a download link outlives the redirect and not much else', function () {
+    $seen = [];
+
+    Storage::fake('files_external');
+    Storage::disk('files_external')->buildTemporaryUrlsUsing(
+        function (string $path, $expiration, array $options) use (&$seen): string {
+            $seen[] = $expiration;
+
+            return 'https://storage.example.test/'.$path;
+        }
+    );
+
+    $file = uploadDocumentFile($this->admin, 'report.pdf');
+    $file->update(['disk' => 'files_external']);
+
+    $this->actingAs($this->admin)->get("/files/{$file->id}/download")->assertRedirect();
+
+    expect($seen)->toHaveCount(1)
+        ->and($seen[0]->getTimestamp())->toBeLessThanOrEqual(now()->addSeconds(60)->getTimestamp())
+        ->and($seen[0]->getTimestamp())->toBeGreaterThan(now()->addSeconds(30)->getTimestamp());
+});
+
+test('a preview link lasts as long as somebody might watch', function () {
+    // The other half of the trade: a player holds this URL and asks it for
+    // ranges every time the viewer seeks past the buffer, so a minute would
+    // break playback of anything longer than a minute.
+    $seen = [];
+
+    Storage::fake('files_external');
+    Storage::disk('files_external')->buildTemporaryUrlsUsing(
+        function (string $path, $expiration, array $options) use (&$seen): string {
+            $seen[] = $expiration;
+
+            return 'https://storage.example.test/'.$path;
+        }
+    );
+
+    // Uploaded rather than factory-made, so it is a real previewable file;
+    // FilePreviewTest's helper is private to that file (Pest globals).
+    $this->actingAs($this->admin)->post('/files', [
+        'file' => UploadedFile::fake()->create('clip.mp4', 16, 'video/mp4'),
+        'name' => '',
+        'description' => '',
+    ]);
+
+    $file = File::query()->latest('id')->firstOrFail();
+    $file->update(['disk' => 'files_external']);
+
+    $this->actingAs($this->admin)->get("/files/{$file->id}/preview")->assertRedirect();
+
+    expect($seen)->toHaveCount(1)
+        ->and($seen[0]->getTimestamp())->toBeGreaterThan(now()->addMinutes(50)->getTimestamp());
 });


### PR DESCRIPTION
`StoredFileResponse` hands external storage a presigned URL good for an hour,
whatever the delivery is for (`:51`).

That URL is a bearer credential. Whoever holds it fetches the file without
passing any of the caller's checks again, and it outlives them: a download cap
spent in the meantime, an `expires_at` that falls inside the hour, an assignment
withdrawn — none of them reach it, and nothing in the application can revoke one.
It is also forwardable, which the local path is not: `X-Accel-Redirect`
authorises one response, to one request. So the same file has materially
different delivery semantics depending on which disk it happens to live on, and
the difference is invisible from every call site.

**Fix.** The two deliveries stop sharing one window.

- **Download → 60 seconds.** It only has to survive being followed: a redirect
  and a request. An object store checks the signature when the request *arrives*
  rather than while it runs, so a transfer that starts inside the window finishes
  however long it takes.
- **Preview → the hour it had.** A preview is watched, not fetched: the player
  holds the URL and issues a Range request every time somebody seeks past the
  buffer, so a minute would break playback of anything longer than a minute.

The class docblock now states that trade, instead of leaving it in a single
number.

**Not changed (deliberate).**
- The local path, which was never affected.
- Counting and authorisation, which stay with the callers — this class still
  authorises nothing and still knows nothing about who is asking.
- The preview window. Shrinking it needs the player to re-ask the application
  for a fresh URL mid-playback, which is a feature, not a constant.
- **What this does not fix:** within its window a download URL is still
  unrevocable and forwardable. What the minute takes away is every *asynchronous*
  way one leaks — a proxy or access log read later, a Referer header, a link
  pasted into a chat, a screenshot — because all of those need somebody to come
  back to the URL. What survives is the synchronous case: an attacker already
  positioned to use it the instant it is issued. That is a far smaller class than
  "forwardable", and it is the honest description of what is left. Closing it
  needs the object store's own request conditions or a proxying delivery path,
  and both are bigger decisions than a constant.
- **And it does not touch previews at all**, which is where the bearer window is
  widest: `inline()` keeps the hour, and its two callers are the signed-in
  preview and `PublicGroupsController::preview`, which is a public route reachable
  without an account. So this narrows the download path and leaves the more
  exposed one exactly as it was. That is the right order — a download URL is the
  one that carries the whole file to somebody who never passed a check — but an
  installation's exposure is reduced on one path, not removed.

**What it costs, from the same premise.** If the store checks the signature when
a request arrives, then a *resumed* request arrives late: an interrupted
download that a browser or a download manager retries more than a minute later
gets a 403 where an hour tolerated it. The transfer already running is
unaffected — only picking it back up is. The way out is the ordinary one, ask
the application again and get a fresh URL, so this is a nuisance on a large file
over a poor connection rather than a loss. It is the real price of the change
and belongs next to the benefit.

Two things bound that price, both checked rather than assumed. **Every caller of
this class is a controller answering a live request** — `FileDownloadController`,
`PublicShareController`, `PublicGroupsController`, `FileThumbnailController` —
so nothing queues, stores or mails one of these URLs, and no automated flow can
meet an expired one. And **zip bundles never take this path**: they are built on
the local disk and served with `X-Accel-Redirect` unconditionally
(`ZipDownloadsController:190`), so the largest downloads an installation makes
are untouched by the shortened window. What is left is a single external-disk
file, resumed by hand more than a minute later.

**Tests.** Two in `tests/Feature/Files/DownloadDispositionTest.php`, one per
window, reading the expiration the signer is handed
(`buildTemporaryUrlsUsing`).

Counter-check: with `StoredFileResponse.php` reset to `main` and the tests kept,
that file alone goes **1 failed / 6 passed** — the download link is an hour long.
The preview test stays green either way, which is the point of it.

Full suite passes (**2107 passed / 2 skipped**, 11417 assertions; `main`
(`06c364d2`) measures 2105/2). PHPStan level 8 clean, `pint --test` clean on both
changed files. No frontend or API controller touched, so `tsc`, ESLint and
`scramble:export` were not run.