### PR TITLE
Leave the caches update.sh's own update command needs to see

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -625,7 +625,37 @@ If you know what you are doing, re-run with --force."
     # vendor/ and public/build/ belong wholly to the release: merged, they
     # keep orphaned classes and orphaned hashed assets from the old one.
     rm -rf "$INSTALL_DIR/vendor" "$INSTALL_DIR/public/build"
-    rm -f "$INSTALL_DIR"/bootstrap/cache/*.php
+    # The compiled manifests and the cached configuration, and only those.
+    #
+    # The manifests must not survive the swap: they name the old release's
+    # package providers, and the first artisan run after the copy would try
+    # to load classes this version no longer ships. The cached
+    # configuration must not survive it either, for a sharper reason --
+    # it is read at every boot, so projectsend:update would read the
+    # *previous* release's version out of it, record that as the version it
+    # applied, and run the migrations under the old configuration.
+    #
+    # The route and event caches stay. Their presence is the signal
+    # projectsend:update reads to decide what to rebuild
+    # (UpdateInstallation::warmCaches), and it clears them itself moments
+    # later anyway. Wiping them here made an installation that had cached
+    # its routes look exactly like one that never had, so nothing was ever
+    # rebuilt and INSTALL.md's promise -- "projectsend:update notices they
+    # are in place and rebuilds them for you after every update" -- quietly
+    # stopped being true for anybody who updates with this script. Neither
+    # cache is read at boot: both are arrays of class names, consulted when
+    # a route is matched or an event dispatched.
+    #
+    # The warning about a cached configuration is said here, because after
+    # this the command cannot see one to warn about. Same sentence it uses,
+    # so an operator meets one wording rather than two.
+    if [[ -f "$INSTALL_DIR/bootstrap/cache/config.php" ]]; then
+        warn "A cached configuration was found and cleared. Do not run config:cache on this application — it stops TRUSTED_PROXIES from being read at all. See INSTALL.md."
+    fi
+
+    rm -f "$INSTALL_DIR/bootstrap/cache/config.php"
+    rm -f "$INSTALL_DIR/bootstrap/cache/packages.php"
+    rm -f "$INSTALL_DIR/bootstrap/cache/services.php"
     cp -a "$TMP_DIR"/. "$INSTALL_DIR"/
 
     # Symlinks are skipped on purpose. A symlink's own ownership decides


### PR DESCRIPTION
`INSTALL.md` tells an operator to cache routes, views and events once, and
promises: "You only run these once: `projectsend:update` notices they are in
place and rebuilds them for you after every update."

It cannot, for anybody who updates with `update.sh`. The script wipes
`bootstrap/cache/*.php` while replacing the application files (`update.sh:628`),
and `UpdateInstallation::warmCaches()` decides what to rebuild by asking
`file_exists()` on exactly those paths — forty lines later. Every installation
looks like one that never cached anything.

Measured in a copy of the tree:

```
wiping everything, as the script does it
  → "Cleared the compiled configuration, events, routes and views."
  → bootstrap/cache is empty afterwards

keeping the route and event caches
  → "Rebuilt the route, event and view caches — they were in place before."
  → routes-v7.php and events.php are back
```

So a site quietly loses route, event and view caching on every update, and the
operator is never told.

**Fix.** The wipe names what it removes rather than taking the directory:

- `packages.php` and `services.php`, because they must not survive the swap: they
  name the old release's package providers, and the first artisan run after the
  copy would try to load classes this version no longer ships.
- `config.php`, for a sharper reason — it is read at *every* boot. Leaving it
  means `projectsend:update` reads the previous release's version out of it.
  Measured, with a doctored version inside a cached config:

  ```
  with the cached config left in place → "Re-applied 2.2.0"        (disk says 9.9.9)
                                          AppliedVersion = 2.2.0
                                          migrations run under the old config
  with it removed                      → "Updated from 2.2.0 to 9.9.9"
                                          AppliedVersion = 9.9.9
  ```

The route and event caches stay. Neither is read at boot — both are arrays of
class names, consulted when a route is matched or an event dispatched — and
`projectsend:update` clears them itself moments later.

Removing `config.php` here would have taken the command's "A cached configuration
was found and cleared" warning with it, since it warns about what it finds. The
script now says it, in the same words, at the moment it removes the file.

**Not changed (deliberate).**
- `UpdateInstallation`. The rule for what gets rebuilt stays in one place; the
  script stops destroying the evidence it reads.
- The removal of `vendor/` and `public/build/`, which belong wholly to the
  release.
- The container entrypoints, which never wiped anything and where the command's
  own warning still fires.

**Tests.** None, and I would rather say so than add one that proves nothing. The
suite already pins the command's side — `UpdateCommandTest` covers the whole
rewarm matrix through a `warmCaches()` seam — and it cannot run a shell script
that replaces an installation. The measurements above are the evidence, the
warning branch was exercised both ways, and `bash -n update.sh` parses.

Full suite unchanged (**2105 passed / 2 skipped**, the `main` (`06c364d2`)
baseline; this branch touches no PHP). PHPStan level 8 clean.