### PR TITLE
Say which permission a bulk edit was actually missing

### DIFF
--- a/app/Modules/Files/Http/Controllers/FilesController.php
+++ b/app/Modules/Files/Http/Controllers/FilesController.php
@@ -504,9 +504,23 @@ class FilesController extends Controller
         });
 
         $requested = count($validated['file_ids']);
-        $message = $updated < $requested
-            ? __(':updated of :requested selected files were updated. The rest were skipped because you don\'t have permission to edit them.', ['updated' => $updated, 'requested' => $requested])
-            : trans_choice(':count file updated.|:count files updated.', $updated, ['count' => $updated]);
+
+        // Two different reasons a selected file can go unchanged, and they
+        // are not the same sentence. Files dropped by the Gate::allows
+        // filter above are ones this user may not edit at all. A file that
+        // survived the filter and still changed nothing was editable --
+        // every field they asked to change was one their role does not let
+        // them set, which is the case the single-file editor states
+        // separately too. Reporting the first reason for the second told a
+        // staff member with edit_files but without set_file_expiration_date
+        // that three files they own are not theirs to edit.
+        $unreachable = $requested - $files->count();
+
+        $message = match (true) {
+            $updated === $requested => trans_choice(':count file updated.|:count files updated.', $updated, ['count' => $updated]),
+            $updated + $unreachable === $requested => __(':updated of :requested selected files were updated. The rest were skipped because you don\'t have permission to edit them.', ['updated' => $updated, 'requested' => $requested]),
+            default => __(':updated of :requested selected files were updated. The rest were skipped because you don\'t have permission to make those changes.', ['updated' => $updated, 'requested' => $requested]),
+        };
 
         return back()->with('success', $message);
     }

--- a/tests/Feature/Files/BulkEditFilesTest.php
+++ b/tests/Feature/Files/BulkEditFilesTest.php
@@ -209,6 +209,62 @@ test('expiration and category changes in a bulk edit are silently ignored withou
         ->and($file->categories()->count())->toBe(0);
 });
 
+test('a skip for a missing field permission is not reported as a missing edit permission', function () {
+    // They own all three files and hold edit_files. What they lack is
+    // set_file_expiration_date, and that is what the message has to say --
+    // "you don't have permission to edit them" is both wrong and
+    // unactionable, since editing is exactly what they may do.
+    $staff = ownFilesOnlyStaff('File Editor Only, No Expiry');
+    expect($staff->can('edit_files'))->toBeTrue()
+        ->and($staff->can('set_file_expiration_date'))->toBeFalse();
+
+    $files = collect(['a.pdf', 'b.pdf', 'c.pdf'])
+        ->map(fn (string $name) => uploadDocumentFile($staff, $name));
+
+    $this->actingAs($staff)->patch('/files/bulk-edit', noEditPayload([
+        'file_ids' => $files->pluck('id')->all(),
+        'expiration_action' => 'set',
+        'expires_at' => '2030-01-01',
+    ]))->assertRedirect();
+
+    expect(session('success'))
+        ->toBe('0 of 3 selected files were updated. The rest were skipped because you don\'t have permission to make those changes.');
+});
+
+test('a skip for a missing edit permission still says so', function () {
+    // The other reason, unchanged: every file that went unchanged here is
+    // one this staff member may not edit at all.
+    $staff = ownFilesOnlyStaff('Own Files Only, Two Reasons Apart');
+    $own = uploadDocumentFile($staff, 'own.pdf');
+    $theirs = uploadDocumentFile($this->admin, 'theirs.pdf');
+
+    $this->actingAs($staff)->patch('/files/bulk-edit', noEditPayload([
+        'file_ids' => [$own->id, $theirs->id],
+        'description_action' => 'set',
+        'description' => 'edited',
+    ]))->assertRedirect();
+
+    expect(session('success'))
+        ->toBe('1 of 2 selected files were updated. The rest were skipped because you don\'t have permission to edit them.');
+});
+
+test('a mixture of both reasons reports the one that covers both', function () {
+    $staff = ownFilesOnlyStaff('Own Files Only, No Expiry');
+    $own = uploadDocumentFile($staff, 'own.pdf');
+    $theirs = uploadDocumentFile($this->admin, 'theirs.pdf');
+
+    // One file is not theirs to edit; the other is, but the only change
+    // asked for needs a permission they do not hold.
+    $this->actingAs($staff)->patch('/files/bulk-edit', noEditPayload([
+        'file_ids' => [$own->id, $theirs->id],
+        'expiration_action' => 'set',
+        'expires_at' => '2030-01-01',
+    ]))->assertRedirect();
+
+    expect(session('success'))
+        ->toBe('0 of 2 selected files were updated. The rest were skipped because you don\'t have permission to make those changes.');
+});
+
 test('a bulk edit that changes nothing is rejected', function () {
     $file = uploadDocumentFile($this->admin);
 


### PR DESCRIPTION
Two different things stop a selected file being changed in a bulk edit, and
`bulkUpdate()` reports both as the first one.

Files dropped by the `Gate::allows('update')` filter are ones this staff member
may not edit at all. A file that survives the filter and still changes nothing is
a different case: it *was* editable, and every field they asked to change is one
their role does not let them set — expiry, download limit and categories each sit
behind their own permission here, exactly as they do in the single-file editor.

Measured on `main`, a staff member with `edit_files` but without
`set_file_expiration_date`, three files they own, expiry the only change:

```
"0 of 3 selected files were updated. The rest were skipped because you don't
 have permission to edit them."
```

They own all three, and editing is precisely what they may do. The sentence is
both wrong and unactionable — nothing about it points at the permission that
actually stopped the edit.

**Fix.** The two cases get their own sentences.

- Every skip a file they may not edit → the existing string, unchanged, so its
  sixteen translations stay in use.
- Otherwise → a new string, "…because you don't have permission to make those
  changes", which is also true when both reasons are in play, so a mixed
  selection is described correctly rather than approximately.

**Not changed (deliberate).**
- Which files get changed, and the silent-skip convention itself: a bulk edit
  still drops what it may not touch rather than 403ing the batch, and still 422s
  when nothing at all is authorised.
- The successful-case message and the 422 strings.
- The new key is English only. A locale without it falls back to English, which
  trades a translated-but-wrong sentence for an untranslated correct one; the
  sixteen catalogs are yours to complete if you want it in this PR.

**Tests.** Three in `tests/Feature/Files/BulkEditFilesTest.php`: each reason on
its own, and a selection where both apply.

Counter-check: with `FilesController.php` reset to `main` and the tests kept,
that file alone goes **2 failed / 12 passed** — the field-permission case and the
mixture. The pure edit-permission case stays green either way, which is the
point.

Full suite passes (**2108 passed / 2 skipped**, 11417 assertions; `main`
(`06c364d2`) measures 2105/2). PHPStan level 8 clean, `pint --test` clean on both
changed files. No frontend or API controller touched, so `tsc`, ESLint and
`scramble:export` were not run.

**Merge note.** `FilesController.php` is also touched by the
`fix/expiry-timezone-drift` branch: its hunks are in `edit()`, `update()` and a
new private method below them, and this one is in `bulkUpdate()`. The two merge
without conflict in either order.