### PR TITLE
Narrow the membership an API member write hands back

### DIFF
--- a/app/Modules/Groups/Http/Controllers/Api/GroupMembersController.php
+++ b/app/Modules/Groups/Http/Controllers/Api/GroupMembersController.php
@@ -11,6 +11,7 @@ use App\Modules\Audit\ActivityLogger;
 use App\Modules\Files\Access\StaffLibraryScope;
 use App\Modules\Groups\Http\Resources\Api\GroupResource;
 use App\Modules\Groups\Models\Group;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 
@@ -56,7 +57,7 @@ class GroupMembersController extends Controller
 
         $this->activity->log(Action::GroupMemberAdded, subject: $group, context: ['member' => $client->name]);
 
-        return new GroupResource($group->loadCount('members')->load('members'));
+        return $this->response($group, $actor);
     }
 
     public function destroy(Request $request, Group $group, User $member): GroupResource
@@ -72,6 +73,28 @@ class GroupMembersController extends Controller
 
         $this->activity->log(Action::GroupMemberRemoved, subject: $group, context: ['member' => $member->name]);
 
-        return new GroupResource($group->loadCount('members')->load('members'));
+        return $this->response($group, $actor);
+    }
+
+    /**
+     * The group as this actor may see it.
+     *
+     * GroupResource carries a name and an email per member, and its own
+     * docblock puts the boundary here: "the controller loading this
+     * relation is where that narrowing is applied". Api\GroupsController
+     * ::show() applies it for the read of the same group; changing the
+     * membership is not a reason to be told more than reading it, so both
+     * halves narrow by the same query.
+     *
+     * The count is deliberately not narrowed. members_count is the size of
+     * the group, which is a fact about the group rather than about who is
+     * in it, and the web screen shows the same total.
+     */
+    private function response(Group $group, User $actor): GroupResource
+    {
+        return new GroupResource($group->loadCount('members')->load([
+            'members' => fn (BelongsToMany $members) => $members
+                ->whereIn('users.id', $this->scope->clients($actor)->select('id')),
+        ]));
     }
 }

--- a/tests/Feature/Groups/GroupMembershipScopeTest.php
+++ b/tests/Feature/Groups/GroupMembershipScopeTest.php
@@ -600,6 +600,55 @@ test('the API twin narrows the membership it hands back', function () {
         ->and($data['members_count'])->toBe(2);
 });
 
+test('the API narrows the membership a member write hands back, the same way', function () {
+    // The read above is narrowed; changing the membership went through the
+    // same resource with the relation loaded whole, so the write handed
+    // back what the read refuses to.
+    $ours = Group::query()->create(['name' => 'Ours', 'slug' => 'ours', 'public' => false]);
+    $ours->members()->syncWithoutDetaching([$this->stranger->id]);
+
+    $token = $this->rep->createToken('t', [Permission::EditGroups->value])->plainTextToken;
+
+    $data = $this->withToken($token)
+        ->postJson("/api/v1/groups/{$ours->id}/members", ['user_id' => $this->mine->id])
+        ->assertOk()
+        ->json('data');
+
+    expect(array_column($data['members'], 'name'))->toBe(['Mine'])
+        ->and($data['members_count'])->toBe(2);
+});
+
+test('and on the way back out again', function () {
+    $ours = Group::query()->create(['name' => 'Ours', 'slug' => 'ours', 'public' => false]);
+    $second = User::factory()->client()->create(['name' => 'Also Mine']);
+    $this->rep->assignedClients()->sync([$this->mine->id, $second->id]);
+    $ours->members()->syncWithoutDetaching([$this->mine->id, $second->id, $this->stranger->id]);
+
+    $token = $this->rep->createToken('t', [Permission::EditGroups->value])->plainTextToken;
+
+    $data = $this->withToken($token)
+        ->deleteJson("/api/v1/groups/{$ours->id}/members/{$second->id}")
+        ->assertOk()
+        ->json('data');
+
+    expect(array_column($data['members'], 'name'))->toBe(['Mine'])
+        ->and($data['members_count'])->toBe(2);
+});
+
+test('an unscoped token keeps every member in the write response', function () {
+    $ours = Group::query()->create(['name' => 'Ours', 'slug' => 'ours', 'public' => false]);
+    $ours->members()->syncWithoutDetaching([$this->stranger->id]);
+
+    $token = $this->admin->createToken('t', [Permission::EditGroups->value])->plainTextToken;
+
+    $data = $this->withToken($token)
+        ->postJson("/api/v1/groups/{$ours->id}/members", ['user_id' => $this->mine->id])
+        ->assertOk()
+        ->json('data');
+
+    expect(array_column($data['members'], 'name'))->toBe(['Mine', 'Not Mine']);
+});
+
 test('an unscoped viewer keeps the whole roster and every member', function () {
     $ours = Group::query()->create(['name' => 'Ours', 'slug' => 'ours', 'public' => false]);
     $ours->members()->syncWithoutDetaching([$this->mine->id]);


### PR DESCRIPTION
Adding or removing a group member answers with the group, and loaded the relation
whole:

```php
return new GroupResource($group->loadCount('members')->load('members'));
```

`GroupResource` gives each member an `id`, a `name` and an `email`. So a
`client_scoped` staff member who added one of their own clients to a group was
handed, in the same response, the name and address of every other client in it —
people they may not read anywhere else in the application, and whom the group
edit screen refuses to name for exactly that reason. `syncWithoutDetaching()`
makes the call idempotent, so the same request returns the same list as often as
it is sent.

Measured on this base, the response in full:

```json
"members":[{"id":2,"name":"Mine","email":"mine@example.test"},
           {"id":3,"name":"Not Mine","email":"stranger@elsewhere.test"}]
```

**The boundary is already written down.** `GroupResource`'s own docblock:

> both narrow the list to the clients the viewer may act on, and **the controller
> loading this relation is where that narrowing is applied**

and `Api\GroupsController::show()` does it for the read of the same group, with
the comment "it hands back the membership with addresses".

**Fix.** Changing the membership is not a reason to be told more than reading it
is, so both halves narrow by the same query — through one private helper rather
than a third copy of it.

**Not changed (deliberate).**

- **`members_count` stays whole**, matching `show()`: a size is not an identity,
  and it is the number the group listing already reports. There is a test.
- **Who may perform the write.** `StaffLibraryScope::allowsGroupMembership()`
  already decided that and still does; this is only what the answer may say.
- The activity log entries, the 403s, the clients-only rule, and the
  `syncWithoutDetaching` idempotency.
- `Api\GroupsController::show()`, which was already correct.

**Tests.** Three added to `tests/Feature/Groups/GroupMembershipScopeTest.php`,
beside the existing *the API twin narrows the membership it hands back* which
covered the read half only.

Counter-check: with the controller reset to `main` and the tests kept, **two of
the three fail**. The third — an unscoped token still receiving every member —
passes either way by design.

`php artisan scramble:export` after the change produces a **byte-identical**
`docs/api/openapi.json`: the response shape is unchanged, only which rows fill it.

Full suite passes (**2244 passed / 2 skipped**, 11941 assertions; `main` (`81bb136e`) measures 2241/2, 11933). PHPStan level 8 clean.

`pint --test` reports one pre-existing issue on
`tests/Feature/Groups/GroupMembershipScopeTest.php` (`no_extra_blank_lines`,
`ordered_imports`). It is **not introduced here** — `main`'s own copy of that file
reports the identical issue, checked directly — and it is deliberately not fixed
here, to keep the diff to the finding. The changed controller is pint-clean.