### PR TITLE
Claim a TOTP code atomically instead of checking then writing

### DIFF
--- a/app/Modules/Identity/TwoFactor/TwoFactorService.php
+++ b/app/Modules/Identity/TwoFactor/TwoFactorService.php
@@ -62,19 +62,20 @@ class TwoFactorService
 
         $replayKey = "two-factor.used.{$user->id}.".hash('sha256', $code);
 
-        if (Cache::has($replayKey)) {
-            return false;
-        }
-
         if ($this->engine->verifyKey($secret, $code) === false) {
             return false;
         }
 
-        // A TOTP code is valid for one window either side; block reuse
-        // for slightly longer than that.
-        Cache::put($replayKey, true, now()->addSeconds(90));
-
-        return true;
+        // Claiming the code *is* the answer. Cache::add writes only if the
+        // key is absent, so of two requests carrying the same valid code
+        // exactly one is told true — where has()-then-put() let both read
+        // "unused" before either wrote, and a code intercepted once could
+        // be spent twice inside its window. Same mechanism, and the same
+        // reason, as the preview log's debounce.
+        //
+        // A TOTP code is valid for one window either side; the claim
+        // outlives that by a little.
+        return Cache::add($replayKey, true, now()->addSeconds(90));
     }
 
     /**

--- a/tests/Feature/Identity/TwoFactorTest.php
+++ b/tests/Feature/Identity/TwoFactorTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use App\Modules\Identity\TwoFactor\TwoFactorService;
 use Illuminate\Support\Facades\Cache;
 use PragmaRX\Google2FA\Google2FA;
 
@@ -87,6 +88,33 @@ test('a totp code cannot be replayed', function () {
         ->assertSessionHasErrors('code');
 
     $this->assertGuest();
+});
+
+// The replay guard used to read, verify, then write. Two requests carrying
+// the same code could both read "unused" before either wrote, and both be
+// told yes -- which is the whole window an intercepted code has. This is
+// that interleaving: the second request's read lands before the winner's
+// write, so the key looks free and is not.
+test('a code already claimed by another request in flight is refused', function () {
+    $user = User::factory()->create();
+    $secret = enableTwoFactor($user);
+
+    $code = app(Google2FA::class)->getCurrentOtp($secret);
+
+    // The winner of the race has claimed the code.
+    Cache::put('two-factor.used.'.$user->id.'.'.hash('sha256', $code), true, now()->addSeconds(90));
+
+    // The loser read before that write landed, so its has() still reports
+    // the key as free. Only that one answer is stale — everything else is
+    // the real store — which leaves the claim itself as the deciding call.
+    $stale = Mockery::mock(Cache::store())->makePartial();
+    $stale->shouldReceive('has')->andReturnFalse();
+
+    config()->set('cache.stores.stale-read', ['driver' => 'stale-read']);
+    Cache::extend('stale-read', fn () => $stale);
+    Cache::setDefaultDriver('stale-read');
+
+    expect(app(TwoFactorService::class)->verify($user->refresh(), $code))->toBeFalse();
 });
 
 test('a recovery code logs in and is consumed', function () {


### PR DESCRIPTION
`TwoFactorService::verify()` asked `Cache::has()`, verified the code, then
`Cache::put()`. Between the read and the write the key is free, so two requests
carrying the same code can both be told yes — which is precisely what the replay
guard exists to prevent, and the window an intercepted code has is the whole of
its validity either side.

The codebase already names the right mechanism for this shape, in the preview
log: "`Cache::add` is the whole mechanism: it writes only if the key is absent,
so the first request through the window logs and the rest are silent, without a
read-then-write race between two of them."

**Fix.** The claim is the answer. `Cache::add()` writes only if the key is
absent, so of two requests carrying the same valid code exactly one gets `true`
back, and `has()` is gone — a failed claim *is* "already used".

**Not changed (deliberate).**
- Verification still runs first, so a wrong code never touches the cache and
  cannot burn the window for the code the person is about to type correctly.
- The 90-second claim and the key's shape.
- Recovery codes, which are consumed by their own single-use path.

**Tests.** One in `tests/Feature/Identity/TwoFactorTest.php`, modelling the
interleaving it is about: the winner's claim has landed, and the loser's `has()`
answers from before that write — one stale answer over the real store, which
leaves the claim as the deciding call.

Counter-check: with `TwoFactorService.php` reset to `main` and the test kept, that
file alone goes **1 failed / 10 passed** — the loser of the race is signed in. The
existing `a totp code cannot be replayed` test passes either way; it covers the
sequential case, which was never the problem.

**Where the atomicity comes from.** `Cache::add()` is only as atomic as the
store under it, so both stores this application runs on were checked rather
than assumed: the Redis store is `SETNX`, and `DatabaseStore::add()` decides on
`insertOrIgnore(...) > 0` against the cache table's key, which is the primary
key. `config/cache.php` falls back to `database` when `CACHE_STORE` is unset,
so that second one is not a hypothetical.

**What the mock in the test is for.** Under the fix, `verify()` never calls
`has()` at all, so the stale answer is inert and what the test asserts on this
side is simply that a claimed code is refused. The mock exists to make the
*old* path reachable: it is what puts the unfixed code into the loser's
position, where it reads "unused" and signs the request in. All of the test's
distinguishing power is in the counter-check, which is what a race without a
sequential observable allows.

Full suite passes (**2106 passed / 2 skipped**, 11412 assertions; `main`
(`06c364d2`) measures 2105/2). PHPStan level 8 clean, `pint --test` clean on both
changed files. No frontend or API controller touched, so `tsc`, ESLint and
`scramble:export` were not run.