### PR TITLE
Name the quota a client is actually held to when an upload is refused

### DIFF
--- a/app/Modules/Files/Http/Controllers/ChunkedUploadsController.php
+++ b/app/Modules/Files/Http/Controllers/ChunkedUploadsController.php
@@ -98,7 +98,14 @@ class ChunkedUploadsController extends Controller
 
             if ($quotaBytes > 0 && $this->storageUsage->usedBytes($user) + (int) $validated['size'] > $quotaBytes) {
                 throw ValidationException::withMessages([
-                    'size' => __('This upload would exceed your storage quota of :quota MB.', ['quota' => (string) $user->storage_quota_mb]),
+                    'size' => __('This upload would exceed your storage quota of :quota MB.', [
+                        // The resolved quota, not the column: a client who
+                        // was never given one of their own carries 0 there
+                        // and inherits the site default, so printing the
+                        // column reads "your storage quota of 0 MB" at the
+                        // moment somebody is asking what their limit is.
+                        'quota' => (string) $this->storageUsage->quotaMb($user),
+                    ]),
                 ]);
             }
         }
@@ -306,7 +313,9 @@ class ChunkedUploadsController extends Controller
                 $session->delete();
 
                 throw ValidationException::withMessages([
-                    'size' => __('This upload would exceed your storage quota of :quota MB.', ['quota' => (string) $user->storage_quota_mb]),
+                    'size' => __('This upload would exceed your storage quota of :quota MB.', [
+                        'quota' => (string) $this->storageUsage->quotaMb($user),
+                    ]),
                 ]);
             }
         }

--- a/tests/Feature/Clients/StorageQuotaTest.php
+++ b/tests/Feature/Clients/StorageQuotaTest.php
@@ -191,6 +191,58 @@ test('a client with no custom quota is limited by the site default once one is s
     ])->assertJsonValidationErrors('size');
 });
 
+test('the rejection names the quota the client is actually held to', function () {
+    // storage_quota_mb of 0 means "no quota of their own", and the site
+    // default is what is then enforced — so the column is the one number
+    // the message must not print.
+    app(Settings::class)->set(Setting::DefaultClientStorageQuotaMb, 1);
+    $client = User::factory()->client()->create(['storage_quota_mb' => 0]);
+    grantUploadPermission($client);
+    makeClientFile($client, 1000 * 1024);
+    $this->actingAs($client);
+
+    $response = $this->postJson('/uploads', [
+        'filename' => 'over-the-default.pdf',
+        'size' => 200 * 1024,
+        'type' => 'application/pdf',
+    ])->assertJsonValidationErrors('size');
+
+    expect($response->json('errors.size.0'))->toBe('This upload would exceed your storage quota of 1 MB.');
+});
+
+test('the same is true when the real byte count is what pushes them over', function () {
+    // The completion check is a second copy of the same sentence, and had
+    // the same bug.
+    app(Settings::class)->set(Setting::DefaultClientStorageQuotaMb, 1);
+    $client = User::factory()->client()->create(['storage_quota_mb' => 0]);
+    grantUploadPermission($client);
+    makeClientFile($client, 1000 * 1024);
+    $this->actingAs($client);
+
+    $sessionId = createChunkedSession(11, 'lied-about-size.txt');
+    putChunkedPart($sessionId, 1, str_repeat('a', 50 * 1024));
+
+    $response = $this->postJson("/uploads/{$sessionId}/complete")->assertJsonValidationErrors('size');
+
+    expect($response->json('errors.size.0'))->toBe('This upload would exceed your storage quota of 1 MB.');
+});
+
+test('a client with a quota of their own still sees their own number', function () {
+    app(Settings::class)->set(Setting::DefaultClientStorageQuotaMb, 250);
+    $client = User::factory()->client()->create(['storage_quota_mb' => 1]);
+    grantUploadPermission($client);
+    makeClientFile($client, 1000 * 1024);
+    $this->actingAs($client);
+
+    $response = $this->postJson('/uploads', [
+        'filename' => 'over-their-own.pdf',
+        'size' => 200 * 1024,
+        'type' => 'application/pdf',
+    ])->assertJsonValidationErrors('size');
+
+    expect($response->json('errors.size.0'))->toBe('This upload would exceed your storage quota of 1 MB.');
+});
+
 test('a client\'s own custom quota is unaffected by later changes to the site default', function () {
     app(Settings::class)->set(Setting::DefaultClientStorageQuotaMb, 1);
     $client = User::factory()->client()->create(['storage_quota_mb' => 500]); // an explicit, much larger override


### PR DESCRIPTION
`ClientStorageUsage::quotaMb()` exists because a client's own
`storage_quota_mb` of 0 does not mean "unlimited" — it means "no quota of their
own", and the site default is what is then enforced. Its docblock says so.

Both chunked-upload quota checks enforce the resolved limit through
`quotaBytes()` and then print the raw column in the rejection
(`ChunkedUploadsController.php:101` and `:309`). Measured on `main`
(`d58e4830`), a client with `storage_quota_mb = 0` and a site default of 1 MB:

```
"This upload would exceed your storage quota of 0 MB."
```

That is every client who was never given a quota of their own, including every
self-registered one — and the sentence appears at the one moment somebody is
trying to find out what their limit is.

**Fix.** Print `quotaMb()`, which is what the check enforced. The API's
single-request upload already does exactly this for the same sentence
(`Api/FilesController.php:208`), so the two chunked copies now agree with it.

**Not changed (deliberate).** The enforcement itself is correct and untouched;
only the number in the message changes. The unlimited case (`quotaMb()` of 0)
never reaches these branches, because `quotaBytes() > 0` guards them.

**Tests.** Three in `tests/Feature/Clients/StorageQuotaTest.php`: the inherited
default is named at session creation and again at completion, and a client with
an explicit quota still sees their own number.

Counter-check: with `ChunkedUploadsController.php` reset to `main` and the tests
kept, that file alone goes **2 failed / 14 passed**. The third test stays green
either way, by design.

Full suite passes (**2108 passed / 2 skipped**, 11420 assertions; `main` (`06c364d2`) measures 2105/2). PHPStan level 8 clean, `pint --test` clean on both changed files. No
frontend or API controller touched, so `tsc`, ESLint and `scramble:export` were
not run.