### PR TITLE
Set the directory permission Flysystem actually reads

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -62,12 +62,27 @@ return [
             // umask 0077 still produces 0700 and still cannot be
             // traversed; INSTALL.md covers fixing that, because it cannot
             // be fixed from this file.
+            //
+            // Both directory keys, because which one Flysystem reads is
+            // decided elsewhere: FilesystemManager passes
+            // `directory_visibility ?? visibility ?? private` as the
+            // default visibility for directories, so with `visibility`
+            // public just below, it reads `dir.public` and never looks at
+            // `dir.private`. Naming only the private one asked for 0755
+            // from a key nobody consults, and got 0755 anyway because that
+            // is Flysystem's default for a public directory — the right
+            // answer from the wrong place, which is the kind that stops
+            // being right quietly. Adding `directory_visibility` here, or
+            // a change to that default, would have been enough.
             // Spread rather than two ternaries so that leaving the flag
             // off is not merely equivalent to the old configuration but
             // literally it — no install that does not need this sees its
             // file modes change.
             ...(env('FILES_WEB_SERVER_READABLE', false)
-                ? ['visibility' => 'public', 'permissions' => ['dir' => ['private' => 0755]]]
+                ? [
+                    'visibility' => 'public',
+                    'permissions' => ['dir' => ['public' => 0755, 'private' => 0755]],
+                ]
                 : []),
         ],
 

--- a/tests/Feature/Files/FilePermissionsTest.php
+++ b/tests/Feature/Files/FilePermissionsTest.php
@@ -15,26 +15,46 @@ declare(strict_types=1);
 // ceiling there rather than a guarantee. That asymmetry is invisible from the
 // configuration and is exactly what someone would "simplify" away.
 
+use Illuminate\Support\Env;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\ParallelTesting;
 use Illuminate\Support\Facades\Storage;
 
 /**
- * Points the `files` disk at a scratch root, configured the way
+ * This worker's scratch root.
+ *
+ * Per worker, like the upload parts directory in Tests\TestCase: eight of
+ * them run this file at once, and the afterEach below deletes the tree it
+ * is given. Shared, one worker's cleanup lands in the middle of another
+ * worker's test, and the failure is a mode read from a directory that was
+ * removed underneath it.
+ */
+function filesPermissionRoot(): string
+{
+    return storage_path('app/files-permission-test/w'.(ParallelTesting::token() ?: '0'));
+}
+
+/**
+ * Points the `files` disk at that root, configured the way
  * config/filesystems.php configures it for the given flag.
+ *
+ * The configuration is *read from that file*, with only the root replaced.
+ * Restating its branch here — which is what this used to do, verbatim down
+ * to the 0755 — meant the test went on passing against its own copy after
+ * somebody changed the shipped one, which is the single thing it exists to
+ * notice.
  */
 function filesDiskWith(bool $webServerReadable): string
 {
-    $root = storage_path('app/files-permission-test');
+    $root = filesPermissionRoot();
 
-    config(['filesystems.disks.files' => [
-        'driver' => 'local',
-        'root' => $root,
-        'serve' => false,
-        'throw' => false,
-        ...($webServerReadable
-            ? ['visibility' => 'public', 'permissions' => ['dir' => ['private' => 0755]]]
-            : []),
-    ]]);
+    Env::getRepository()->set('FILES_WEB_SERVER_READABLE', $webServerReadable ? 'true' : 'false');
+
+    // Required rather than read through config(), so the env() call in it
+    // is evaluated now, against the flag just set.
+    $shipped = require base_path('config/filesystems.php');
+
+    config(['filesystems.disks.files' => [...$shipped['disks']['files'], 'root' => $root]]);
 
     Storage::forgetDisk('files');
 
@@ -50,11 +70,16 @@ function modeOf(string $path): string
 
 beforeEach(function () {
     $this->originalUmask = umask();
+
+    // Also before: a run killed mid-test leaves its tree behind, and these
+    // cases read modes off directories they expect to have created.
+    File::deleteDirectory(filesPermissionRoot());
 });
 
 afterEach(function () {
     umask($this->originalUmask);
-    File::deleteDirectory(storage_path('app/files-permission-test'));
+    File::deleteDirectory(filesPermissionRoot());
+    Env::getRepository()->clear('FILES_WEB_SERVER_READABLE');
     Storage::forgetDisk('files');
 });
 


### PR DESCRIPTION
`FILES_WEB_SERVER_READABLE` exists so a web server running as a different user
can traverse the directories a download lives in (#1668). It asks for 0755 —
from a key that is never consulted.

`FilesystemManager::createLocalDriver()` passes
`$config['directory_visibility'] ?? $config['visibility'] ?? Visibility::PRIVATE`
to `PortableVisibilityConverter::fromArray()` as the *default visibility for
directories*. This disk sets `visibility` to `public` two lines above and no
`directory_visibility`, so directories are public and the converter reads
`dir.public`. The configuration names only `dir.private`.

The mode comes out 0755 anyway, because 0755 is Flysystem's default for a public
directory. The right answer from the wrong place. Measured on `main`, flag on:

```
dir.private 0755 → 0750    the directory stays 0755   (nothing reads it)
dir.public  0755 → 0750    the directory becomes 0750 (this is the key)
```

Adding a `directory_visibility` to this disk — an ordinary hardening move — or a
change to that Flysystem default is all it would take for the flag to stop doing
what it says, silently, on exactly the hosts that need it.

**Fix.** Name both directory keys, so the intent survives either way round.

Keeping `dir.private` alongside the new `dir.public` is deliberate and is not
the thing this PR complains about. The bug was that the *only* key named was
one nothing reads, so the promised 0755 came from a Flysystem default rather
than from the configuration. Naming both makes the flag mean what it says —
the web server user can traverse — whichever visibility the disk ends up with,
including after somebody adds a `directory_visibility` to it, which is an
ordinary hardening move and exactly the change that would have broken this
silently before. One key is a guess about which branch Flysystem takes; two is
an answer that does not depend on the guess.

**And the test could not have caught it**, because it was not testing this
configuration. `filesDiskWith()` restated the shipped branch inline, verbatim
down to the `0755`, so it kept passing against its own copy however the real one
changed. It now `require`s `config/filesystems.php` and replaces only the root.

**Two more things in the same helper**, about the suite rather than the subject:

- The scratch root is per worker (`ParallelTesting::token()`), the way
  `Tests\TestCase` already does it for upload parts. Eight workers sharing one
  real directory means one worker's `afterEach` deletes another's tree mid-test —
  the same shape as the `clear-compiled` flake in #1711.
- It is cleared *before* each test as well as after, so a killed run does not
  poison the next one.

**Not changed (deliberate).**
- The modes themselves, the flag's meaning, and the umask reasoning in the
  config's comment — a directory mode is still a ceiling, not a guarantee.
- The `visibility => public` line, which is what makes files 0644 and is read.
- The default (flag off) branch, which stays literally the old configuration.

**Tests.** No new cases: the three that exist are the right ones, and they now
test the shipped configuration instead of a copy of it.

Counter-check, by mutation rather than reversion, since this is mostly about what
the test can see. With the shipped `dir.public` changed to 0750:

```
this branch          → 1 failed / 2 passed   (the test notices)
main's test file     → 3 passed              (it cannot)
```

Full suite passes (**2105 passed / 2 skipped**, 11409 assertions — the `main`
(`06c364d2`) baseline exactly, since no case was added). PHPStan level 8 clean,
`pint --test` clean on both changed files. No frontend or API controller touched,
so `tsc`, ESLint and `scramble:export` were not run.