### PR TITLE
Bound the two preference endpoints by their own registries

### DIFF
--- a/app/Modules/Audit/Http/Controllers/DashboardWidgetPreferencesController.php
+++ b/app/Modules/Audit/Http/Controllers/DashboardWidgetPreferencesController.php
@@ -45,8 +45,14 @@ class DashboardWidgetPreferencesController extends Controller
 
         $validated = $request->validate([
             'columns' => ['required', 'integer', 'between:1,4'],
-            'widgets' => ['required', 'array'],
-            'widgets.*.widget_key' => ['required', 'string', Rule::in(self::WIDGET_KEYS)],
+            // Bounded by the allowlist itself, and unique on the key. The
+            // Rule::in below checks each value; it says nothing about how
+            // many there are or whether they repeat, and the loop writes
+            // one row per element. A layout has at most one entry per
+            // widget, so anything longer than the registry is not a layout
+            // this screen could have produced.
+            'widgets' => ['required', 'array', 'max:'.count(self::WIDGET_KEYS)],
+            'widgets.*.widget_key' => ['required', 'string', 'distinct', Rule::in(self::WIDGET_KEYS)],
             'widgets.*.enabled' => ['required', 'boolean'],
             'widgets.*.column_index' => ['required', 'integer', 'between:0,3'],
             'widgets.*.position' => ['required', 'integer', 'min:0'],

--- a/app/Modules/Notifications/Http/Controllers/NotificationPreferencesController.php
+++ b/app/Modules/Notifications/Http/Controllers/NotificationPreferencesController.php
@@ -46,13 +46,22 @@ class NotificationPreferencesController extends Controller
         $user = $request->user();
         assert($user !== null);
 
+        $keys = $this->emailableKeys();
+
         $validated = $request->validate([
-            'preferences' => ['required', 'array'],
+            // Bounded by the registry, and unique on the type. The
+            // Rule::in below checks each value; it says nothing about how
+            // many there are or whether they repeat, and the loop writes
+            // one row per element. The count comes from the registry
+            // rather than a literal because the registry is open --
+            // modules register their own types into it, so a number here
+            // would be wrong the moment one does.
+            'preferences' => ['required', 'array', 'max:'.count($keys)],
             // Against the registry, not merely "a string": a preference row
             // for a type nothing can send is a row that will never be read
             // again, and the screen only ever offers back what edit() gave
             // it.
-            'preferences.*.type' => ['required', 'string', Rule::in($this->emailableKeys())],
+            'preferences.*.type' => ['required', 'string', 'distinct', Rule::in($keys)],
             'preferences.*.email_enabled' => ['required', 'boolean'],
         ]);
 

--- a/tests/Feature/Audit/DashboardWidgetPreferencesTest.php
+++ b/tests/Feature/Audit/DashboardWidgetPreferencesTest.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use App\Modules\Audit\Models\DashboardWidgetPreference;
 use App\Modules\Identity\Models\Role;
 use App\Modules\Identity\Models\RolePermission;
+use Illuminate\Support\Facades\DB;
 use Inertia\Testing\AssertableInertia;
 
 beforeEach(function () {
@@ -116,4 +117,65 @@ test('saving rejects an unknown widget key', function () {
             ['widget_key' => 'not_a_real_widget', 'enabled' => true, 'column_index' => 0, 'position' => 0],
         ],
     ])->assertSessionHasErrors(['widgets.0.widget_key']);
+});
+
+test('saving rejects a layout longer than the widget list', function () {
+    // The allowlist checks each value, not how many there are, and the
+    // loop wrote a row per element -- so one request could be made to
+    // cost a query per entry with nothing to show for it. Sent as JSON:
+    // a form-encoded array this large is truncated by max_input_vars long
+    // before it reaches the rule under test.
+    $widgets = [];
+
+    for ($i = 0; $i < 3000; $i++) {
+        $widgets[] = ['widget_key' => 'counters', 'enabled' => true, 'column_index' => 0, 'position' => $i];
+    }
+
+    DB::enableQueryLog();
+
+    $this->actingAs($this->admin)
+        ->putJson('/dashboard/widgets', ['columns' => 2, 'widgets' => $widgets])
+        ->assertJsonValidationErrors(['widgets']);
+
+    $queries = count(DB::getQueryLog());
+    DB::disableQueryLog();
+
+    // Refused before the loop, so the cost is the session's own reads
+    // rather than one write per element.
+    expect($queries)->toBeLessThan(20)
+        ->and(DashboardWidgetPreference::query()->count())->toBe(0);
+});
+
+test('saving rejects the same widget key twice', function () {
+    // Rule::in passes on both, and updateOrCreate made the second a
+    // pointless rewrite of the row the first had just created.
+    $this->actingAs($this->admin)->putJson('/dashboard/widgets', [
+        'columns' => 2,
+        'widgets' => [
+            ['widget_key' => 'counters', 'enabled' => true, 'column_index' => 0, 'position' => 0],
+            ['widget_key' => 'counters', 'enabled' => false, 'column_index' => 1, 'position' => 1],
+        ],
+    ])->assertJsonValidationErrors(['widgets.0.widget_key']);
+
+    expect(DashboardWidgetPreference::query()->count())->toBe(0);
+});
+
+test('a full layout of every widget still saves', function () {
+    // The bound is the allowlist, so the largest legitimate layout -- one
+    // entry per widget this screen knows -- has to pass.
+    $keys = ['counters', 'transfers', 'top_clients_by_storage', 'largest_files',
+        'recent', 'system', 'news', 'expired_files', 'api'];
+
+    $widgets = [];
+
+    foreach ($keys as $index => $key) {
+        $widgets[] = ['widget_key' => $key, 'enabled' => true, 'column_index' => 0, 'position' => $index];
+    }
+
+    $this->actingAs($this->admin)
+        ->put('/dashboard/widgets', ['columns' => 2, 'widgets' => $widgets])
+        ->assertSessionHasNoErrors();
+
+    expect(DashboardWidgetPreference::query()->where('user_id', $this->admin->id)->count())
+        ->toBe(count($keys));
 });

--- a/tests/Feature/Notifications/NotificationPreferencesTest.php
+++ b/tests/Feature/Notifications/NotificationPreferencesTest.php
@@ -9,6 +9,7 @@ use App\Modules\Notifications\NotificationPreference;
 use App\Modules\Notifications\Notifier;
 use App\Modules\Platform\Settings\Setting;
 use App\Modules\Platform\Settings\Settings;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
 use Inertia\Testing\AssertableInertia;
 
@@ -133,4 +134,65 @@ test('the preferences edit page lists every type that can email, however it emai
                 ->not->toContain('client_uploaded');
         },
     );
+});
+
+test('saving rejects more preferences than there are types', function () {
+    // The registry check asks what each type is, not how many were sent,
+    // and the loop wrote a row per element. Sent as JSON: a form-encoded
+    // array this large is truncated by max_input_vars before it reaches
+    // the rule under test.
+    $client = User::factory()->client()->create();
+
+    $preferences = [];
+
+    for ($i = 0; $i < 2000; $i++) {
+        $preferences[] = ['type' => 'group.membership_approved', 'email_enabled' => true];
+    }
+
+    DB::enableQueryLog();
+
+    $this->actingAs($client)
+        ->putJson('/settings/notifications', ['preferences' => $preferences])
+        ->assertJsonValidationErrors(['preferences']);
+
+    $queries = count(DB::getQueryLog());
+    DB::disableQueryLog();
+
+    expect($queries)->toBeLessThan(20)
+        ->and(NotificationPreference::query()->count())->toBe(0);
+});
+
+test('saving rejects the same type twice', function () {
+    $client = User::factory()->client()->create();
+
+    $this->actingAs($client)->putJson('/settings/notifications', [
+        'preferences' => [
+            ['type' => 'group.membership_approved', 'email_enabled' => true],
+            ['type' => 'group.membership_approved', 'email_enabled' => false],
+        ],
+    ])->assertJsonValidationErrors(['preferences.0.type']);
+
+    expect(NotificationPreference::query()->count())->toBe(0);
+});
+
+test('the whole set of emailable types still saves at once', function () {
+    // The bound is the registry, so what edit() offers must always fit:
+    // this is the largest submission the screen itself can produce.
+    $client = User::factory()->client()->create();
+
+    $types = $this->actingAs($client)->get('/settings/notifications')
+        ->viewData('page')['props']['types'];
+
+    $preferences = array_map(
+        fn (array $type): array => ['type' => $type['key'], 'email_enabled' => false],
+        $types,
+    );
+
+    $this->actingAs($client)
+        ->putJson('/settings/notifications', ['preferences' => $preferences])
+        ->assertSessionHasNoErrors();
+
+    expect(NotificationPreference::query()->where('user_id', $client->id)->count())
+        ->toBe(count($types))
+        ->and(count($types))->toBeGreaterThan(0);
 });


### PR DESCRIPTION
Both preference writers validated their array as `['required', 'array']` and
looped `updateOrCreate` over it:

```php
'widgets' => ['required', 'array'],
'widgets.*.widget_key' => ['required', 'string', Rule::in(self::WIDGET_KEYS)],
```

`Rule::in` answers "is this a key I know", once per element. It says nothing about
how many elements there are, and nothing about whether they repeat — so a request
could name the same valid key any number of times and buy a `SELECT` and an
`UPDATE` for each one.

Measured on this base, sent as JSON (a form-encoded array that size is truncated
by `max_input_vars` long before it reaches the controller):

| entries | queries | rows written |
|---|---|---|
| `PUT /dashboard/widgets` 10 | 37 | 1 |
| 500 | 1044 | 1 |
| **3000** | **7051** | **1** |
| `PUT /settings/notifications` 10 | 23 | 1 |
| **2000** | **2025** | **1** |

One row, every time. The work is not even data growth — 3000 entries write the
same single row 3000 times, because `updateOrCreate` matches on
`(user_id, widget_key)` and every element after the first is an update of what
the one before it just wrote.

**Neither route is behind a throttle.** `bootstrap/app.php` applies
`throttleApi()` to the API group only; `/dashboard/widgets` is behind `auth`
alone, and `/settings/notifications` is deliberately outside the `staff` group
because every account manages its own. So the weakest account on the installation
— a client with no permission at all — reaches both, and the only ceiling is
`post_max_size`.

**Fix.** Each is bounded by the list it already validates against, not by a
number, and made unique on the key.

- widgets by `count(self::WIDGET_KEYS)`, the same constant `Rule::in` reads.
- preferences by `count($this->emailableKeys())`, because
  `NotificationTypeRegistry` is deliberately open — *"never a closed enum, since
  core must not need to know a package's notification type keys at compile time"*
  — so a literal would be wrong the day a module registers one.

`distinct` on the key does the other half: a layout has at most one entry per
widget, which is what the screen sends and what the loop already assumes.

After: 3000 entries cost **30 queries**, write nothing, and are refused with a 422
rather than half-applied.

**Two findings, one change.** They are the same three words in two modules, and
splitting them would leave the rule stated once and broken once.

**Not changed (deliberate).**

- The allowlists themselves, and what either screen offers.
- The `updateOrCreate` loop, which is correct for a legitimate submission.
- The absence of a throttle on these routes: the bound belongs in validation,
  where the cost actually is, and a throttle would still let each permitted
  request be arbitrarily expensive.
- `columns`, `enabled`, `column_index`, `position` and `email_enabled` rules.

**Tests.** Six, three with each controller: a refusal for over-length (with the
query count asserted, so a future regression shows up as cost and not only as
status), a refusal for a repeated key, and — the important one — the largest
*legitimate* submission still saving: a full nine-widget layout, and every
emailable type at once. That last pair is what stops the bound ever being tighter
than the screen.

Counter-check: with both controllers reset to `main` and the tests kept, **four of
the six fail**. The two "still saves" tests pass either way by design.

Full suite passes (**2247 passed / 2 skipped**, 11952 assertions; `main` (`81bb136e`) measures 2241/2, 11933). PHPStan level 8 clean, `pint --test` clean on
all four changed files. No frontend or API controller touched, so `tsc`, ESLint
and `scramble:export` were not run.