### PR TITLE
Say what expiry does to a client-scoped staff member's library

### DIFF
--- a/app/Modules/Files/Http/Controllers/Api/FilesController.php
+++ b/app/Modules/Files/Http/Controllers/Api/FilesController.php
@@ -130,9 +130,12 @@ class FilesController extends Controller
         }
 
         // Expiry is a filter, not a default: staff see expired files in the
-        // UI too (that is how they notice and act on them). Only the client
-        // branch of the visibility rules drops them, and it does so inside
-        // ViewableFileScope where it belongs.
+        // UI too (that is how they notice and act on them). Dropping them
+        // is the client branch's rule, applied inside the visibility scopes
+        // where it belongs — which is also why a client-scoped caller does
+        // not get their clients' expired files back here whatever this
+        // filter says: their library is built on that same branch. See
+        // File::isExpired.
         if ($request->has('expired') && ($filters['expired'] ?? null) !== null) {
             $request->boolean('expired') ? $query->expired() : $query->notExpired();
         }

--- a/app/Modules/Files/Models/File.php
+++ b/app/Modules/Files/Models/File.php
@@ -247,8 +247,20 @@ class File extends Model
     /**
      * A file's own expiration date — independent of any share link's.
      * Null means never expires. Once past, the file is hidden from
-     * clients and the public site (see scopeNotExpired) but staff keep
-     * full access to view, download, and manage it.
+     * clients and the public site (see scopeNotExpired) and staff keep
+     * full access to view, download, and manage it — with one boundary
+     * this used to leave out.
+     *
+     * A client-scoped staff member's library is their own uploads ∪ what
+     * each assigned client may see (StaffLibraryScope::buildFiles), and
+     * that second half is scopeVisibleToClient, which ends in
+     * notExpired(). So an expired file they held only through a client
+     * leaves their library too, while their own expired upload stays.
+     * That is deliberate: c8078f65 weighed widening it and left the
+     * boundary where it is, because scopeVisibleToClient is the single
+     * source of truth for client file access, and relabelled the
+     * expired-files widget instead. ExpiredFileStaffAccessTest pins both
+     * halves so the sentence above cannot drift from the code again.
      */
     public function isExpired(): bool
     {

--- a/tests/Feature/Files/ExpiredFileStaffAccessTest.php
+++ b/tests/Feature/Files/ExpiredFileStaffAccessTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Files\Access\StaffLibraryScope;
+use App\Modules\Files\Models\File;
+use App\Modules\Identity\Models\Role;
+use App\Modules\Identity\Models\RolePermission;
+use App\Modules\Identity\Permissions\Permission;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+/**
+ * Expiry hides a file from clients and the public site; staff keep it.
+ * For a client-scoped staff member that is true of their own uploads and
+ * not of their clients' files, because the second half of their library
+ * is File::scopeVisibleToClient and it ends in notExpired().
+ *
+ * c8078f65 decided that deliberately rather than widening the scope —
+ * "the single source of truth for client file access", changed for a
+ * dashboard widget — and relabelled the widget instead. Nothing executed
+ * that decision, so File::isExpired's docblock could go on promising
+ * staff full access without anything failing. These pin both halves.
+ */
+beforeEach(function () {
+    Storage::fake('files');
+    $this->admin = User::factory()->create();
+
+    $role = Role::query()->create(['name' => 'Reps '.Str::random(6), 'client_scoped' => true]);
+    foreach ([Permission::Upload, Permission::EditFiles] as $permission) {
+        RolePermission::query()->create(['role_id' => $role->id, 'permission' => $permission->value]);
+    }
+
+    $this->rep = User::factory()->create(['role_id' => $role->id]);
+    $this->client = User::factory()->client()->create();
+    $this->rep->assignedClients()->sync([$this->client->id]);
+});
+
+function libraryHoldsFile(User $staff, File $file): bool
+{
+    // The scope memoises its built query per user id, so a fresh
+    // container is what makes a second question in one test honest.
+    app()->forgetInstance(StaffLibraryScope::class);
+
+    return app(StaffLibraryScope::class)->files($staff)->whereKey($file->id)->exists();
+}
+
+test('an unscoped staff member keeps a file after it expires', function () {
+    $file = uploadNamedFile($this->admin, 'annual-report');
+    shareFileWith($file, $this->client);
+
+    $file->forceFill(['expires_at' => now()->subDay()])->save();
+
+    expect(libraryHoldsFile($this->admin, $file))->toBeTrue();
+    $this->actingAs($this->admin)->get("/files/{$file->id}/download")->assertOk();
+});
+
+test('a client-scoped staff member keeps their own expired upload', function () {
+    $file = uploadNamedFile($this->rep, 'my-own-note');
+
+    $file->forceFill(['expires_at' => now()->subDay()])->save();
+
+    expect(libraryHoldsFile($this->rep, $file))->toBeTrue();
+});
+
+test('a client-scoped staff member loses a client file when it expires', function () {
+    $file = uploadNamedFile($this->admin, 'annual-report');
+    shareFileWith($file, $this->client);
+
+    expect(libraryHoldsFile($this->rep, $file))->toBeTrue();
+    $this->actingAs($this->rep)->get("/files/{$file->id}/download")->assertOk();
+
+    $file->forceFill(['expires_at' => now()->subDay()])->save();
+
+    // Deliberate, not an oversight — see the file docblock above. If this
+    // ever changes, File::isExpired's docblock changes with it.
+    expect(libraryHoldsFile($this->rep, $file))->toBeFalse();
+    $this->actingAs($this->rep)->get("/files/{$file->id}/download")->assertForbidden();
+});


### PR DESCRIPTION
`File::isExpired()` documents the rule the whole application is supposed to
follow:

> Once past, the file is hidden from clients and the public site (see
> `scopeNotExpired`) but staff keep full access to view, download, and manage it.

The second half is not true of a client-scoped staff member.
`StaffLibraryScope::buildFiles()` builds their library as
`own uploads ∪ (what each assigned client may see)`, and the second half runs
through `File::scopeVisibleToClient`, which ends in `notExpired()` — a
client-side rule. Measured on `main`, with a rep holding one client and a file
the administrator uploaded and shared with that client:

```
before expiry:  in_library true    GET /files/{id}/download → 200
after expiry:   in_library false   GET /files/{id}/download → 403

the same rep's own expired upload:            in_library true
an unscoped administrator, same expired file: in_library true
```

`Api\FilesController` states it the same way — "Only the client branch of the
visibility rules drops them" — which reads as though a staff caller is
unaffected, when a client-scoped one is reached through that very branch.

**This does not propose changing that behaviour.** `c8078f65` weighed exactly
this and decided against it, two days ago:

> Widening that would mean a library query that keeps expired rows, and
> `scopeVisibleToClient` is the single source of truth for client file access —
> the highest-stakes function to go changing for a dashboard widget. So the
> boundary stays where it is and the widget stops overstating itself.

That decision was recorded in a commit message and in one widget's label.
Nothing in the code said it, and the docblock nearest the rule went on
promising the opposite — which is how the next person re-derives "staff keep
full access" and widens something.

## Fix

Documentation and characterisation only; no behaviour changes.

- `File::isExpired()` now states the boundary, why it is where it is, and
  points at `c8078f65` and at the test below.
- The `Api\FilesController` comment is corrected the same way.
- `ExpiredFileStaffAccessTest` pins all three cases, so the sentence and the
  code cannot drift apart again:
  an unscoped staff member keeps an expired file; a client-scoped one keeps
  their *own* expired upload; a client-scoped one loses a *client's* file when
  it expires.

**Not changed (deliberate):** `scopeVisibleToClient`, `StaffLibraryScope`, and
the expired-files widget. If the boundary should move, that is a separate
conversation and a separate change — this one only makes the current answer
findable and executable.

## Tests

Three new cases, in a new `tests/Feature/Files/ExpiredFileStaffAccessTest.php`.

Counter-check, inverted for a characterisation test: these pass on unmodified
`main` by construction — there is no behaviour fix for them to prove. What they
have to do is fail if the boundary moves, so the mutation is the widening
itself. Deleting the closing `$query->notExpired();` from
`File::scopeVisibleToClient` turns the file red — **1 failed / 2 passed** —
and it is the third case, the one carrying the decision, that falls.

Full suite passes (2108 passed / 2 skipped, 11416 assertions; `main` measures 2105/2), PHPStan level 8 clean.
`docs/api/openapi.json` re-exported and byte-identical to main's — the
only change in `Api\FilesController` is a comment.

**Merge note.** Both application files here are touched by other branches of
this series, and in both the hunks are elsewhere in the file:
`File.php` with `fix/rendition-cleanup-independent`, whose comment sits in
`booted()` about 140 lines above this docblock, and
`Api/FilesController.php` with `fix/api-expiry-end-of-day`, which changes
`update()` where this changes a comment in `index()`. They merge without
conflict in either order.