### PR TITLE
Tell the admins the mailbox is dead, even when a send noticed first

### DIFF
--- a/app/Modules/Platform/Http/Controllers/EmailOAuthController.php
+++ b/app/Modules/Platform/Http/Controllers/EmailOAuthController.php
@@ -162,8 +162,9 @@ class EmailOAuthController extends Controller
             'refresh_token' => null,
             'token_expires_at' => null,
             'account_email' => null,
-            'last_error' => null,
-        ])->save();
+        ]);
+        $connection->clearFailure();
+        $connection->save();
 
         $this->activateConnection();
 

--- a/app/Modules/Platform/Http/Controllers/EmailSettingsController.php
+++ b/app/Modules/Platform/Http/Controllers/EmailSettingsController.php
@@ -185,8 +185,8 @@ class EmailSettingsController extends Controller
                         'refresh_token' => null,
                         'token_expires_at' => null,
                         'account_email' => null,
-                        'last_error' => null,
                     ]);
+                    $connection->clearFailure();
                 }
 
                 $connection->save();

--- a/app/Modules/Platform/Mail/Console/RefreshMailOAuthTokensCommand.php
+++ b/app/Modules/Platform/Mail/Console/RefreshMailOAuthTokensCommand.php
@@ -71,7 +71,17 @@ class RefreshMailOAuthTokensCommand extends Command
                 // notification would otherwise repeat daily for as long
                 // as nobody reconnects, and a nagging alert trains
                 // people to ignore the one that matters.
-                if (! $hadError) {
+                //
+                // Asked of broken_notified_at, not of last_error. The
+                // question is "have the admins been told", and last_error
+                // cannot answer it: the send path writes that column too
+                // (OAuthCodeFlowBroker::refresh, reached from
+                // freshAccessToken) and notifies nobody. On an
+                // installation that actually sends mail, that write lands
+                // first — so reading it as "already told them" left this
+                // silent for good, on exactly the installations whose
+                // password-reset mail rides on the connection.
+                if ($connection->broken_notified_at === null) {
                     $recipients = array_values(User::query()->where('type', UserType::Staff)->get()
                         ->filter(fn (User $staff): bool => $permissions->allows($staff, Permission::EditSettings))
                         ->all());
@@ -80,6 +90,9 @@ class RefreshMailOAuthTokensCommand extends Command
                         'provider' => $connection->provider->label(),
                         'account' => (string) $connection->account_email,
                     ]);
+
+                    $connection->broken_notified_at = now();
+                    $connection->save();
                 }
 
                 $mailConfig->flush();

--- a/app/Modules/Platform/Mail/MailOAuthConnection.php
+++ b/app/Modules/Platform/Mail/MailOAuthConnection.php
@@ -35,6 +35,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $token_expires_at
  * @property Carbon|null $last_refreshed_at
  * @property string|null $last_error
+ * @property Carbon|null $broken_notified_at
  */
 class MailOAuthConnection extends Model
 {
@@ -51,7 +52,25 @@ class MailOAuthConnection extends Model
             'refresh_token' => 'encrypted',
             'token_expires_at' => 'datetime',
             'last_refreshed_at' => 'datetime',
+            'broken_notified_at' => 'datetime',
         ];
+    }
+
+    /**
+     * The failure is over: the error and the record of having alarmed
+     * about it go together, because they describe one state.
+     *
+     * One method rather than two nulls at each call site. The three
+     * places that end a failure — a successful refresh, a disconnect, a
+     * changed client id — must never clear one and keep the other: a
+     * connection that is healthy but still marked "already told them"
+     * would go quiet the next time it dies, which is the shape of the
+     * bug this column was added to close.
+     */
+    public function clearFailure(): void
+    {
+        $this->last_error = null;
+        $this->broken_notified_at = null;
     }
 
     public static function for(MailProvider $provider): self

--- a/app/Modules/Platform/Mail/OAuthCodeFlowBroker.php
+++ b/app/Modules/Platform/Mail/OAuthCodeFlowBroker.php
@@ -172,7 +172,7 @@ abstract class OAuthCodeFlowBroker implements MailOAuthBroker
         }
 
         $connection->last_refreshed_at = now();
-        $connection->last_error = null;
+        $connection->clearFailure();
         $connection->save();
     }
 

--- a/database/migrations/2026_09_07_090000_add_broken_notified_at_to_mail_oauth_connections_table.php
+++ b/database/migrations/2026_09_07_090000_add_broken_notified_at_to_mail_oauth_connections_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // `last_error` was answering two questions at once — the table's
+        // own comment says so: "what the settings page's warning and the
+        // admin notification read". The warning wants "is this connection
+        // broken", and any writer may answer it; the notification wants
+        // "have the admins been told", which only the notifier can.
+        //
+        // They came apart because the send path writes last_error too
+        // (OAuthCodeFlowBroker::refresh, reached from freshAccessToken).
+        // On an installation that actually sends mail, that write lands
+        // first, and the daily command then read it as "already notified"
+        // and stayed silent forever.
+        //
+        // Cleared wherever last_error is cleared, and only there:
+        // a successful refresh, a disconnect, and a changed client id.
+        Schema::table('mail_oauth_connections', function (Blueprint $table) {
+            $table->timestamp('broken_notified_at')->nullable()->after('last_error');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('mail_oauth_connections', function (Blueprint $table) {
+            $table->dropColumn('broken_notified_at');
+        });
+    }
+};

--- a/tests/Feature/Platform/MailOAuthTest.php
+++ b/tests/Feature/Platform/MailOAuthTest.php
@@ -454,6 +454,82 @@ test('a dead grant records the error and notifies settings admins exactly once',
     expect(InAppNotification::query()->where('type', 'mail_oauth_connection_broken')->count())->toBe(1);
 });
 
+/**
+ * The same grant, dying in the order it actually dies on an installation
+ * that sends mail: a message goes out, the transport refreshes, and the
+ * failure is recorded by the send path — which notifies nobody. Reading
+ * that record as "already told them" is what kept the daily command
+ * silent for good.
+ */
+test('a send that reaches the dead grant first does not swallow the alarm', function () {
+    Http::fake([
+        'login.microsoftonline.com/*' => Http::response([
+            'error' => 'invalid_grant',
+            'error_description' => 'AADSTS50173: The provided grant has expired.',
+        ], 400),
+    ]);
+
+    $connection = connectMicrosoftMailbox();
+    $connection->fill(['token_expires_at' => now()->subMinute()])->save();
+
+    // A password-reset mail — the case the command's docblock is about.
+    try {
+        Mail::mailer('microsoft-graph')->raw('Reset your password', function ($message) {
+            $message->to('client@example.com')->subject('Password reset');
+        });
+    } catch (TransportException) {
+        // The send fails; that half already worked.
+    }
+
+    // The send path records the failure and tells nobody, as before.
+    expect(MailOAuthConnection::for(MailProvider::Microsoft365)->last_error)->toContain('AADSTS50173')
+        ->and(InAppNotification::query()->where('type', 'mail_oauth_connection_broken')->count())->toBe(0);
+
+    Artisan::call('projectsend:refresh-mail-oauth-tokens');
+
+    expect(InAppNotification::query()->where('type', 'mail_oauth_connection_broken')->count())->toBe(1);
+
+    // And still exactly once: the anti-nag rule is unchanged.
+    Artisan::call('projectsend:refresh-mail-oauth-tokens');
+
+    expect(InAppNotification::query()->where('type', 'mail_oauth_connection_broken')->count())->toBe(1);
+});
+
+test('a connection that recovers can raise the alarm a second time', function () {
+    Http::fake([
+        'login.microsoftonline.com/*' => Http::sequence()
+            ->push(['error' => 'invalid_grant'], 400)
+            ->push(fakeTokenResponse())
+            ->push(['error' => 'invalid_grant'], 400),
+    ]);
+
+    connectMicrosoftMailbox();
+
+    Artisan::call('projectsend:refresh-mail-oauth-tokens');   // dies, alarms
+    Artisan::call('projectsend:refresh-mail-oauth-tokens');   // recovers
+    Artisan::call('projectsend:refresh-mail-oauth-tokens');   // dies again
+
+    expect(InAppNotification::query()->where('type', 'mail_oauth_connection_broken')->count())->toBe(2);
+});
+
+test('ending the failure any other way also clears the record of having alarmed', function () {
+    Http::fake([
+        'login.microsoftonline.com/*' => Http::response(['error' => 'invalid_grant'], 400),
+    ]);
+
+    connectMicrosoftMailbox();
+    Artisan::call('projectsend:refresh-mail-oauth-tokens');
+
+    expect(MailOAuthConnection::for(MailProvider::Microsoft365)->broken_notified_at)->not->toBeNull();
+
+    $this->actingAs($this->admin)
+        ->from('/system/settings/email')
+        ->delete('/system/settings/email/oauth')
+        ->assertRedirect();
+
+    expect(MailOAuthConnection::for(MailProvider::Microsoft365)->broken_notified_at)->toBeNull();
+});
+
 test('a transient token endpoint failure neither flags the connection nor notifies anyone', function () {
     Http::fake([
         'login.microsoftonline.com/*' => Http::response(['error' => 'temporarily_unavailable'], 503),


### PR DESCRIPTION
`RefreshMailOAuthTokensCommand` is the daily refresh and, by its own docblock,
the health check that goes with it:

> the delegated flow's one real weakness is that a grant can die silently
> (password reset, Conditional Access change), which **for a portal whose
> password-reset mails ride on this connection** must surface as a warning, not
> as a support ticket weeks later.

It decides whether to warn from `last_error`. But `last_error` has a second
writer: `OAuthCodeFlowBroker::refresh()` records a dead grant and notifies
nobody, and `freshAccessToken()` reaches it from **every send**. So on an
installation that is actually sending mail, the send gets there first, the
command reads the column as "already told them", and the warning never goes out
— and `last_error` is cleared only by a *successful* refresh, which a dead grant
never has, so it never goes out later either.

Measured on `main` (`20293091`), the same dead grant in the two possible orders:

```
nobody sends, the command is first
  after run 1   1 notification
  after run 2   1                    ← correct: alarms once, then quiet

a password-reset mail goes out first
  after the send   last_error set, 0 notifications
  after run 1      0
  after run 2      0                 ← the alarm never fires
```

The alarm worked on installations that were not using the mailbox and failed on
the ones that were.

**The anti-nag rule is not the problem** and does not change here — "a nagging
alert trains people to ignore the one that matters" is right, and one
notification per broken state is still all anybody gets.

The problem is that one column was answering two questions. The table's own
comment says so: `last_error` is described as *"what the settings page's warning
and the admin notification read"*. The warning wants **"is this connection
broken"**, and any writer may answer it — the send path included, which is why
the settings page turning red on a failed send is correct and stays. The
notification wants **"have the admins been told"**, and only the notifier can
answer that.

**Fix.** The notification gets its own column.

- `broken_notified_at` is stamped when the command sends the notification, and
  the command asks *that* rather than `last_error`.
- It is cleared wherever `last_error` is cleared: a successful refresh, a
  disconnect, and a changed client id.
- Those three sites call `MailOAuthConnection::clearFailure()` instead of
  nulling two columns each. A connection left healthy but still marked "already
  told them" would go quiet the next time it died — the same bug in a new place,
  and a fourth caller is exactly how the first one happened.

`$hadError` stays where it is still the right question: whether a *successful*
refresh is a recovery, which is what decides the `MailConfigApplier` flush.

**Not changed (deliberate).**
- The send path still records the failure and still notifies nobody. A transport
  is not a place to decide who gets alarmed, and the settings page reads
  `last_error` for its warning — that is the half that was always working.
- Transient failures. `needsReconnect` still gates everything; a temporarily
  unavailable endpoint neither flags nor notifies, and its test is untouched.
- Who is notified (staff holding `EditSettings`), the notification type, and its
  payload.
- The settings page, which reads `last_error` exactly as before.

**Tests.** Three new in `tests/Feature/Platform/MailOAuthTest.php`, beside the
existing `a dead grant records the error and notifies settings admins exactly
once` that they extend:

- a send reaches the dead grant first — the admins are still told, and still
  only once on the following run;
- a connection that recovers and dies again alarms a second time, so the new
  column cannot silently latch;
- ending the failure another way (disconnect) clears the record of having
  alarmed.

Counter-check: with the four application files reset to `main` and the migration
and tests kept, that file goes **2 failed / 24 passed**. The recovery test passes
either way by design — on `main` a successful refresh clears `last_error`, so
re-arming already worked; it is here to say the new column did not break it.

Full suite passes (**2108 passed / 2 skipped**, 11417 assertions; `main`
(`20293091`) measures 2105/2, 11409). PHPStan level 8 clean, `pint --test` clean
on all seven changed files. No frontend or API controller touched, so `tsc`,
ESLint and `scramble:export` were not run.

**Merge note.** `fix/scheduled-mail-refresh-lock` changes the same command and
the same broker — its hunks are the refresh call and a new `refreshSerially()`,
where these are the notify guard and `storeTokens()` — and appends to the same
test file. They merge without conflict, but a clean merge of two changes to one
method proves nothing, so the merged tree was built and run: `MailOAuthTest` is
27 passed and the full suite is **2109 / 2**, exactly `main` plus both branches'
tests. The one place they could have interfered was checked too:
`refreshSerially()` re-reads the row through the same instance before refreshing,
so the `broken_notified_at` this command reads afterwards is the stored one.