### PR TITLE
Give every password check in front of an account its own bucket

### DIFF
--- a/routes/auth.php
+++ b/routes/auth.php
@@ -99,7 +99,19 @@ Route::middleware('auth')->group(function () {
     // on route names, and an unnamed route matches nothing -- which left
     // the form reachable and its submission not, closing the enrolment
     // path enforcement depends on.
+    //
+    // Throttled because it checks a password. It was the one credential
+    // check in this file with no bucket at all: not the per-email-and-IP
+    // limiter POST login has, not a named `throttle:` like the rest --
+    // nothing, so an attacker holding a stolen session could sit on it
+    // and guess. That is the wrong door to leave open, because passing it
+    // is exactly what re-proving the password is meant to make expensive:
+    // beyond it lie disabling two-factor, regenerating recovery codes and
+    // minting an API token, and the password is then known for everything
+    // else too. Six a minute, matching the other credential-facing
+    // buckets here.
     Route::post('confirm-password', [ConfirmablePasswordController::class, 'store'])
+        ->middleware('throttle:6,1,password-confirm')
         ->name('password.confirm.store');
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -46,10 +46,21 @@ Route::middleware('auth')->group(function () {
     Route::get('settings/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('settings/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::get('settings/delete-account', [ProfileController::class, 'deleteAccount'])->name('profile.delete-account');
-    Route::delete('settings/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+    // Throttled for the same reason as confirm-password in routes/auth.php:
+    // destroy() verifies the account's password (`current_password`), and a
+    // credential check without a bucket is a credential check somebody can
+    // sit on. Named buckets, per the note at the top of routes/auth.php --
+    // a bare `throttle:` would share one counter with the public share
+    // links.
+    Route::delete('settings/profile', [ProfileController::class, 'destroy'])
+        ->middleware('throttle:6,1,account-delete')
+        ->name('profile.destroy');
 
     Route::get('settings/password', [PasswordController::class, 'edit'])->name('password.edit');
-    Route::put('settings/password', [PasswordController::class, 'update'])->name('password.update');
+    // Same again: update() verifies `current_password` before it writes.
+    Route::put('settings/password', [PasswordController::class, 'update'])
+        ->middleware('throttle:6,1,password-update')
+        ->name('password.update');
 
     Route::get('settings/two-factor', [TwoFactorEnrollmentController::class, 'show'])->name('two-factor.show');
 

--- a/tests/Feature/Auth/CredentialThrottleTest.php
+++ b/tests/Feature/Auth/CredentialThrottleTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+/**
+ * Every endpoint that checks the account's own password has a bucket.
+ *
+ * routes/auth.php says so at the top -- "Every `throttle:` below names its
+ * own bucket, and must" -- and POST login is the documented exception,
+ * because LoginRequest limits it per email *and* IP, which is stronger.
+ * confirm-password had neither, and it is the door that stands in front of
+ * disabling two-factor, regenerating recovery codes and minting an API
+ * token.
+ */
+beforeEach(function () {
+    $this->user = User::factory()->create();
+});
+
+test('confirming a password stops accepting guesses', function () {
+    foreach (range(1, 6) as $attempt) {
+        $this->actingAs($this->user)
+            ->post('/confirm-password', ['password' => "wrong-{$attempt}"])
+            ->assertSessionHasErrors('password');
+    }
+
+    $this->actingAs($this->user)
+        ->post('/confirm-password', ['password' => 'wrong-7'])
+        ->assertStatus(429)
+        ->assertHeader('Retry-After');
+});
+
+test('changing a password stops accepting guesses at the current one', function () {
+    foreach (range(1, 6) as $attempt) {
+        $this->actingAs($this->user)->put('/settings/password', [
+            'current_password' => "wrong-{$attempt}",
+            'password' => 'a-new-password-1',
+            'password_confirmation' => 'a-new-password-1',
+        ])->assertSessionHasErrors('current_password');
+    }
+
+    $this->actingAs($this->user)->put('/settings/password', [
+        'current_password' => 'wrong-7',
+        'password' => 'a-new-password-1',
+        'password_confirmation' => 'a-new-password-1',
+    ])->assertStatus(429);
+});
+
+test('deleting an account stops accepting guesses at the password', function () {
+    foreach (range(1, 6) as $attempt) {
+        $this->actingAs($this->user)
+            ->delete('/settings/profile', ['password' => "wrong-{$attempt}"])
+            ->assertSessionHasErrors('password');
+    }
+
+    $this->actingAs($this->user)
+        ->delete('/settings/profile', ['password' => 'wrong-7'])
+        ->assertStatus(429);
+
+    expect(User::query()->whereKey($this->user->id)->exists())->toBeTrue();
+});
+
+test('the three buckets are separate, and separate from the rest', function () {
+    // Named buckets, so exhausting one does not spend another's budget --
+    // the failure the note at the top of routes/auth.php describes, where
+    // opening six share links locked the visitor out of the two-factor
+    // challenge.
+    foreach (range(1, 7) as $attempt) {
+        $this->actingAs($this->user)->post('/confirm-password', ['password' => "wrong-{$attempt}"]);
+    }
+
+    $this->actingAs($this->user)->put('/settings/password', [
+        'current_password' => 'wrong-again',
+        'password' => 'a-new-password-1',
+        'password_confirmation' => 'a-new-password-1',
+    ])->assertSessionHasErrors('current_password');
+});
+
+test('somebody who knows the password is not locked out by somebody who does not', function () {
+    // The limiter is keyed on the account, not on the installation: a
+    // second account's guesses must not cost this one its own attempts.
+    $other = User::factory()->create();
+
+    foreach (range(1, 7) as $attempt) {
+        $this->actingAs($other)->post('/confirm-password', ['password' => "wrong-{$attempt}"]);
+    }
+
+    $this->actingAs($this->user)
+        ->post('/confirm-password', ['password' => 'password'])
+        ->assertSessionHasNoErrors();
+});


### PR DESCRIPTION
`POST /confirm-password` verifies the account's password and counted nothing.
Forty wrong guesses, forty identical refusals, no lockout, no `Retry-After`, no
log line.

`routes/auth.php` opens by requiring the opposite:

> **Every `throttle:` below names its own bucket, and must.**

and every other route in the file has one. `POST login` is the deliberate
exception, and the file says why — `LoginRequest` limits it per email *and* IP,
which is a stronger boundary than a per-IP count. `confirm-password` had neither
of those things.

It is the wrong door to leave unlatched. Re-proving the password is what stands
between a stolen session and disabling two-factor, regenerating recovery codes,
or minting an API token — credentials that outlive the session, which is the
reason `routes/settings.php` gives for putting those routes behind it. An
attacker who already holds the session can sit on this endpoint until the
password falls out of it, and then holds the password for everything else too.

**Two more with the same shape**, in `routes/settings.php`:

- `PUT /settings/password` — `update()` validates `current_password`.
- `DELETE /settings/profile` — `destroy()` validates `current_password`.

Both were equally uncounted, and all three answer the same question in the same
way, so an attacker refused at one door simply used the next. Fixing one of three
would have been cosmetic.

**Fix.** All three get named buckets at `6,1`, matching the credential-facing
routes already in `auth.php`. Named rather than bare: a bare `throttle:` keys on
`sha1(domain|ip)` or `sha1(user_id)` with no route in it, which is how six share
links once locked a visitor out of the two-factor challenge.

**Not changed (deliberate).**

- **`POST /logout`** has no bucket either and does not need one — it checks no
  credential and reveals nothing by being repeated. Same for
  `PATCH /settings/profile`. (Worth stating, because "the only POST without a
  bucket" would have been wrong: `logout` is the other one, and it is fine.)
- `POST login`, which keeps its stronger per-email-and-IP limiter.
- The refusal messages, the validation rules, and what each endpoint does on
  success.
- The numbers on every existing bucket.

**Tests.** Five in a new `tests/Feature/Auth/CredentialThrottleTest.php`.

Counter-check: with both route files reset to `main` and the tests kept, **three
of the five fail** — one per endpoint. The other two pass either way by design,
and they are the ones worth keeping: exhausting one bucket must not spend
another's, and one account's guesses must not lock a different account out.

Full suite passes (**2246 passed / 2 skipped**, 11977 assertions; `main` (`81bb136e`) measures 2241/2, 11933). PHPStan level 8 clean, `pint --test` clean on
all three changed files. No frontend or API controller touched, so `tsc`, ESLint
and `scramble:export` were not run.

**Merge note.** `fix/provider-link-password-confirm` also edits
`routes/settings.php` — its hunk is the connected-accounts block at lines 56–84,
where these are `profile.destroy` and `password.update` just above. They merge
without conflict in either order, verified by merging both onto `main` and
running the suite.