### PR TITLE
Keep the mail and storage credentials out of the boot-config cache

### DIFF
--- a/app/Modules/Platform/Settings/BootSettingsCache.php
+++ b/app/Modules/Platform/Settings/BootSettingsCache.php
@@ -35,6 +35,11 @@ use PDOException;
  * EmailTemplateResolver). A database failure there should stay loud: those
  * run long after the install, where "quietly fell back to defaults" hides a
  * real outage instead of enabling a legitimate first run.
+ *
+ * Two entry points, same rule. rememberForever() is for values worth
+ * keeping; read() is for the ones that must not be kept — a credential
+ * read on the boot path needs the identical "the database may not answer
+ * yet" guarantee, and stating it twice is how the two drift apart.
  */
 final class BootSettingsCache
 {
@@ -55,6 +60,33 @@ final class BootSettingsCache
             // QueryException extends PDOException, so this covers both a
             // missing table and a connection that could not be opened.
             self::warnOnce($key, $e);
+
+            return $whenUnavailable;
+        }
+    }
+
+    /**
+     * The same protection for a value that is deliberately *not* cached.
+     *
+     * A credential must not sit in the cache store, so it is read on each
+     * boot that actually needs it — but that read lands on the same path
+     * as the cached ones and must survive the same missing database. The
+     * caller has already been handed a cached array saying the feature is
+     * configured; that array can be warm while the database is, right now,
+     * unreachable.
+     *
+     * @template TValue
+     *
+     * @param  Closure(): TValue  $read  Reads the real value from the database.
+     * @param  TValue  $whenUnavailable  Returned as-is when the database cannot answer.
+     * @return TValue
+     */
+    public static function read(Closure $read, mixed $whenUnavailable = null): mixed
+    {
+        try {
+            return $read();
+        } catch (PDOException $e) {
+            self::warnOnce('(uncached credential read)', $e);
 
             return $whenUnavailable;
         }

--- a/app/Modules/Platform/Settings/ExternalStorageConfigApplier.php
+++ b/app/Modules/Platform/Settings/ExternalStorageConfigApplier.php
@@ -44,7 +44,13 @@ class ExternalStorageConfigApplier
     // Bumped on any shape change to the resolved array below — a stale
     // rememberForever value under an old key would otherwise crash every
     // boot with "Undefined array key" (apply() calls resolve() unconditionally).
-    private const CACHE_KEY = 'platform.external_storage_settings.v2';
+    // v3: the S3 secret and the GCS key file left the shape. The cache
+    // store encrypts nothing and rememberForever never expires, so on the
+    // documented CACHE_STORE=database they sat in clear — the service
+    // account's private key included — in the same database whose dump
+    // the `encrypted` cast exists to survive. Both are now read straight
+    // from the row, by the provider branch that uses them.
+    private const CACHE_KEY = 'platform.external_storage_settings.v3';
 
     public function __construct(
         private readonly CapabilityRegistry $capabilities,
@@ -67,7 +73,9 @@ class ExternalStorageConfigApplier
 
         match ($provider) {
             StorageProvider::S3 => $this->applyS3($resolved),
-            StorageProvider::Gcs => $this->applyGcs($resolved),
+            // No $resolved: everything GCS needs from the row is the key
+            // file, and that is a credential the cache no longer holds.
+            StorageProvider::Gcs => $this->applyGcs(),
         };
 
         if ($resolved['root'] !== null) {
@@ -86,22 +94,22 @@ class ExternalStorageConfigApplier
     private function applyS3(array $resolved): void
     {
         Config::set('filesystems.disks.files_external.key', $resolved['key']);
-        Config::set('filesystems.disks.files_external.secret', $resolved['secret']);
+        Config::set('filesystems.disks.files_external.secret', $this->credential('secret'));
         Config::set('filesystems.disks.files_external.region', $resolved['region']);
         Config::set('filesystems.disks.files_external.endpoint', $resolved['endpoint']);
         Config::set('filesystems.disks.files_external.use_path_style_endpoint', $resolved['use_path_style']);
     }
 
-    /**
-     * @param  array<string, mixed>  $resolved
-     */
-    private function applyGcs(array $resolved): void
+    private function applyGcs(): void
     {
         // Decoded here rather than stored decoded: the column holds the
         // key file verbatim, exactly as Google issued it, so that what an
         // administrator pasted is what can be handed back to them and
         // compared against the console.
-        $keyFile = json_decode((string) $resolved['key_file'], true);
+        //
+        // Read from the row rather than from $resolved: it is a private
+        // key, and the cached array no longer carries one.
+        $keyFile = json_decode((string) $this->credential('key_file'), true);
 
         Config::set('filesystems.disks.files_external.key_file', is_array($keyFile) ? $keyFile : null);
 
@@ -116,6 +124,28 @@ class ExternalStorageConfigApplier
     public function flush(): void
     {
         Cache::forget(self::CACHE_KEY);
+    }
+
+    /**
+     * One credential column, read from the row rather than from the cache.
+     *
+     * The same rule MailOAuthConnection states for tokens — "must never
+     * travel through the boot-config cache" — applied to the two columns
+     * on this row that are credentials: the S3 secret access key and the
+     * GCS service account key file. Reached only from the provider branch
+     * that uses one, and only when isActive() has already said the disk is
+     * configured and permitted, so nothing is read on an installation that
+     * stores files locally.
+     *
+     * Guarded like the cached read beside it: resolve() can hand back a
+     * warm "configured" from a database that has since stopped answering,
+     * and booting must survive that.
+     */
+    private function credential(string $column): ?string
+    {
+        return BootSettingsCache::read(
+            fn (): ?string => ExternalStorageSettings::current()->{$column},
+        );
     }
 
     public function resolveDisk(ResolvingUploadDisk $event): void
@@ -142,14 +172,14 @@ class ExternalStorageConfigApplier
      * filled in and active, nothing more. Callers AND the capability check
      * live and uncached — see class docblock.
      *
-     * @return array{configured: bool, provider: string, key: string|null, secret: string|null, key_file: string|null, region: string|null, bucket: string|null, endpoint: string|null, use_path_style: bool, root: string|null}
+     * @return array{configured: bool, provider: string, key: string|null, region: string|null, bucket: string|null, endpoint: string|null, use_path_style: bool, root: string|null}
      */
     private function resolve(): array
     {
         $blank = [
             'configured' => false,
             'provider' => StorageProvider::S3->value,
-            'key' => null, 'secret' => null, 'key_file' => null,
+            'key' => null,
             'region' => null, 'bucket' => null,
             'endpoint' => null, 'use_path_style' => false, 'root' => null,
         ];
@@ -173,8 +203,6 @@ class ExternalStorageConfigApplier
                 'configured' => true,
                 'provider' => $settings->provider->value,
                 'key' => $settings->key,
-                'secret' => $settings->secret,
-                'key_file' => $settings->key_file,
                 'region' => $settings->region,
                 'bucket' => $settings->bucket,
                 'endpoint' => $settings->endpoint,

--- a/app/Modules/Platform/Settings/MailConfigApplier.php
+++ b/app/Modules/Platform/Settings/MailConfigApplier.php
@@ -42,7 +42,13 @@ class MailConfigApplier
     // connection row at send time — only readiness and the connected
     // address are cheap enough to be worth caching, and neither is a
     // credential.
-    private const CACHE_KEY = 'platform.mail_provider_settings.v3';
+    // v4: the SMTP password left for the same reason the tokens never
+    // arrived. The cache store encrypts nothing and rememberForever never
+    // expires, so on the documented CACHE_STORE=database it wrote the
+    // password in clear into the same database whose dump the `encrypted`
+    // cast exists to survive. It is now read straight from the row, and
+    // only on the boot that actually configures an SMTP transport.
+    private const CACHE_KEY = 'platform.mail_provider_settings.v4';
 
     public function __construct(
         private readonly CapabilityRegistry $capabilities,
@@ -67,7 +73,7 @@ class MailConfigApplier
             Config::set('mail.mailers.smtp.host', $resolved['host']);
             Config::set('mail.mailers.smtp.port', $resolved['port']);
             Config::set('mail.mailers.smtp.username', $resolved['username']);
-            Config::set('mail.mailers.smtp.password', $resolved['password']);
+            Config::set('mail.mailers.smtp.password', $this->password());
             Config::set('mail.mailers.smtp.encryption', $resolved['encryption']);
         }
 
@@ -86,13 +92,33 @@ class MailConfigApplier
     }
 
     /**
-     * @return array{transport_configured: bool, host: string|null, port: int|null, username: string|null, password: string|null, encryption: string|null, from_address: string|null, from_name: string|null, oauth_mailer: string|null, oauth_ready: bool, oauth_account: string|null}
+     * The SMTP password, read from the row rather than from the cache.
+     *
+     * The same rule MailOAuthConnection states for tokens — "must never
+     * travel through the boot-config cache" — applied to the credential
+     * this class configures itself. Reached only from the SMTP branch of
+     * apply(), so an installation using OAuth, or one that has never
+     * opened the Email screen, still boots without touching the table.
+     *
+     * Guarded like the cached read beside it: resolve() can hand back a
+     * warm "transport_configured" from a database that has since stopped
+     * answering, and booting must survive that.
+     */
+    private function password(): ?string
+    {
+        return BootSettingsCache::read(
+            fn (): ?string => MailProviderSettings::current()->password,
+        );
+    }
+
+    /**
+     * @return array{transport_configured: bool, host: string|null, port: int|null, username: string|null, encryption: string|null, from_address: string|null, from_name: string|null, oauth_mailer: string|null, oauth_ready: bool, oauth_account: string|null}
      */
     private function resolve(): array
     {
         $blank = [
             'transport_configured' => false,
-            'host' => null, 'port' => null, 'username' => null, 'password' => null, 'encryption' => null,
+            'host' => null, 'port' => null, 'username' => null, 'encryption' => null,
             'from_address' => null, 'from_name' => null,
             'oauth_mailer' => null, 'oauth_ready' => false, 'oauth_account' => null,
         ];
@@ -130,7 +156,6 @@ class MailConfigApplier
                 'host' => $settings->host,
                 'port' => $settings->port,
                 'username' => $settings->username,
-                'password' => $settings->password,
                 'encryption' => $settings->encryption === 'none' ? null : $settings->encryption,
                 'from_address' => $settings->from_address,
                 'from_name' => $settings->from_name,

--- a/tests/Feature/Platform/ExternalStorageSettingsTest.php
+++ b/tests/Feature/Platform/ExternalStorageSettingsTest.php
@@ -26,6 +26,65 @@ test('the secret is encrypted at rest', function () {
         ->and(ExternalStorageSettings::current()->secret)->toBe('super-secret-access-key');
 });
 
+test('the secret never reaches the cache store', function () {
+    // The column above is only half the promise: this class caches its
+    // resolved settings forever on every process boot, and a cache store
+    // encrypts nothing. See the same pair in MailProviderSettingsTest.
+    ExternalStorageSettings::current()->fill([
+        'active' => true,
+        'key' => 'AKIAEXAMPLE',
+        'secret' => 'super-secret-access-key',
+        'bucket' => 'my-bucket',
+        'region' => 'us-east-1',
+    ])->save();
+
+    Cache::flush();
+    app(ExternalStorageConfigApplier::class)->apply();
+
+    $cached = Cache::get('platform.external_storage_settings.v3');
+
+    expect($cached)->toBeArray()
+        ->and(json_encode($cached))->not->toContain('super-secret-access-key');
+});
+
+test('the secret never reaches the database cache store either', function () {
+    // Against the store config/cache.php actually defaults to, read as the
+    // raw row an operator would find in a dump.
+    config(['cache.default' => 'database']);
+
+    ExternalStorageSettings::current()->fill([
+        'active' => true,
+        'key' => 'AKIAEXAMPLE',
+        'secret' => 'super-secret-access-key',
+        'bucket' => 'my-bucket',
+        'region' => 'us-east-1',
+    ])->save();
+
+    Cache::store('database')->flush();
+    app(ExternalStorageConfigApplier::class)->apply();
+
+    $rows = DB::table('cache')->pluck('value')->implode('|');
+
+    expect($rows)->not->toContain('super-secret-access-key');
+});
+
+test('apply() still configures the secret it no longer caches', function () {
+    // The other half: keeping the credential out of the cache must not
+    // stop the disk from being configured with it.
+    ExternalStorageSettings::current()->fill([
+        'active' => true,
+        'key' => 'AKIAEXAMPLE',
+        'secret' => 'super-secret-access-key',
+        'bucket' => 'my-bucket',
+        'region' => 'us-east-1',
+    ])->save();
+
+    app(ExternalStorageConfigApplier::class)->flush();
+    app(ExternalStorageConfigApplier::class)->apply();
+
+    expect(config('filesystems.disks.files_external.secret'))->toBe('super-secret-access-key');
+});
+
 test('apply() is a no-op when not fully configured', function () {
     $originalKey = config('filesystems.disks.files_external.key');
 

--- a/tests/Feature/Platform/GoogleCloudStorageTest.php
+++ b/tests/Feature/Platform/GoogleCloudStorageTest.php
@@ -8,6 +8,7 @@ use App\Modules\Files\Storage\ResolvingUploadDisk;
 use App\Modules\Platform\Settings\ExternalStorageConfigApplier;
 use App\Modules\Platform\Settings\ExternalStorageSettings;
 use App\Modules\Platform\Settings\StorageProvider;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
@@ -162,6 +163,52 @@ test('the service account key is encrypted at rest', function () {
     expect($raw)->not->toContain('BEGIN PRIVATE KEY')
         ->and($raw)->not->toContain('iam.gserviceaccount.com')
         ->and(json_decode((string) ExternalStorageSettings::current()->key_file, true)['private_key'])
+        ->toBe($key['private_key']);
+});
+
+test('the service account key never reaches the cache store', function () {
+    // The assertion above says the private key is not in the column. It was
+    // in the cache store at the same moment: ExternalStorageConfigApplier
+    // cached the key file verbatim, forever, and a cache store encrypts
+    // nothing.
+    $key = fakeServiceAccountKey();
+
+    ExternalStorageSettings::current()->fill([
+        'active' => true,
+        'provider' => StorageProvider::Gcs,
+        'bucket' => 'projectsend-files',
+        'key_file' => json_encode($key),
+    ])->save();
+
+    Cache::flush();
+    app(ExternalStorageConfigApplier::class)->apply();
+
+    $cached = Cache::get('platform.external_storage_settings.v3');
+
+    // Asserted to exist before it is searched: a renamed cache key would
+    // otherwise make this pass by finding nothing at all, which is how a
+    // test for an absence quietly stops testing anything.
+    expect($cached)->toBeArray()
+        ->and(json_encode($cached))->not->toContain('BEGIN PRIVATE KEY')
+        ->and(json_encode($cached))->not->toContain('iam.gserviceaccount.com');
+});
+
+test('apply() still configures the key file it no longer caches', function () {
+    $key = fakeServiceAccountKey();
+
+    ExternalStorageSettings::current()->fill([
+        'active' => true,
+        'provider' => StorageProvider::Gcs,
+        'bucket' => 'projectsend-files',
+        'key_file' => json_encode($key),
+    ])->save();
+
+    app(ExternalStorageConfigApplier::class)->flush();
+    app(ExternalStorageConfigApplier::class)->apply();
+
+    expect(config('filesystems.disks.files_external.key_file'))
+        ->toBeArray()
+        ->and(config('filesystems.disks.files_external.key_file')['private_key'])
         ->toBe($key['private_key']);
 });
 

--- a/tests/Feature/Platform/MailProviderSettingsTest.php
+++ b/tests/Feature/Platform/MailProviderSettingsTest.php
@@ -21,6 +21,66 @@ test('the password is encrypted at rest', function () {
         ->and(MailProviderSettings::current()->password)->toBe('super-secret-smtp-password');
 });
 
+test('the password never reaches the cache store', function () {
+    // The column above is only half the promise. This class caches its
+    // resolved settings forever on every process boot, and a cache store
+    // encrypts nothing — so a password in that array is a password in
+    // clear, in whatever the store happens to be. On the store INSTALL.md
+    // documents that is the same database the cast above protects.
+    MailProviderSettings::current()->fill([
+        'host' => 'smtp.example.test',
+        'port' => 587,
+        'username' => 'postmaster',
+        'password' => 'super-secret-smtp-password',
+    ])->save();
+
+    Cache::flush();
+    app(MailConfigApplier::class)->apply();
+
+    $cached = Cache::get('platform.mail_provider_settings.v4');
+
+    expect($cached)->toBeArray()
+        ->and(json_encode($cached))->not->toContain('super-secret-smtp-password');
+});
+
+test('the password never reaches the database cache store either', function () {
+    // The same assertion against the store config/cache.php actually
+    // defaults to, read as the raw row an operator would find in a dump —
+    // phpunit.xml runs the suite on the array store, where a regression
+    // here would still be invisible to anybody reading a backup.
+    config(['cache.default' => 'database']);
+
+    MailProviderSettings::current()->fill([
+        'host' => 'smtp.example.test',
+        'port' => 587,
+        'username' => 'postmaster',
+        'password' => 'super-secret-smtp-password',
+    ])->save();
+
+    Cache::store('database')->flush();
+    app(MailConfigApplier::class)->apply();
+
+    $rows = DB::table('cache')->pluck('value')->implode('|');
+
+    expect($rows)->not->toContain('super-secret-smtp-password');
+});
+
+test('apply() still configures the smtp password it no longer caches', function () {
+    // The other half: keeping the credential out of the cache must not
+    // stop the transport from being configured with it.
+    MailProviderSettings::current()->fill([
+        'host' => 'smtp.example.test',
+        'port' => 587,
+        'username' => 'postmaster',
+        'password' => 'super-secret-smtp-password',
+    ])->save();
+
+    Cache::flush();
+    app(MailConfigApplier::class)->apply();
+
+    expect(config('mail.mailers.smtp.password'))->toBe('super-secret-smtp-password');
+});
+
 test('apply() is a no-op when no host is configured', function () {
     $originalHost = config('mail.mailers.smtp.host');
 


### PR DESCRIPTION
`MailConfigApplier` and `ExternalStorageConfigApplier` read their settings through
the `encrypted` casts — so, decrypted — and write the result into the cache store
with `rememberForever()`. The SMTP password, the S3 secret access key and the
whole GCS service account key file, private key included, go in as plain text
under a key that never expires.

A cache store encrypts nothing. On the store `INSTALL.md` documents for a manual
install (`CACHE_STORE=database`) and `config/cache.php` defaults to, that is the
`cache` table of **the same database** whose dump the `encrypted` cast exists to
survive. On redis it is the redis dump.

**The code already states the rule, two files away.** `MailOAuthConnection`:

> Transports read this row fresh at send time — tokens **must never travel
> through the boot-config cache** (see MailConfigApplier, which caches only
> readiness and the account address).

`MailConfigApplier`'s own cache-key comment says the same thing about the same
array — what is deliberately *not* in the cached shape is tokens, because neither
readiness nor an address is a credential. The SMTP password was in it anyway.
And `SocialSettings::available()` names both classes outright:

> Only the key and the label — no secret is ever written to the cache store,
> **which is the mistake MailConfigApplier and ExternalStorageConfigApplier both
> make** with their own credentials.

Measured on this base, with the cache store read directly rather than through the
applier:

```
the database column                     encrypted    ✓
the same password in the cache store    plain text   ✓
```

**Fix.** The credentials are read the way the tokens already are: from the row,
at the point that uses them.

- The cached array keeps everything that is not a credential.
- `MailConfigApplier` reads the password inside the SMTP branch of `apply()`, so
  an installation on OAuth, on cloud, or one that has never opened the Email
  screen reads nothing extra.
- `ExternalStorageConfigApplier` reads the secret in `applyS3()` and the key file
  in `applyGcs()`, both reached only after `isActive()` has said the disk is
  configured and permitted — so an installation storing files locally reads
  nothing extra either.
- Both cache keys are bumped, as their own comments require on a shape change.

`BootSettingsCache` grows a second entry point rather than the callers restating
its rule. The cached read already survives a database with no tables, because
booting must not require this application's own database; an uncached credential
read on the same path needs exactly that guarantee and nothing else — `resolve()`
can hand back a warm `configured` from a database that has since stopped
answering, and booting has to survive that. It is the same `PDOException` guard,
not a second one.

**Not changed (deliberate).**

- The `encrypted` casts, the columns, and what the settings screens accept or
  hand back.
- The capability checks. `ExternalStorageConfigApplier` keeps deciding edition
  outside the cached value, for the reason its docblock gives.
- `SocialSettings::available()`, which was already correct.
- The `Cache::rememberForever` shape itself — the boot path still reads one
  cached array, and gains at most one extra query on installations that have
  actually configured a transport.

**Tests.** Eight, beside the existing "is encrypted at rest" assertions they
complete — those checked only the column, and `phpunit.xml` runs the suite on the
array store, which is why the cache path was structurally invisible.
`GoogleCloudStorageTest` could assert the private key is absent from the column
while the same key sat in the cache.

- three that the credential is absent from the cache store;
- two of those repeated against the **database** cache store, read as the raw
  rows an operator would find in a dump;
- three that each applier still configures the credential it no longer caches.

Counter-check: with the three application files reset to `main` and the tests
kept, **five of the eight fail**. The three "still configures what it no longer
caches" tests pass either way by design — they pin the behaviour the fix must not
break.

One of the five was wrong first time and is worth recording: the GCS test read
the *new* cache key, which unfixed code never writes, so it received `null` and
found no private key in it — passing for the wrong reason. It now asserts the
entry exists before searching it, so a renamed key fails the test instead of
satisfying it.

Full suite passes (**2249 passed / 2 skipped**, 11946 assertions; `main` (`81bb136e`) measures 2241/2, 11933). PHPStan level 8 clean, `pint --test` clean on
all six changed files. No frontend or API controller touched, so `tsc`, ESLint and
`scramble:export` were not run.