### PR TITLE
Ask about the zips queue on every path that could answer it

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -669,6 +669,11 @@ Then reload PHP-FPM, and bring the site back with: php artisan up"
     if [[ "$NO_RESTART" == "1" ]]; then
         warn "Not touching systemd, as asked."
         warn "PHP is still running the old code until you reload it — ProjectSend will keep telling your staff so."
+        # Said rather than done: the check below edits a unit file, which is
+        # exactly what --no-restart asks us not to do. But a worker that
+        # predates the zips queue is broken whether or not we are allowed to
+        # touch it, and this is the only place that knows to mention it.
+        warn "Your worker's queues were not checked either. If it predates the zips queue, zip downloads never finish — run without --no-restart, or add 'zips' to its --queue list yourself."
     elif [[ "${SYSTEMD:-0}" == "1" && -n "${FPM_SERVICE:-}" ]]; then
         say "Reloading $FPM_SERVICE"
         systemctl reload "$FPM_SERVICE" 2>/dev/null || systemctl restart "$FPM_SERVICE" \
@@ -684,6 +689,29 @@ Then reload PHP-FPM, and bring the site back with: php artisan up"
         fi
     else
         warn "No PHP-FPM service was found to reload. Reload PHP yourself now, or it keeps serving the old code."
+
+        # The worker is a different unit from PHP-FPM, and not finding one
+        # says nothing about the other: a host running mod_php, or one where
+        # the FPM unit is named in a way this script does not recognise, can
+        # still have a systemd worker that predates the zips queue. The
+        # function returns immediately unless systemd and a worker unit are
+        # both there, so reaching it from here costs nothing and stops this
+        # branch being the one place the queue is never mentioned.
+        ensure_worker_watches_zips
+
+        # Paired with the edit, exactly as the FPM branch above pairs them,
+        # and for the reason its comment gives: the new --queue argument
+        # only reaches the worker when systemd next starts it from
+        # ExecStart. projectsend:update's queue:restart cannot deliver it —
+        # that makes a worker pick up new *code*, and it has already run by
+        # the time we get here, so the worker came back on the old command
+        # line. Without this, the unit is edited, the operator is told so,
+        # and zips still never finish: a false completion, which is worse
+        # than the silence this branch used to keep.
+        if [[ "${SYSTEMD:-0}" == "1" && -n "${WORKER_SERVICE:-}" ]]; then
+            say "Restarting $WORKER_SERVICE"
+            systemctl restart "$WORKER_SERVICE" || warn "Could not restart $WORKER_SERVICE."
+        fi
     fi
 
     say "Bringing the site back up"


### PR DESCRIPTION
`ensure_worker_watches_zips()` exists because a worker unit written before zip
downloads had their own queue watches `default` only. A zip enqueued to `zips`
then waits forever, and nothing says why — which is what the function's own
message tells the operator.

It is called from exactly one place (`update.sh:680`): inside the branch that
reloads PHP-FPM, nested inside the branch that found a worker unit. So it runs
only when a PHP-FPM unit was detected.

Driving the restart block through four host shapes, with everything it touches
stubbed:

```
systemd + fpm + worker      reached, restarted
systemd + worker, no fpm    silent
--no-restart                silent
no systemd at all           silent
```

The second line is the one that matters. A worker is a different unit from
PHP-FPM, and not finding one says nothing about the other: a host running
mod_php, or one whose FPM unit is named in a way this script does not recognise,
still has a systemd worker that may predate the zips queue. It gets no check and
no mention.

**Fix.** The check also runs in the `else` branch, where it costs nothing — its
own first line returns immediately unless systemd and a worker unit are both
present — and the worker is restarted after it, paired exactly as the FPM branch
pairs them.

**That pairing is the point, not a flourish.** The new `--queue` argument reaches
the worker only when systemd next starts it from `ExecStart`. The `queue:restart`
that `projectsend:update` signals cannot deliver it: that makes a worker pick up
new *code*, and it has already run by the time this block is reached, so the
worker came back on the old command line. Editing the unit without a restart
would leave the operator *told* that zip downloads were fixed while they still
could not finish — worse than the silence it replaces, because silence sends
somebody looking and a success message does not. The FPM branch's own comment
says the same thing from the other side: "Before the restart, so the worker comes
back on the command it is going to keep rather than needing a second bounce."

Under `--no-restart` it is *said* rather than done: editing a unit file is exactly
what that flag asks us not to do, but a worker that cannot finish a zip is broken
whether or not we may touch it, and this is the only place that knows to mention
it.

```
systemd + fpm + worker      reached, restarted
systemd + worker, no fpm    reached, restarted
--no-restart                not reached, but said so
no systemd at all           reached, no restart (returns immediately)
```

**Not changed (deliberate).**
- The function itself: what it detects, what it asks, the backup it takes and the
  three ways it can decline are all untouched.
- `--no-restart` still touches no unit file. It only gains a sentence.
- Nothing else about the restart block: PHP-FPM is still not reloaded on a host
  where no unit was found, and `--no-restart` still touches no unit file.
- The worker restart on the new path is guarded the same way the check is
  (`systemd` and a worker unit both present), so a host with neither gets a
  no-op rather than an error.

**Tests.** None — the suite cannot drive a shell script that restarts services.
The transcripts above come from a harness that lifts the restart block out of
each version of the script and runs it with `say`, `warn`, `systemctl` and the
check itself stubbed, so nothing on the machine is touched. It is not part of the
branch, since a scratch harness is not a test, but it is short enough to include
here so the numbers can be reproduced:

<details>
<summary>The harness</summary>

```bash
#!/usr/bin/env bash
# Drives the restart block of a given update.sh through four host shapes and
# reports whether the zips-queue check is reached. Stubs everything the block
# touches, so nothing on this machine is restarted or edited.
set -uo pipefail

SCRIPT="$1"

say()  { echo "say: $*"; }
warn() { echo "warn: $*"; }
note() { echo "note: $*"; }
systemctl() { echo "systemctl: $*"; return 0; }
ensure_worker_watches_zips() { echo "REACHED ensure_worker_watches_zips"; }

# The restart block, lifted verbatim from the script under test.
block="$(awk '/# ---- restart ---/,/^    fi$/' "$SCRIPT")"

run_case() {
    local label="$1" no_restart="$2" systemd="$3" fpm="$4" worker="$5"

    NO_RESTART="$no_restart" SYSTEMD="$systemd" FPM_SERVICE="$fpm" WORKER_SERVICE="$worker"
    export NO_RESTART SYSTEMD FPM_SERVICE WORKER_SERVICE

    local out
    out="$(eval "$block" 2>&1)"

    local restarted="no restart"
    if echo "$out" | grep -q "systemctl: restart ${worker:-__none__}"; then
        restarted="restarted"
    fi

    if echo "$out" | grep -q "REACHED ensure_worker_watches_zips"; then
        echo "$label: reached, $restarted"
    elif echo "$out" | grep -qi "zips"; then
        echo "$label: not reached, but said so"
    else
        echo "$label: silent"
    fi
}

run_case "systemd + fpm + worker      " 0 1 php-fpm.service projectsend-worker.service
run_case "systemd + worker, no fpm    " 0 1 "" projectsend-worker.service
run_case "--no-restart                " 1 1 php-fpm.service projectsend-worker.service
run_case "no systemd at all           " 0 0 "" ""
```

</details>

`bash -n update.sh` parses. Full suite unchanged (**2105 passed / 2 skipped**, the `main` (`06c364d2`)
baseline — this branch touches no PHP). PHPStan level 8 clean.