### PR TITLE
Stop a version link telling people about a file they already had

### DIFF
--- a/app/Modules/Files/Versions/FileVersions.php
+++ b/app/Modules/Files/Versions/FileVersions.php
@@ -96,8 +96,9 @@ class FileVersions
             DB::transaction(function () use ($file, $previous, $root, $actor): void {
                 // Move, never drop: a revision holds no recipients of its
                 // own, but the people who already had this file must not
-                // lose it. Through FileSharing so each target still gets
-                // its activity entry, notification and digest.
+                // lose it. Through FileSharing, so a target the root does
+                // not hold yet still gets its activity entry, notification
+                // and digest — and only such a target, see below.
                 $this->moveAssignmentsToRoot($file, $root);
 
                 $file->update([
@@ -544,8 +545,27 @@ class FileVersions
                 continue;
             }
 
-            // firstOrCreate inside, so a target the root already has is a
-            // no-op rather than a duplicate notification.
+            // A target the root already holds gains nothing here, so it
+            // is skipped rather than handed to FileSharing::assign().
+            // That method's firstOrCreate makes the assignment row
+            // idempotent but not the three side effects under it, so such
+            // a target was told a file had been shared with it about a
+            // file it already had — on top of the file_new_version it
+            // gets from sharedAudience(), which is exactly the two
+            // notifications for one action link() resolves that audience
+            // early to avoid. copyAssignmentsFrom() below states the rule
+            // outright for its own case: nobody is gaining access, so the
+            // notification would be a lie.
+            $alreadyOnRoot = FileAssignment::query()
+                ->where('file_id', $root->id)
+                ->where('assignable_type', $target->getMorphClass())
+                ->where('assignable_id', $target->getKey())
+                ->exists();
+
+            if ($alreadyOnRoot) {
+                continue;
+            }
+
             $this->sharing->assign($root, $target, $target->name);
         }
 

--- a/tests/Feature/Files/ShareNotificationsTest.php
+++ b/tests/Feature/Files/ShareNotificationsTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 use App\Models\User;
 use App\Modules\Files\Models\File;
+use App\Modules\Files\Models\FileAssignment;
 use App\Modules\Files\Models\Folder;
+use App\Modules\Files\Versions\FileVersions;
 use App\Modules\Groups\Models\Group;
 use App\Modules\Notifications\InAppNotification;
 use Illuminate\Database\Eloquent\Collection;
@@ -103,3 +105,75 @@ test('unsharing does not notify', function (string $type) {
 
     expect(sharedNotificationsFor($client))->toHaveCount(1);
 })->with(['files', 'folders']);
+
+/*
+|--------------------------------------------------------------------------
+| Linking a revision moves recipients; it must not re-announce the root
+|--------------------------------------------------------------------------
+*/
+
+function notificationTypesFor(User $client): array
+{
+    return InAppNotification::query()
+        ->where('user_id', $client->id)
+        ->orderBy('id')
+        ->pluck('type')
+        ->all();
+}
+
+test('linking a revision does not re-announce the root to somebody who already had it', function () {
+    $client = User::factory()->client()->create();
+    $root = File::factory()->create(['name' => 'Report']);
+    $revision = File::factory()->create(['name' => 'Report v2']);
+
+    $this->actingAs($this->admin)->post("/files/{$root->id}/assignments", ['type' => 'client', 'id' => $client->id]);
+    $this->actingAs($this->admin)->post("/files/{$revision->id}/assignments", ['type' => 'client', 'id' => $client->id]);
+
+    InAppNotification::query()->where('user_id', $client->id)->delete();
+
+    app(FileVersions::class)->link($revision->refresh(), $root->refresh(), $this->admin);
+
+    // One action, one notification. file_new_version is the right one:
+    // link() resolves that audience before the merge precisely so the
+    // people who could already see both are told once, and here they hold
+    // the root itself, so nothing was shared with them.
+    expect(notificationTypesFor($client))->toBe(['file_new_version'])
+        ->and(FileAssignment::query()->where('file_id', $root->id)->count())->toBe(1);
+});
+
+test('linking a revision still announces the root to somebody who is gaining it', function () {
+    $client = User::factory()->client()->create();
+    $root = File::factory()->create(['name' => 'Report']);
+    $revision = File::factory()->create(['name' => 'Report v2']);
+
+    // Only the revision, so the merge really does hand them the root.
+    $this->actingAs($this->admin)->post("/files/{$revision->id}/assignments", ['type' => 'client', 'id' => $client->id]);
+
+    InAppNotification::query()->where('user_id', $client->id)->delete();
+
+    app(FileVersions::class)->link($revision->refresh(), $root->refresh(), $this->admin);
+
+    // Not file_new_version: they could not see the root before, so they are
+    // not part of sharedAudience() — see its INTERSECTION docblock.
+    expect(notificationTypesFor($client))->toBe(['file_shared'])
+        ->and(FileAssignment::query()->where('file_id', $root->id)->count())->toBe(1);
+});
+
+test('a group already on the root is skipped the same way a client is', function () {
+    $member = User::factory()->client()->create();
+    $group = Group::query()->create(['name' => 'Design Team']);
+    $group->members()->sync([$member->id]);
+
+    $root = File::factory()->create(['name' => 'Report']);
+    $revision = File::factory()->create(['name' => 'Report v2']);
+
+    $this->actingAs($this->admin)->post("/files/{$root->id}/assignments", ['type' => 'group', 'id' => $group->id]);
+    $this->actingAs($this->admin)->post("/files/{$revision->id}/assignments", ['type' => 'group', 'id' => $group->id]);
+
+    InAppNotification::query()->where('user_id', $member->id)->delete();
+
+    app(FileVersions::class)->link($revision->refresh(), $root->refresh(), $this->admin);
+
+    expect(notificationTypesFor($member))->toBe(['file_new_version'])
+        ->and(FileAssignment::query()->where('file_id', $root->id)->count())->toBe(1);
+});


### PR DESCRIPTION
`FileVersions::link()` goes out of its way to send one notification per person
per action. Its own comment says why the audience is resolved before the merge
rather than after:

> RESOLVED BEFORE THE MERGE, and the ordering is the whole dedupe: these are the
> people who could already see both files, so anyone the merge below is about to
> reach for the first time is excluded here and gets `file_shared` from
> `FileSharing::assign()` instead. Resolve it afterwards and every newly-added
> client receives two emails about one action.

The merge itself then undoes that. `moveAssignmentsToRoot()` hands every one of
the revision's targets to `FileSharing::assign()`, under this comment:

> firstOrCreate inside, so a target the root already has is a no-op rather than
> a duplicate notification.

It is not. `firstOrCreate` makes the assignment **row** idempotent; the three
side effects below it — activity entry, in-app notification, digest — run
unconditionally. So a client who already held both files is in
`sharedAudience()` *and* gets a `file_shared` for a file they already had:

```
client already holds the root and the revision, then the two are linked:
  file_shared      (Report)      ← wrong: they have had "Report" all along
  file_new_version (Report v2)   ← right
  assignment rows on the root → 1   (the row is idempotent; the notice is not)

client holds only the revision, then the two are linked:
  file_shared      (Report)      ← right: the merge really does hand them the root
```

Two notifications for one action, for exactly the people the early resolve was
meant to protect. `unassign()` next door already gates its activity entry on
whether anything was actually removed; `assign()` does not.

## Fix

`moveAssignmentsToRoot()` skips a target the root already holds, rather than
handing it to `assign()` and relying on a no-op that is not one. Nobody is
gaining access in that case, so the activity entry would be as untrue as the
notification.

`copyAssignmentsFrom()`, directly below, already states the rule for its own
case and is why it inserts directly instead of going through `FileSharing`:

> A direct insert rather than `FileSharing::assign()`: nobody is gaining access
> here, the same people keep exactly what they had, so a "shared with you"
> notification would be a lie.

The two stale comments are corrected along with it.

**Not changed (deliberate):** `FileSharing::assign()` itself, and therefore the
behaviour `ShareNotificationsTest` pins — re-posting an existing assignment
through the share endpoint still notifies again. That test says the condition
for changing it:

> If the repeat notification is ever judged wrong, it should stop being sent for
> both at once — which is the point of them sharing one implementation.

That is a decision about what a deliberate re-share means, for files and folders
together, and it is not this change. This one is narrower and does not touch it:
a version merge is not somebody choosing to share again, and it already had a
stated intent to send exactly one notification.

## Tests

Three new cases in `ShareNotificationsTest`:

- linking a revision does not re-announce the root to somebody who already had
  it — `['file_new_version']`, and one assignment row on the root
- linking a revision still announces the root to somebody who is gaining it —
  `['file_shared']`, since they were never in `sharedAudience()`
- a group already on the root is skipped the same way a client is

`a repeat share notifies again, identically for files and folders` still
passes, unchanged — which is the point.

Counter-check: reverting `FileVersions` alone leaves **2 failed / 8 passed** in
that file. The middle case passes without the fix; it guards against skipping
too much, not against the duplicate notice.

Full suite passes (2108 passed / 2 skipped, 11415 assertions; `main` measures 2105/2), PHPStan level 8 clean.