### PR TITLE
Stop an editable-once checkbox locking before anybody ticks it

### DIFF
--- a/app/Modules/Clients/ClientPortalCustomFields.php
+++ b/app/Modules/Clients/ClientPortalCustomFields.php
@@ -158,7 +158,23 @@ class ClientPortalCustomFields
      */
     private function isLocked(ClientCustomField $field, BaseCollection $values): bool
     {
-        return $field->client_editability === ClientFieldEditability::EditableOnce
-            && filled($values->get($field->id));
+        if ($field->client_editability !== ClientFieldEditability::EditableOnce) {
+            return false;
+        }
+
+        $stored = $values->get($field->id);
+
+        // A checkbox has a stored value from the first save onwards: an
+        // unticked box is written as '0', and filled('0') is true. Asking
+        // "is anything stored" therefore locked the field on the first save
+        // of the form it sits on, whatever the client had chosen — and a
+        // box they never ticked can then never be ticked. '0' is the
+        // absence of a decision, which is the state the other types express
+        // as null, so it is what an unlocked checkbox looks like.
+        if ($field->type === ClientCustomFieldType::Checkbox) {
+            return $stored === '1';
+        }
+
+        return filled($stored);
     }
 }

--- a/tests/Feature/Clients/ClientPortalCustomFieldsTest.php
+++ b/tests/Feature/Clients/ClientPortalCustomFieldsTest.php
@@ -104,6 +104,66 @@ test('an editable_once field locks after the client sets it once', function () {
         ->toBe('1');
 });
 
+test('an editable_once checkbox is not locked by never having been ticked', function () {
+    // Saving the form writes '0' for an unticked box, and filled('0') is
+    // true — so the field locked itself on the first save of the page it
+    // sits on, before the client had decided anything. A text field left
+    // empty stores null and stays open, which is the behaviour this now
+    // matches.
+    $client = User::factory()->client()->create();
+
+    $field = ClientCustomField::query()->create([
+        'name' => 'newsletter', 'label' => 'Send me the newsletter', 'type' => 'checkbox',
+        'required' => false, 'client_editability' => 'editable_once',
+        'client_contexts' => ['account_edit'],
+    ]);
+
+    // A save that has nothing to do with the checkbox.
+    $this->actingAs($client)->patch('/settings/profile', [
+        'name' => 'Renamed', 'email' => $client->email,
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->actingAs($client)->get('/settings/profile')->assertInertia(
+        fn (AssertableInertia $page) => $page->where('custom_fields.0.locked', false),
+    );
+
+    // And the one decision they are entitled to still lands.
+    $this->actingAs($client)->patch('/settings/profile', [
+        'name' => 'Renamed', 'email' => $client->email,
+        'custom_field_values' => [$field->id => '1'],
+    ])->assertSessionDoesntHaveErrors();
+
+    expect(ClientCustomFieldValue::query()
+        ->where('client_custom_field_id', $field->id)->where('user_id', $client->id)->value('value'))->toBe('1');
+
+    $this->actingAs($client)->get('/settings/profile')->assertInertia(
+        fn (AssertableInertia $page) => $page->where('custom_fields.0.locked', true),
+    );
+});
+
+test('an editable_once text field is unchanged by all this', function () {
+    $client = User::factory()->client()->create();
+
+    $field = ClientCustomField::query()->create([
+        'name' => 'vat', 'label' => 'VAT number', 'type' => 'text',
+        'required' => false, 'client_editability' => 'editable_once',
+        'client_contexts' => ['account_edit'],
+    ]);
+
+    $this->actingAs($client)->patch('/settings/profile', [
+        'name' => $client->name, 'email' => $client->email,
+        'custom_field_values' => [$field->id => 'ATU12345678'],
+    ])->assertSessionDoesntHaveErrors();
+
+    $this->actingAs($client)->patch('/settings/profile', [
+        'name' => $client->name, 'email' => $client->email,
+        'custom_field_values' => [$field->id => 'changed'],
+    ])->assertSessionDoesntHaveErrors();
+
+    expect(ClientCustomFieldValue::query()
+        ->where('client_custom_field_id', $field->id)->where('user_id', $client->id)->value('value'))->toBe('ATU12345678');
+});
+
 test('a required checkbox in a client context must actually be checked', function () {
     $client = User::factory()->client()->create();
 


### PR DESCRIPTION
`ClientPortalCustomFields::save()` writes `'0'` for an unticked checkbox, and
`filled('0')` is **true** in Laravel. `isLocked()` asks whether anything is
stored — so an `editable_once` checkbox locked itself the first time the client
saved the page it sits on, whatever they had chosen.

A box they never ticked could then never be ticked, and the one edit the setting
promises was spent on a decision they had not made. A text field left empty
stores `null` and stays open; that asymmetry is the bug, and `'0'` is the absence
of a decision in exactly the way `null` is for every other type.

**Fix.** A checkbox locks on a stored `'1'` and nothing else. Every other type
keeps `filled()`.

**Not changed (deliberate).**
- What `save()` stores. `'0'` remains a recorded "no" — the API's client create
  writes it too, and reading a checkbox as null would be a different change.
- The existing behaviour after a real tick: the client cannot untick it, and the
  test that pins that is untouched.
- Fields that are `editable` or `hidden`.

**Tests.** Two in `tests/Feature/Clients/ClientPortalCustomFieldsTest.php`: an
unrelated profile save leaves the box open, and the tick that follows still lands
and locks it; and an editable-once *text* field behaves exactly as before.

Counter-check: with `ClientPortalCustomFields.php` reset to `main` and the tests
kept, that file alone goes **1 failed / 5 passed**. The text-field test stays
green either way, which is the point of it.

Full suite passes (**2107 passed / 2 skipped**, 11435 assertions; `main`
(`06c364d2`) measures 2105/2). PHPStan level 8 clean, `pint --test` clean on both
changed files. No frontend or API controller touched, so `tsc`, ESLint and
`scramble:export` were not run.