### PR TITLE
Narrow the conversion list to the clients its own refusal allows

### DIFF
--- a/app/Modules/Identity/Http/Controllers/AccountConversionController.php
+++ b/app/Modules/Identity/Http/Controllers/AccountConversionController.php
@@ -7,6 +7,7 @@ namespace App\Modules\Identity\Http\Controllers;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Modules\Api\Auth\ApiTokens;
+use App\Modules\Files\Access\StaffLibraryScope;
 use App\Modules\Files\DeletedAccountContent;
 use App\Modules\Identity\AccountConversion;
 use App\Modules\Identity\Models\Role;
@@ -46,6 +47,7 @@ class AccountConversionController extends Controller
         private readonly StaffAccounts $accounts,
         private readonly DeletedAccountContent $accountContent,
         private readonly ApiTokens $apiTokens,
+        private readonly StaffLibraryScope $library,
     ) {}
 
     public function index(Request $request): Response
@@ -59,8 +61,18 @@ class AccountConversionController extends Controller
         $search = $validated['search'] ?? null;
         $actor = $this->actor($request);
 
-        $accounts = User::query()
-            ->where('type', $direction === 'to_client' ? UserType::Staff : UserType::Client)
+        // Narrowed for the direction that lists clients, by the same rule
+        // store() refuses one with: AccountConversion::guardToStaff() aborts
+        // 404 unless StaffLibraryScope::canAssignClient() allows the target,
+        // and clients() is that same method's listing half. Without this a
+        // client-scoped staff member was refused the promotion and then
+        // shown the person's name and address in the list it was refused
+        // from. Staff are not narrowed: whoever may demote a staff member
+        // may see the staff roster, which is what assignableRoles() and
+        // guardTarget() already decide on the write side.
+        $accounts = ($direction === 'to_client'
+            ? User::query()->where('type', UserType::Staff)
+            : $this->library->clients($actor))
             ->with('role')
             ->when($search, fn (Builder $query, string $term) => $query->where(fn (Builder $inner) => $inner
                 ->where('name', 'like', "%{$term}%")

--- a/tests/Feature/Identity/AccountConversionScopeTest.php
+++ b/tests/Feature/Identity/AccountConversionScopeTest.php
@@ -107,3 +107,58 @@ test('the demotion direction keeps answering through guardTarget', function () {
 
     expect($colleague->fresh()->type)->toBe(UserType::Staff);
 });
+
+/*
+|--------------------------------------------------------------------------
+| The listing half of the same boundary
+|--------------------------------------------------------------------------
+| The refusals above are about the write. index() builds the list the
+| write is started from, and a name and an address handed to somebody who
+| may reach nothing of that person is the disclosure the refusal exists to
+| prevent.
+*/
+
+test('the promotion list does not show a client outside the roster', function () {
+    $response = $this->actingAs($this->rep)->get('/users/convert?direction=to_staff');
+
+    $response->assertOk();
+
+    expect($response->getContent())->not->toContain($this->stranger->email)
+        ->and($response->getContent())->not->toContain('Not Mine');
+});
+
+test('the promotion list still shows the scoped staff member their own client', function () {
+    $response = $this->actingAs($this->rep)->get('/users/convert?direction=to_staff');
+
+    expect($response->getContent())->toContain($this->mine->email);
+});
+
+test('search cannot reach a client outside the roster', function () {
+    // The narrowing is on the query the search filters, not on the result,
+    // so naming the account exactly still returns nothing.
+    $response = $this->actingAs($this->rep)->get('/users/convert?direction=to_staff&search=Not+Mine');
+
+    $response->assertOk();
+
+    expect($response->getContent())->not->toContain($this->stranger->email);
+});
+
+test('unscoped staff still see every client in the promotion list', function () {
+    $response = $this->actingAs($this->admin)->get('/users/convert?direction=to_staff');
+
+    expect($response->getContent())->toContain($this->stranger->email)
+        ->and($response->getContent())->toContain($this->mine->email);
+});
+
+test('the demotion list is unchanged, and still lists staff', function () {
+    // Only the client direction is narrowed: whoever may demote a staff
+    // member may see the staff roster, which guardTarget() decides on the
+    // write side rather than the listing.
+    $colleague = User::factory()->create(['name' => 'A Colleague']);
+
+    $response = $this->actingAs($this->rep)->get('/users/convert?direction=to_client');
+
+    $response->assertOk();
+
+    expect($response->getContent())->toContain($colleague->email);
+});


### PR DESCRIPTION
`/users/convert` lists the accounts a conversion can be started from. For the
promotion direction those are clients, and `index()` asked only for the type:

```php
$accounts = User::query()
    ->where('type', $direction === 'to_client' ? UserType::Staff : UserType::Client)
```

The write beside it does not. `AccountConversion::guardToStaff()` ends with

```php
abort_unless($this->library->canAssignClient($actor, $target), 404);
```

and says why — a promotion is the most far-reaching thing that can be done to a
client, so reaching one outside the actor's roster

> through this door and no other **is not a rule, it is a gap**.

The gap was on the way in. Measured on this base: a `client_scoped` staff account
holding `manage_users` and `edit_users` is refused the promotion with the 404
that is deliberately careful not to distinguish a stranger from an account that
is not there — and is then shown that same person's name, email, role, status and
consequence counts in the list the refusal came from. Searchable by name or
address through `?search=`, and paginated to the end.

**Fix.** `StaffLibraryScope::clients()` is `canAssignClient()`'s listing half,
written for exactly this:

> The listing half of canAssignClient(), so a screen narrows by the same rule its
> buttons are guarded with rather than restating it — which is how
> ClientsController came to list every client on the installation, name and
> email, to a viewer who could reach nothing of theirs.

The client direction now goes through it. The `clients` picker twenty lines below
already went through the same boundary via `assignableClientIds()`.

**Not changed (deliberate).**

- **The staff direction.** Whoever may demote a staff member may see the staff
  roster; what limits a demotion is `guardTarget()` on the write, not the
  listing. Only the client half is narrowed, and there is a test saying so.
- The write path, the guards, the 404, and the consequence counts.
- `assignableRoles()` and the `clients` picker, both already narrowed.
- Pagination, search and ordering, which now operate on the narrowed query rather
  than being filtered afterwards — so naming a stranger exactly still returns
  nothing.

**Tests.** Five added to `tests/Feature/Identity/AccountConversionScopeTest.php`,
which until now covered only the refusals — the file's own docblock describes the
boundary, and this is its listing half.

Counter-check: with the controller reset to `main` and the tests kept, **two of
the five fail** — the stranger's address appearing in the list, and reaching it by
exact search. The other three pass either way by design: the actor still sees
their own client, unscoped staff still see everybody, and the demotion list still
lists staff.

Full suite passes (**2246 passed / 2 skipped**, 11943 assertions; `main` (`81bb136e`) measures 2241/2, 11933). PHPStan level 8 clean, `pint --test` clean on
both changed files. No frontend or API controller touched, so `tsc`, ESLint and
`scramble:export` were not run.