### PR TITLE
Let a password reset know where the account's credentials live

### DIFF
--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Modules\Identity\AuthSource;
+use App\Modules\Identity\Ldap\LdapAuthenticator;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -16,6 +18,10 @@ use Inertia\Response;
 
 class NewPasswordController extends Controller
 {
+    public function __construct(
+        private readonly LdapAuthenticator $ldap,
+    ) {}
+
     /**
      * Show the password reset page.
      */
@@ -46,10 +52,55 @@ class NewPasswordController extends Controller
         $status = Password::reset(
             $request->only('email', 'password', 'password_confirmation', 'token'),
             function ($user) use ($request) {
-                $user->forceFill([
+                // A directory account's password lives in the directory and
+                // the local hash is not consulted at all, which is what
+                // isDirectoryAccount() means. Writing one here reported
+                // success and changed nothing anybody could use -- including
+                // when the directory it points at is gone, which is exactly
+                // when somebody reaches for a reset.
+                //
+                // Refused here rather than where the link is asked for: that
+                // endpoint answers "A reset link will be sent if the account
+                // exists" to everybody on purpose, and a refusal there would
+                // tell a stranger both that an address is an account and how
+                // it signs in. By this point the caller holds a token that
+                // was emailed to the address, so the explanation reaches the
+                // account holder and nobody else.
+                //
+                // Throwing before the write also leaves the token unspent:
+                // PasswordBroker deletes it after the callback returns, so
+                // the link still works if an administrator converts the
+                // account in the meantime.
+                if ($this->ldap->isDirectoryAccount($user)) {
+                    throw ValidationException::withMessages([
+                        'email' => [__('This account signs in through your directory, so its password is not set here. Ask an administrator if you cannot sign in.')],
+                    ]);
+                }
+
+                $attributes = [
                     'password' => Hash::make($request->password),
                     'remember_token' => Str::random(60),
-                ])->save();
+                ];
+
+                // `social` records that the account came into existence
+                // without anybody choosing a password, which AuthSource
+                // states outright -- along with "a social account may later
+                // set a real password". This is that moment, and nothing
+                // else in the application writes it: the Connected accounts
+                // screen reads `auth_source === Local` as
+                // `has_local_password`, so without this line its refusal
+                // goes on asking for a password that has just been set.
+                //
+                // The two branches of this method are the same rule read
+                // twice: `social` is where the account came from and the
+                // hash here is what signs it in, so choosing one settles it;
+                // `ldap` is the authentication path itself, so nothing
+                // chosen here settles anything.
+                if ($user->auth_source === AuthSource::Social) {
+                    $attributes['auth_source'] = AuthSource::Local;
+                }
+
+                $user->forceFill($attributes)->save();
 
                 event(new PasswordReset($user));
             }

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -3,9 +3,12 @@
 namespace Tests\Feature\Auth;
 
 use App\Models\User;
+use App\Modules\Identity\AuthSource;
 use App\Modules\Identity\Notifications\ResetPasswordNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
 use Tests\TestCase;
 
 class PasswordResetTest extends TestCase
@@ -108,5 +111,57 @@ class PasswordResetTest extends TestCase
 
             return true;
         });
+    }
+
+    /**
+     * The reset used to report success for an account whose password does
+     * not live here: isDirectoryAccount() means the local hash is never
+     * consulted, so the password it wrote could not sign anybody in — and
+     * nothing said so. Nothing about the account moves either, the source
+     * included: taking an account off its directory is an administrator's
+     * decision, not a side effect of a reset.
+     */
+    public function test_a_directory_account_is_told_where_its_password_lives()
+    {
+        $client = User::factory()->client()->create();
+        $client->forceFill([
+            'auth_source' => AuthSource::Ldap,
+            'ldap_dn' => 'cn=dana,dc=test',
+        ])->save();
+        $before = $client->password;
+
+        $this->post('/reset-password', [
+            'token' => Password::createToken($client),
+            'email' => $client->email,
+            'password' => 'a-password-of-her-own',
+            'password_confirmation' => 'a-password-of-her-own',
+        ])->assertSessionHasErrors('email');
+
+        $client->refresh();
+
+        $this->assertSame($before, $client->password);
+        $this->assertSame(AuthSource::Ldap, $client->auth_source);
+        $this->assertSame('cn=dana,dc=test', $client->ldap_dn);
+    }
+
+    /**
+     * The half that must not be refused, and the reason the check is
+     * isDirectoryAccount() rather than a comparison against auth_source:
+     * LDAP is client-only, enforced on the account, so a staff row is
+     * verified against the local hash whatever its source happens to say.
+     */
+    public function test_a_staff_account_resets_whatever_its_source_says()
+    {
+        $staff = User::factory()->create();
+        $staff->forceFill(['auth_source' => AuthSource::Ldap])->save();
+
+        $this->post('/reset-password', [
+            'token' => Password::createToken($staff),
+            'email' => $staff->email,
+            'password' => 'a-password-of-his-own',
+            'password_confirmation' => 'a-password-of-his-own',
+        ])->assertSessionHasNoErrors();
+
+        $this->assertTrue(Hash::check('a-password-of-his-own', $staff->fresh()->password));
     }
 }

--- a/tests/Feature/Identity/ConnectedAccountsTest.php
+++ b/tests/Feature/Identity/ConnectedAccountsTest.php
@@ -11,6 +11,7 @@ use App\Modules\Identity\Social\SocialGateway;
 use App\Modules\Identity\Social\SocialIdentity;
 use App\Modules\Identity\Social\SocialProvider;
 use App\Modules\Identity\Social\SocialSettings;
+use Illuminate\Support\Facades\Password;
 use Illuminate\Testing\TestResponse;
 use Tests\Support\FakeSocialGateway;
 
@@ -145,6 +146,30 @@ test('an account created by a provider cannot remove its last connection', funct
         ->assertSessionHasErrors('provider');
 
     expect(SocialAccount::query()->count())->toBe(1);
+});
+
+// And the instruction inside that refusal, followed. AuthSource says a
+// social account "may later set a real password"; a reset by emailed token
+// is where somebody does, and nothing else in the application records it.
+test('a provider account that resets its password can then disconnect', function () {
+    $client = User::factory()->client()->create();
+    $client->forceFill(['auth_source' => AuthSource::Social])->save();
+    linkRow($client, 'sub-1');
+
+    $this->post(route('password.store'), [
+        'token' => Password::createToken($client),
+        'email' => $client->email,
+        'password' => 'a-password-of-her-own',
+        'password_confirmation' => 'a-password-of-her-own',
+    ])->assertSessionHasNoErrors();
+
+    expect($client->fresh()->auth_source)->toBe(AuthSource::Local);
+
+    $this->actingAs($client->fresh())
+        ->delete(route('connected-accounts.destroy', ['provider' => 'google']))
+        ->assertSessionHasNoErrors();
+
+    expect(SocialAccount::query()->count())->toBe(0);
 });
 
 test('it can remove one of two connections', function () {


### PR DESCRIPTION
Two accounts reach the same reset with opposite needs, and it answered both
by writing a hash and hoping.

**A provider account is asked for something it cannot do.** The Connected
accounts screen refuses to release an account's last provider:

> This is the only way you can sign in. Set a password first, then disconnect
> Google.

Nothing sets `auth_source` back to `Local`. `AccountConversion` is the only
writer that does, and that is an administrator converting an account. Measured
on `main` (`20293091`), a provider-provisioned client resetting their password
by email:

```
reset                             → 302, no errors
can sign in with the new password → true
auth_source                       → still "social"
disconnect the provider           → refused, the same sentence again
```

The screen goes on asking for what has just been done, and there is no way out
of that from inside the application.

`AuthSource` already states the rule that closes it, for this case by name:

> Unlike Ldap this does not mean "the password lives elsewhere and the local
> hash is never consulted" — **a social account may later set a real password**
> … It means the account came into existence without anybody choosing a
> password for it.

A reset by emailed token is where somebody chooses one. And the prop the screen
reads is literally `auth_source === AuthSource::Local`, under the name
`has_local_password`.

**A directory account is told something untrue.**
`LdapAuthenticator::isDirectoryAccount()` means the local hash is not consulted
at all, so the same reset wrote a password that could never sign anybody in —
and said it had worked:

```
reset            → 302, no errors
password written → true
ever consulted   → no, isDirectoryAccount() short-circuits the local check
```

Including when the directory it points at is gone, which is exactly the
situation that sends somebody to a reset in the first place.

**Fix.** The reset asks where the account's credentials live and answers
accordingly.

- **`social`** — the new password *is* the account's credential now, so the
  source becomes `Local`. The disconnect the screen asks for then works.
- **a directory account** — refused, with the reason, and nothing about the
  account moves.
- **everything else** — byte for byte as before.

**Why the directory case is refused rather than converted.** Writing `Local`
there would not record something that had happened; it would move the account
off its directory as a side effect of a password reset. That is an
administrator's decision, and `AccountConversion` is where it already lives —
with the password requirement and the activity entry that go with it. The
rejected shape was measured too: with the source rewritten unconditionally, an
`ldap` client's `auth_source` flips to `local` on any reset, and the guard test
in this PR goes red on it.

**Where the refusal sits, and why not earlier.** `PasswordResetLinkController`
answers *"A reset link will be sent if the account exists"* to everybody on
purpose. A refusal there would tell a stranger both that an address is an
account and how it signs in. By the point this refuses, the caller holds a token
that was emailed to the address, so the sentence reaches the account holder and
nobody else. Throwing before the write also leaves the token unspent —
`PasswordBroker` deletes it after the callback returns — so the link still works
if an administrator converts the account in the meantime.

**Not changed (deliberate).**
- `ldap_dn` and `ldap_synced_at`, on both paths. They record which directory
  entry an account corresponds to, and neither is a credential.
- `LdapAuthenticator::stamp()`, which still refuses to set `auth_source` on a
  login — "a login is not an authenticated request and has no business flipping
  a privilege-adjacent flag". A reset is the account holder acting on an emailed
  token, which is the act `AccountConversion` already reads this way.
- `Settings\PasswordController::update()`, which requires `current_password` and
  so is only reachable by an account whose local password already works.
- Staff. The check is `isDirectoryAccount()` rather than a comparison against
  `auth_source` precisely because LDAP is client-only, enforced on the account:
  a staff row is verified against the local hash whatever its source says, so it
  must not be refused. There is a test for that.
- The link-request endpoint, its generic answer and its throttles.

**Tests.** Three.

- `tests/Feature/Identity/ConnectedAccountsTest.php`, beside the refusal it is
  about: a provider account resets its password and can then disconnect its last
  connection.
- `tests/Feature/Auth/PasswordResetTest.php`: a directory account is refused,
  its password unchanged and its source and `ldap_dn` untouched; and a staff
  account resets whatever its source says.

Counter-check: with `NewPasswordController.php` reset to `main` and the tests
kept, the two files go **2 failed / 18 passed**. The staff case stays green
either way, which is what says this did not simply refuse more.

Full suite passes (**2108 passed / 2 skipped**, 11420 assertions; `main`
(`20293091`) measures 2105/2, 11409). PHPStan level 8 clean, `pint --test` clean
on all three changed files. No frontend or API controller touched, so `tsc`,
ESLint and `scramble:export` were not run.

**One new string**, English only: *"This account signs in through your
directory, so its password is not set here. Ask an administrator if you cannot
sign in."* It echoes the wording `AccountConversion` already uses for the same
situation. Say the word and I will add the sixteen catalogue entries.