### PR TITLE
Put a client on the roster of the scoped staff member who created them

### DIFF
--- a/app/Modules/Clients/Http/Controllers/Api/ClientsController.php
+++ b/app/Modules/Clients/Http/Controllers/Api/ClientsController.php
@@ -153,6 +153,20 @@ class ClientsController extends Controller
 
         $this->activity->log(Action::UserCreated, subject: $client);
 
+        $creator = $request->user();
+        assert($creator !== null);
+
+        // A client-scoped creator would otherwise lose the client they just
+        // made. guardTarget() answers 404 for anything off their roster, so
+        // the record they created is not theirs to open, and
+        // StaffLibraryScope::clients() leaves it out of their list as well —
+        // the client exists, is welcomed by email, and is invisible to the
+        // person who made it. Their own roster is where a client they
+        // created belongs; an unscoped creator has no roster to add to.
+        if ($creator->isClientScoped()) {
+            $creator->assignedClients()->attach($client->id);
+        }
+
         $this->saveCustomFieldValues($client, $validated['custom_field_values'] ?? []);
 
         if ($this->settings->get(Setting::EmailNotificationsEnabled) === true) {

--- a/app/Modules/Clients/Http/Controllers/ClientsController.php
+++ b/app/Modules/Clients/Http/Controllers/ClientsController.php
@@ -154,6 +154,20 @@ class ClientsController extends Controller
 
         $this->activity->log(Action::UserCreated, subject: $client);
 
+        $creator = $request->user();
+        assert($creator !== null);
+
+        // A client-scoped creator would otherwise lose the client they just
+        // made. guardTarget() answers 404 for anything off their roster, so
+        // the record they created is not theirs to open, and
+        // StaffLibraryScope::clients() leaves it out of their list as well —
+        // the client exists, is welcomed by email, and is invisible to the
+        // person who made it. Their own roster is where a client they
+        // created belongs; an unscoped creator has no roster to add to.
+        if ($creator->isClientScoped()) {
+            $creator->assignedClients()->attach($client->id);
+        }
+
         $this->saveCustomFieldValues($client, $validated['custom_field_values'] ?? []);
 
         if ($this->settings->get(Setting::EmailNotificationsEnabled) === true) {
@@ -166,7 +180,7 @@ class ClientsController extends Controller
         // Fall back to the create form: it shares this route's own gate, so
         // it is reachable by exactly whoever just created the record, and
         // the success toast shows there.
-        $target = $request->user()?->can('edit_clients')
+        $target = $creator->can('edit_clients')
             ? redirect()->route('clients.edit', $client)
             : redirect()->route('clients.create');
 

--- a/tests/Feature/Api/ClientsTest.php
+++ b/tests/Feature/Api/ClientsTest.php
@@ -9,6 +9,8 @@ use App\Modules\Clients\ClientCustomFieldType;
 use App\Modules\Clients\Models\ClientCustomField;
 use App\Modules\Clients\Models\ClientCustomFieldValue;
 use App\Modules\Files\Models\File;
+use App\Modules\Identity\Models\Role;
+use App\Modules\Identity\Models\RolePermission;
 use App\Modules\Identity\Permissions\Permission;
 use Illuminate\Support\Facades\Storage;
 
@@ -97,6 +99,32 @@ test('a client can be created', function () {
     expect($client->isClient())->toBeTrue()
         ->and($client->active)->toBeTrue()
         ->and(ActivityLog::query()->where('action', Action::UserCreated)->exists())->toBeTrue();
+});
+
+test('a client-scoped token keeps the client it creates', function () {
+    // The API twin of the same rule: without the roster entry, the token's
+    // owner gets a 404 from every route that binds the client they just
+    // created, including show and update.
+    $role = Role::query()->create(['name' => 'Scoped creator', 'client_scoped' => true]);
+    RolePermission::query()->insert([
+        ['role_id' => $role->id, 'permission' => Permission::ManageClients->value],
+        ['role_id' => $role->id, 'permission' => Permission::CreateClients->value],
+        ['role_id' => $role->id, 'permission' => Permission::EditClients->value],
+    ]);
+    $creator = User::factory()->create(['role_id' => $role->id]);
+    $token = $creator->createToken('t', [
+        Permission::ManageClients->value,
+        Permission::CreateClients->value,
+        Permission::EditClients->value,
+    ])->plainTextToken;
+
+    $id = $this->withToken($token)->postJson('/api/v1/clients', [
+        'name' => 'Brand New',
+        'email' => 'api-brand-new@example.com',
+        'password' => 'super-secret-password',
+    ])->assertCreated()->json('data.id');
+
+    $this->withToken($token)->getJson("/api/v1/clients/{$id}")->assertOk();
 });
 
 test('a required custom field is enforced on create', function () {

--- a/tests/Feature/Clients/ClientsManagementTest.php
+++ b/tests/Feature/Clients/ClientsManagementTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 use App\Models\User;
 use App\Modules\Audit\Action;
 use App\Modules\Audit\ActivityLog;
+use App\Modules\Identity\Models\Role;
+use App\Modules\Identity\Models\RolePermission;
+use App\Modules\Identity\Permissions\Permission;
 use App\Modules\Identity\Permissions\SystemRole;
 use App\Modules\Identity\UserType;
 use App\Modules\Platform\Capabilities\Edition;
@@ -12,6 +15,54 @@ use Inertia\Testing\AssertableInertia;
 
 beforeEach(function () {
     $this->admin = User::factory()->create();
+});
+
+/*
+|--------------------------------------------------------------------------
+| A scoped creator keeps what they create
+|--------------------------------------------------------------------------
+*/
+
+test('a client-scoped creator can open the client they just made', function () {
+    // guardTarget() answers 404 for anything off the roster, and
+    // StaffLibraryScope::clients() leaves it out of the list -- so without
+    // the roster entry the record exists, is welcomed by email, and is
+    // invisible to the person who created it.
+    $role = Role::query()->create(['name' => 'Scoped creator', 'client_scoped' => true]);
+    RolePermission::query()->insert([
+        ['role_id' => $role->id, 'permission' => Permission::ManageClients->value],
+        ['role_id' => $role->id, 'permission' => Permission::CreateClients->value],
+        ['role_id' => $role->id, 'permission' => Permission::EditClients->value],
+    ]);
+    $creator = User::factory()->create(['role_id' => $role->id]);
+
+    $this->actingAs($creator)->post('/clients', [
+        'name' => 'Brand New',
+        'email' => 'brand-new@example.com',
+        'password' => 'super-secret-password',
+        'password_confirmation' => 'super-secret-password',
+    ])->assertRedirect();
+
+    $client = User::query()->where('email', 'brand-new@example.com')->sole();
+
+    $this->actingAs($creator)->get("/clients/{$client->id}")->assertOk();
+
+    $props = $this->actingAs($creator)->get('/clients')->assertOk()->viewData('page')['props'];
+    expect(collect($props['clients'])->pluck('name')->all())->toContain('Brand New');
+});
+
+test('an unscoped creator gains no roster entry from creating a client', function () {
+    // Nothing to add to: an unscoped staff member sees every client
+    // already, and a roster entry would change what assignedClients means
+    // for them.
+    $this->actingAs($this->admin)->post('/clients', [
+        'name' => 'Also New',
+        'email' => 'also-new@example.com',
+        'password' => 'super-secret-password',
+        'password_confirmation' => 'super-secret-password',
+    ])->assertRedirect();
+
+    expect($this->admin->refresh()->assignedClients()->count())->toBe(0);
 });
 
 test('the index lists clients only — staff never appear', function () {


### PR DESCRIPTION
A client-scoped staff member with `create_clients` creates a client and loses it
in the same request. `guardTarget()` answers 404 for anything off their roster,
and `StaffLibraryScope::clients()` leaves it out of their list — so the record
exists, is logged, is welcomed by email, and is invisible to the person who made
it. `store()` redirects to the edit page, which is exactly where they land:

```
POST /clients        → 302 → /clients/4
on_creator_roster    → false
GET /clients/4/edit  → 404
clients listed       → ["Mine"]      the new client is not among them
```

**Fix.** The new client is attached to the creator's roster when the creator is
client-scoped. That is where a client they created belongs — the roster is the
same list `assignedClients` already uses for everything else they may reach.

The API twin does the same, for the same reason: a scoped token gets a 404 from
every route that binds the client it just created.

**Not changed (deliberate).**
- Unscoped creators gain nothing. They see every client already, and a roster
  entry would change what `assignedClients` means for them.
- The seat guard, the welcome mail, the activity entry and the redirect fallback
  for a creator without `edit_clients` — all untouched.
- Nothing is attached retroactively. Clients created before this change stay
  where they are; an installation that wants them assigned can do it from the
  staff member's own edit screen.

**Tests.** Three: the scoped creator can open and list the client, an unscoped
creator gains no roster entry, and the API twin behaves like the web
(`tests/Feature/Clients/ClientsManagementTest.php`, `tests/Feature/Api/ClientsTest.php`).

Counter-check: with both controllers reset to `main` and the tests kept, the two
files together go **2 failed / 29 passed**. The unscoped-creator test stays green
either way, by design.

Full suite passes (**2108 passed / 2 skipped**, 11417 assertions; `main`
(`06c364d2`) measures 2105/2). PHPStan level 8 clean. `php artisan
scramble:export` produces a `docs/api/openapi.json` byte-identical to `main`'s.
`pint --test` is clean on both test files; the two controllers report
`unary_operator_spaces, braces_position, not_operator_with_successor_space` here
and report exactly the same on `main`'s versions — nothing added. No frontend
change, so `tsc`/ESLint were not run.

**Merge note.** This is the busiest file set of the series, and everything in it
is in a different method:

- **#1709** touched both controllers, in `update()`, and has since landed in
  `main` — so this branch is rebased on top of it rather than beside it.
- `fix/reassign-candidates-scope` touches `ClientsController.php`, in `index()`
  and `edit()`.
- `fix/api-patch-custom-fields` touches `Api/ClientsController.php` and
  `tests/Feature/Api/ClientsTest.php` — the custom-field pass and one line in
  `update()`.
- This change is in `store()` on both sides.

The three that remain merge together with git's own machinery leaving both
controllers auto-merged and no conflict between them, and the counter-check
above is measured against `main` with #1709 already in it. The independence is
behavioural as well as textual: a roster attachment moves no seat count, since
seats are counted by `active` and `account_requested` and this changes neither.