### PR TITLE
Honour Laravel's placeholder case convention in t()

### DIFF
--- a/resources/js/hooks/use-translation.ts
+++ b/resources/js/hooks/use-translation.ts
@@ -8,6 +8,16 @@ import { usePage } from '@inertiajs/react';
  *
  * Every user-facing string in a component must go through `t()` — no
  * hardcoded copy.
+ *
+ * Replacements follow Laravel's own placeholder convention, because the
+ * catalogs already do: a `:name` in the key licenses `:name`, `:Name`
+ * and `:NAME` in a locale's value, receiving the replacement as-is,
+ * capitalized, or upper-cased. That case shift is how a language that
+ * orders the sentence differently keeps its typography — Dutch writes
+ * "Add :name" as ":Name toevoegen", the noun capitalized because it now
+ * opens the phrase. The backend translator has always honoured all
+ * three forms; an exact-match replace here would hand those locales the
+ * literal ":Name" instead of the value.
  */
 export function useTranslation() {
     const { translations } = usePage<SharedData>().props;
@@ -15,8 +25,25 @@ export function useTranslation() {
     const t = (key: string, replacements: Record<string, string | number> = {}): string => {
         let message = translations[key] ?? key;
 
+        const variants: [string, string][] = [];
         for (const [name, value] of Object.entries(replacements)) {
-            message = message.replaceAll(`:${name}`, String(value));
+            const text = String(value);
+            variants.push(
+                [`:${name}`, text],
+                [`:${name.charAt(0).toUpperCase()}${name.slice(1)}`, `${text.charAt(0).toUpperCase()}${text.slice(1)}`],
+                [`:${name.toUpperCase()}`, text.toUpperCase()],
+            );
+        }
+
+        // Longest placeholder first — strtr's implicit rule, made
+        // explicit: with both :name and :names in play, :name must not
+        // eat the front half of :names. Ties keep insertion order, so a
+        // key whose case variants collide resolves to the as-is value,
+        // as the backend's array assignment order does.
+        variants.sort((a, b) => b[0].length - a[0].length);
+
+        for (const [placeholder, replacement] of variants) {
+            message = message.replaceAll(placeholder, replacement);
         }
 
         return message;


### PR DESCRIPTION
The frontend translator replaces placeholders by exact match only:

```ts
message = message.replaceAll(`:${name}`, String(value));
```

But the catalogs it consumes are Laravel JSON catalogs, and Laravel's
placeholder convention has always been three forms: `:name` receives the
value as-is, `:Name` capitalized, `:NAME` upper-cased. The backend translator
honours all three — and the catalogs already rely on it. Fifteen values in
`lang/nl.json` and one in `lang/tr.json` write the capitalized form:

```json
"Add :name": ":Name toevoegen",
"Go to page :page": ":Page sayfasına git",
```

Dutch capitalizes the noun because it now *opens* the phrase; Turkish does the
same. Those values are right for the language and right for the backend — and
wrong only for the half of the app that reads them with an exact-match
replace, which renders the literal `:Name` and `:Page` to the visitor.

**Fix.** `t()` builds the three variants per replacement now — as-is,
capitalized, upper-cased — and applies the longest placeholder first: strtr's
implicit rule made explicit, so with `:name` and `:names` both in play,
`:name` cannot eat the front half of `:names`. Ties keep insertion order,
which resolves a fully-colliding key to the as-is value, the same answer the
backend's assignment order produces.

**Not changed (deliberate).**

- **The nl and tr catalog values.** The other direction of this fix —
  lower-casing the placeholders in the catalogs — would cost those locales
  their capitalization and diverge from what the backend renders. The values
  are correct; the replace was not.
- The hook's key-lookup and fallback behaviour. Calls without replacements,
  and every replacement the repo currently makes (`:name`, `:count`, `:date`,
  `:used of :limit downloads used`, `:name — files`, …), are byte-identical
  before and after — their keys and values agree on the lowercase form.

**Verification.** No test accompanies this: there is no JavaScript test runner
in the project, and the PHP suite exercises the backend translator, which was
never wrong. Counter-checked by running both implementations side by side in
node over the affected values and the in-repo call shapes — the old replace
leaves `":Name toevoegen"` and `":Page sayfasına git"` literal; the new one
renders `"Bestand toevoegen"` and `"2 sayfasına git"`; the in-repo shapes come
out byte-identical. The suite is unchanged from `main` `4556ccf6`
(**2282 passed / 2 skipped**, 12076 assertions, measured on both).
`tsc --noEmit` clean, `npx eslint .` clean, prettier clean on the changed
file.