### PR TITLE
Stop the zip poll when its page goes away

### DIFF
--- a/resources/js/hooks/use-zip-download.ts
+++ b/resources/js/hooks/use-zip-download.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { xsrfToken } from '@/lib/xsrf';
 
@@ -22,6 +22,7 @@ export function useZipDownload() {
     const [status, setStatus] = useState<ZipDownloadStatus>('idle');
     const [error, setError] = useState<string | null>(null);
     const pollRef = useRef<number | null>(null);
+    const unmountedRef = useRef(false);
 
     const stopPolling = useCallback(() => {
         if (pollRef.current !== null) {
@@ -36,8 +37,25 @@ export function useZipDownload() {
         setError(null);
     }, [stopPolling]);
 
+    // The poll must not outlive the page: an Inertia visit unmounts the
+    // component mid-build, nothing calls close(), and the interval would
+    // keep hitting zip-downloads/{id} every two seconds for as long as
+    // the tab lives — the server keeps answering "pending" to nobody.
+    // The flag covers the gap the cleanup alone leaves open: an unmount
+    // while the store POST is still in flight, whose then() would set a
+    // fresh interval after the cleanup already ran.
+    useEffect(() => {
+        return () => {
+            unmountedRef.current = true;
+            stopPolling();
+        };
+    }, [stopPolling]);
+
     const start = useCallback(
         (selection: ZipSelection) => {
+            // A second start while a poll is running would overwrite
+            // pollRef and orphan the first interval the same way.
+            stopPolling();
             setStatus('preparing');
             setError(null);
 
@@ -59,6 +77,9 @@ export function useZipDownload() {
                     return response.json() as Promise<{ id: number }>;
                 })
                 .then(({ id }) => {
+                    if (unmountedRef.current) {
+                        return;
+                    }
                     pollRef.current = window.setInterval(() => {
                         fetch(route('zip-downloads.show', id), {
                             credentials: 'same-origin',


### PR DESCRIPTION
`useZipDownload` sets an interval that polls `zip-downloads/{id}` every two
seconds until the build reports `ready` or `failed`. The only paths that ever
cleared it were those two answers and `close()` — there is no `useEffect` in
the file, so no unmount cleanup at all.

But the components that hold the hook are Inertia pages (`files/index.tsx`
directly, the portal themes through `use-portal-files.ts`). Navigating away
unmounts them without `close()`, and the interval keeps hitting the endpoint
every two seconds for as long as the tab lives — polling for a download nobody
can receive any more. A zip stuck in `pending`, the exact case the polling
exists for, polls forever; a zip that later reports `ready` fires
`window.location.href` from a page the visitor already left.

**Fix.** Three holes, one leak:

- **No cleanup on unmount.** A `useEffect` cleanup now stops the poll when the
  component goes away — the main path.
- **An unmount while the store `POST` is still in flight.** Its `then()` runs
  after the cleanup already did, and would set a fresh interval on the dead
  component. An `unmountedRef` flag makes that `then()` a no-op.
- **A second `start()` while a poll is running** overwrote `pollRef` and
  orphaned the first interval the same way. `start()` stops the previous poll
  first now.

**Not changed (deliberate).**

- The poll body's `fetch` chain still has no `.catch` — a transient network
  error skips one tick and the next tick retries, which is the behaviour the
  2-second interval already implies. Separate question, separate change if
  wanted.
- The consumers. Both only ever cleared the interval through the dialog's
  `onClose` before; they need no change now that the hook cleans up after
  itself.

**Verification.** No test accompanies this: there is no JavaScript test runner
in the project, and the PHP suite never mounts a component. The suite is
unchanged from `main` `4556ccf6` (**2282 passed / 2 skipped**, 12076
assertions, measured on both). `tsc --noEmit` clean, `npx eslint .` clean —
including `react-hooks/exhaustive-deps` over the new effect — prettier clean
on the changed file.