### PR TITLE
A deleted account is still the person who wrote the comment

### DIFF
--- a/app/Modules/Comments/CommentPresenter.php
+++ b/app/Modules/Comments/CommentPresenter.php
@@ -141,14 +141,19 @@ class CommentPresenter
         ];
     }
 
+    /**
+     * Asked of the column, not of the relation — the same rule
+     * isFromGuest() and authorName() follow. Since author() reads a
+     * deleted account too this would now answer correctly either way; it
+     * is written this way so the next reader does not re-derive "no
+     * author row means guest", which is what it used to mean here.
+     */
     private function authorType(FileComment $comment): string
     {
-        $author = $comment->author;
-
-        if ($author === null) {
+        if ($comment->isFromGuest()) {
             return 'guest';
         }
 
-        return $author->isStaff() ? 'staff' : 'client';
+        return $comment->author?->isStaff() === true ? 'staff' : 'client';
     }
 }

--- a/app/Modules/Comments/Http/Controllers/CommentsController.php
+++ b/app/Modules/Comments/Http/Controllers/CommentsController.php
@@ -147,15 +147,17 @@ class CommentsController extends Controller
         ];
     }
 
+    /**
+     * See CommentPresenter::authorType(): asked of the column, because
+     * that is what decides whether a comment is a guest's.
+     */
     private function authorType(FileComment $comment): string
     {
-        $author = $comment->author;
-
-        if ($author === null) {
+        if ($comment->isFromGuest()) {
             return 'guest';
         }
 
-        return $author->isStaff() ? 'staff' : 'client';
+        return $comment->author?->isStaff() === true ? 'staff' : 'client';
     }
 
     /**

--- a/app/Modules/Comments/Models/FileComment.php
+++ b/app/Modules/Comments/Models/FileComment.php
@@ -76,11 +76,30 @@ class FileComment extends Model
     }
 
     /**
+     * The account that wrote this comment, deleted or not.
+     *
+     * `author_id` is cascadeOnDelete and the cascade never fires, because
+     * a user is soft-deleted: the row behind a deleted commenter is still
+     * there and the column still points at it. Handing back null for one
+     * left every caller to invent a meaning for the absence, and they
+     * invented different ones — the author type became "guest" on two
+     * screens and "client" in the API, while the name beside it stayed
+     * correct, and the author filter and the name search stopped matching
+     * the comment at all.
+     *
+     * Whether a comment is from a guest is decided by `author_id` alone.
+     * isFromGuest() and authorName() already say so; this makes the
+     * relation agree with them.
+     *
+     * Nothing that decides who may *read* a comment goes through here —
+     * VisibleCommentScope and FileCommentPolicy both compare `author_id`
+     * directly — so this widens no visibility.
+     *
      * @return BelongsTo<User, $this>
      */
     public function author(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'author_id');
+        return $this->belongsTo(User::class, 'author_id')->withTrashed();
     }
 
     /**

--- a/tests/Feature/Comments/DeletedCommentAuthorTest.php
+++ b/tests/Feature/Comments/DeletedCommentAuthorTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Modules\Comments\CommentVisibility;
+use App\Modules\Comments\Models\FileComment;
+use App\Modules\Files\Models\File;
+use App\Modules\Platform\Settings\Setting;
+use App\Modules\Platform\Settings\Settings;
+use Inertia\Testing\AssertableInertia;
+use Laravel\Sanctum\Sanctum;
+
+/**
+ * The author half of what DeletedClientThreadTest describes for
+ * `client_context_id`: both columns are cascadeOnDelete, neither cascade
+ * ever fires because users are soft-deleted, and everything that asked
+ * the relation instead of the column read the survivor as absent.
+ *
+ * Here the absence was filled in three different ways — "guest" on the
+ * two screens, "client" in the API — beside a name that stayed right,
+ * and the author filter and name search dropped the comment entirely.
+ */
+beforeEach(function () {
+    $settings = app(Settings::class);
+    $settings->set(Setting::CommentsScope, 'all');
+    $settings->set(Setting::CommentsAuthors, 'everyone');
+
+    $this->admin = User::factory()->create(['name' => 'Admin']);
+    $this->dana = User::factory()->create(['name' => 'Dana Staff']);
+    $this->file = File::factory()->create(['uploaded_by' => $this->admin->id, 'name' => 'Merger terms']);
+
+    $this->comment = FileComment::factory()->for($this->file)->create([
+        'author_id' => $this->dana->id,
+        'body' => 'internal note',
+        'visibility' => CommentVisibility::StaffOnly,
+    ]);
+});
+
+/**
+ * The management screen's first row, as `name / type`.
+ *
+ * @param  array<string, string>  $query
+ */
+function authorRow(array $query = []): string
+{
+    $row = '';
+
+    test()->actingAs(test()->admin)
+        ->get('/comments'.($query === [] ? '' : '?'.http_build_query($query)))
+        ->assertOk()
+        ->assertInertia(function (AssertableInertia $page) use (&$row): void {
+            $entry = $page->toArray()['props']['entries'][0];
+            $row = $entry['author_name'].' / '.$entry['author_type'];
+        });
+
+    return $row;
+}
+
+/**
+ * How many rows the screen returns for a query.
+ *
+ * @param  array<string, string>  $query
+ */
+function commentsMatching(array $query): int
+{
+    $n = 0;
+
+    test()->actingAs(test()->admin)
+        ->get('/comments?'.http_build_query($query))
+        ->assertOk()
+        ->assertInertia(function (AssertableInertia $page) use (&$n): void {
+            $n = count($page->toArray()['props']['entries']);
+        });
+
+    return $n;
+}
+
+test('the moderation screen keeps a deleted author\'s type', function () {
+    expect(authorRow())->toBe('Dana Staff / staff');
+
+    $this->dana->delete();
+
+    expect(authorRow())->toBe('Dana Staff / staff');
+});
+
+test('the file\'s own comment list keeps it too', function () {
+    $this->dana->delete();
+
+    $comments = $this->actingAs($this->admin)
+        ->getJson("/files/{$this->file->id}/comments")
+        ->assertOk()
+        ->json('comments');
+
+    expect($comments[0]['author_name'])->toBe('Dana Staff')
+        ->and($comments[0]['author_type'])->toBe('staff');
+});
+
+test('the author-type filter still finds the comment', function () {
+    expect(commentsMatching(['author_type' => 'staff']))->toBe(1);
+
+    $this->dana->delete();
+
+    expect(commentsMatching(['author_type' => 'staff']))->toBe(1);
+});
+
+test('the name search still finds the comment', function () {
+    $this->dana->delete();
+
+    expect(commentsMatching(['search' => 'Dana']))->toBe(1);
+});
+
+// The half that must not move: a comment with no author_id is a guest's,
+// and deleting accounts does not turn one into staff.
+test('a guest comment is still a guest comment', function () {
+    FileComment::factory()->for($this->file)->create([
+        'author_id' => null,
+        'guest_name' => 'A visitor',
+        'body' => 'a question from outside',
+        'visibility' => CommentVisibility::Everyone,
+        'approved_at' => now(),
+    ]);
+
+    $this->dana->delete();
+
+    expect(commentsMatching(['author_type' => 'guest']))->toBe(1);
+});
+
+test('the API reports a deleted staff author as staff', function () {
+    $this->dana->delete();
+
+    Sanctum::actingAs($this->admin, ['edit_others_files']);
+
+    $author = $this->getJson("/api/v1/files/{$this->file->id}/comments")
+        ->assertOk()
+        ->json('data.0.author');
+
+    expect($author['name'])->toBe('Dana Staff')
+        ->and($author['type'])->toBe('staff')
+        ->and($author['id'])->toBe($this->dana->id);
+});


### PR DESCRIPTION
`file_comments.author_id` is `cascadeOnDelete` and the cascade never fires,
because a user is soft-deleted. The row behind a deleted commenter is still
there and the column still points at it — the relation just would not hand it
over, and every caller then had to invent a meaning for the absence. They
invented different ones.

Measured on `main` (`20293091`): one staff member's staff-only comment, read
from every surface before and after the account is deleted.

```
                              before            after
/comments screen        Dana Staff / staff  →  Dana Staff / guest
the file's own thread   Dana Staff / staff  →  Dana Staff / guest
GET /api/v1/…/comments        type staff    →  type client
filter author_type=staff          1 row     →  0 rows
search "Dana"                     1 row     →  0 rows
unfiltered                        1 row     →  1 row
```

Three surfaces, three different wrong answers, each of them printed next to a
name that stayed correct — so one row says "Dana Staff" and "guest" at the same
time. And the comment is still in the list: a moderator filtering for staff
comments does not see a staff comment sitting in front of them, which is the
worse half, because nothing about it looks like a missing row.

**This is the author half of #1717.** That fix was for `client_context_id`, and
`DeletedClientThreadTest`'s docblock already describes both columns:

> `file_comments.client_context_id` and `author_id` are both cascadeOnDelete,
> and neither cascade ever fires: users are soft-deleted, so the row survives
> and the column goes on pointing at it. Everything that asked the *relation*
> instead of the column read that as "there is no client here".

`FileComment::authorName()` is the one place that already reached past it, by
hand — `$this->author()->withTrashed()->value('name')` — which is why the names
above are right while everything beside them is wrong.

**Fix.** The relation, not the five call sites: `author()` reads a deleted
account. The API resource, the author filter and the name search then need no
change at all — they were already asking the right question of a relation that
would not answer it.

The two `authorType()` copies now ask `author_id` instead of the relation. After
the relation fix they answer the same either way; it is written that way because
that is the rule the module already states — `isFromGuest()` and `authorName()`
both decide guest-ness from the column, and "no author row means guest" is
exactly the reading that produced the bug.

**No visibility widens.** Nothing that decides who may *read* a comment goes
through this relation: `VisibleCommentScope` and `FileCommentPolicy` compare
`author_id` directly, at every one of their five decision points. What changes
is what is displayed, and which rows the author filter and the name search
match.

**Not changed (deliberate).**
- `authorName()`. Its manual `withTrashed()` lookup is redundant now rather than
  wrong, and it is freshly landed code; removing a branch that changes no answer
  belongs in a cleanup, not here.
- `clientContext()`, which #1717 settled its own way.
- What a *fully erased* account does. `author_id` is `cascadeOnDelete`, so the
  comment goes with the row when the grace period ends — there is no state where
  the column points at nothing.
- Guest comments, in every direction. A comment with no `author_id` is a guest's
  before and after, and there is a test that says so.

**Tests.** Six, in a new `tests/Feature/Comments/DeletedCommentAuthorTest.php`,
placed beside the `DeletedClientThreadTest` it is the other half of: the
moderation screen, the file's own thread, the author-type filter, the name
search, the API, and the guard that a guest comment is still a guest comment.

Counter-check: with the three application files reset to `main` and the tests
kept, that file goes **5 failed / 1 passed**. The survivor is the guest guard,
which is green either way by design — it is what says this did not simply
relabel everything as staff.

Full suite passes (**2111 passed / 2 skipped**, 11476 assertions; `main`
(`20293091`) measures 2105/2, 11409). PHPStan level 8 clean, `pint --test` clean
on all four changed files. `php artisan scramble:export` reproduces
`docs/api/openapi.json` byte for byte — the resource's shape is unchanged, only
what it now finds behind the relation. No frontend change, so `tsc`/ESLint were
not run.