### PR TITLE
Name the official hosted version near the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ page to download it.
 No public link passed around by email, no third-party service holding your clients' documents, no
 per-seat pricing. It runs on your server, and the files stay there.
 
+Prefer not to run the server yourself? [ProjectSend Cloud](https://projectsend.cloud) is the
+official hosted version of ProjectSend, run by the same team — every subscription funds this free
+software. The line between the free core and Cloud, and the commitments that go with it, are set
+out in [LICENSING.md](LICENSING.md).
+
 ## What it does
 
 **For the people you send to**


### PR DESCRIPTION
ProjectSend Cloud already appears in LICENSING.md ("What's in the core, and what's in ProjectSend Cloud") and in CONTRIBUTING.md — but not in the README, which is the first thing both people and search engines read about the project.

This adds one paragraph after the intro. It deliberately:

- comes **after** "It runs on your server, and the files stay there" — self-hosting stays the headline, Cloud answers the reader who doesn't want a server;
- uses the exact wording already published in the projectsend.org footer ("the official hosted version, run by the same team — every subscription funds this free software"), so the two surfaces describe the same thing the same way;
- points to LICENSING.md, where the line between the free core and Cloud — and the commitments that go with it — is already written down. No new claims are introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)