### PR TITLE
Check the read half of the redirect rule at every door, not one

### DIFF
--- a/tests/Feature/Auth/WriteRedirectStatusTest.php
+++ b/tests/Feature/Auth/WriteRedirectStatusTest.php
@@ -77,11 +77,43 @@ it('answers a write with 303 when two-factor enrolment is being enforced', funct
         ->assertRedirect(route('two-factor.show'));
 });
 
-it('leaves a read alone in every one of those cases', function () {
-    $user = User::factory()->create();
-    $user->update(['active' => false]);
+// The other half of the rule, and the half that says the upgrade is
+// targeted: a read still gets the plain 302. Once per door, because "every
+// one of those cases" was one of them — the deactivation — and a change
+// that upgraded reads at either of the other two would have been invisible
+// here while this name said otherwise.
+it('leaves a read alone at every one of those doors', function (Closure $arrange, string $read, Closure $target) {
+    $arrange();
 
-    $this->actingAs($user)->get(route('dashboard'))
+    $this->get($read)
         ->assertStatus(302)
-        ->assertRedirect(route('login'));
-});
+        ->assertRedirect($target());
+})->with([
+    // A guest-reachable GET, for the same reason the write case uses
+    // PUT /timezone: anything behind `auth` is answered by the guest
+    // redirect before EnsureSetupIsComplete ever sees it.
+    'no administrator yet' => [
+        fn () => User::query()->delete(),
+        '/login',
+        fn () => route('setup'),
+    ],
+    'deactivated mid-session' => [
+        function (): void {
+            $user = User::factory()->create();
+            $user->update(['active' => false]);
+            test()->actingAs($user);
+        },
+        '/dashboard',
+        fn () => route('login'),
+    ],
+    'two-factor enrolment enforced' => [
+        function (): void {
+            // Set explicitly rather than relying on the default: the
+            // settings cache outlives a database rollback in this suite.
+            app(Settings::class)->set(Setting::TwoFactorEnforcement, TwoFactorEnforcement::All->value);
+            test()->actingAs(User::factory()->create());
+        },
+        '/dashboard',
+        fn () => route('two-factor.show'),
+    ],
+]);


### PR DESCRIPTION
Three middleware answer before `HandleInertiaRequests` and so repeat its 302→303
upgrade themselves: `EnsureSetupIsComplete`, `EnsureUserIsActive` and
`EnforceTwoFactor`. This file has a write case for each of them (#1673, #1680).

The rule has a second half — a read still gets a plain 302, because a 303 there
is an upgrade nobody asked for — and that half was checked once, on the
deactivation door, under a name that says otherwise:

```php
it('leaves a read alone in every one of those cases', …)   // one of them
```

So a change that upgraded reads at the setup door or the two-factor door would
have gone through with the suite green and this test still claiming it would not.

**Fix.** One case per door, as a dataset. The setup case reads a guest-reachable
GET for the same reason the write case posts to `/timezone`: anything behind
`auth` is answered by the guest redirect before `EnsureSetupIsComplete` ever sees
it.

**No production code changes.** All three doors answer a read with 302 today,
which is what the new cases assert — the gap was in the coverage, not the
behaviour.

**Counter-check by mutation**, since there is nothing to revert. Making
`EnsureSetupIsComplete` upgrade every redirect to 303:

```
this file      → 1 failed / 8 passed   (the setup door's read case)
main's file    → 7 passed              (blind to it)
```

The write case for that door keeps passing under the mutation, which is right:
303 is what a write should get, and it is the read that moved.

Full suite passes (**2107 passed / 2 skipped**, 11415 assertions; `main`
(`06c364d2`) measures 2105/2 — two cases added, one replaced). PHPStan level 8
clean, `pint --test` clean on the changed file. No frontend or API controller
touched, so `tsc`, ESLint and `scramble:export` were not run.